### PR TITLE
create a room name and a password for each document

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -17,6 +17,7 @@ return [
 		['name' => 'document#index', 'url' => 'index', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
 		['name' => 'document#create', 'url' => 'ajax/documents/create', 'verb' => 'POST'],
+		['name' => 'document#generate', 'url' => 'ajax/generate.php', 'verb' => 'GET'],
 
 		// WOPI access
 		['name' => 'wopi#checkFileInfo', 'url' => 'wopi/files/{fileId}', 'verb' => 'GET'],

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -124,15 +124,24 @@ var odfViewer = {
 		$('#app-content #controls').addClass('hidden');
 		$('#app-content').append($iframe);
 
-		$.ajax({type: 'GET', url: OC.filePath('richdocuments', 'ajax', 'generate.php'), data: {id: context.$file.attr('data-id')}, async: false, success: function(result) {
-			if(result.status=="success"){
-				var $chatroom = $('<iframe id="chatroom" data-chatroom-password="'+result.password+'" data-chatroom-title="'+fileName+'" data-chatroom-name="'+result.name+'" hidden />');
-				$('#app-content').append($chatroom);
+		$.ajax({type: 'GET',
+			url: OC.filePath('richdocuments', 'ajax', 'generate.php'),
+			data: {id: context.$file.attr('data-id')},
+			async: false, success: function(result) {
+				if(result.status=="success"){
+					var $chatroom = $('<div />');
+					$chatroom.attr('id','chatroom');
+					$chatroom.data('chatroom-password',result.password);
+					$chatroom.data('chatroom-name',result.name);
+					$chatroom.data('chatroom-title',fileName);
+					$('#app-content').append($chatroom);
+				} else {
+					console.log(result.message);
+				}
+			}, error: function(xhr, textStatus, errorThrown){
+				console.log(errorThrown);
 			}
-
-		}, error: function(xhr, textStatus, errorThrown){
-			password=errorThrown;
-		}});
+		});
 	},
 
 

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -127,8 +127,9 @@ var odfViewer = {
 		$.ajax({type: 'GET',
 			url: OC.filePath('richdocuments', 'ajax', 'generate.php'),
 			data: {id: context.$file.attr('data-id')},
-			async: false, success: function(result) {
-				if(result.status=="success"){
+			async: false,
+			success: function(result) {
+				if(result.status==='success'){
 					var $chatroom = $('<div />');
 					$chatroom.attr('id','chatroom');
 					$chatroom.data('chatroom-password',result.password);

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -123,6 +123,16 @@ var odfViewer = {
 
 		$('#app-content #controls').addClass('hidden');
 		$('#app-content').append($iframe);
+
+		$.ajax({type: 'GET', url: OC.filePath('richdocuments', 'ajax', 'generate.php'), data: {id: context.$file.attr('data-id')}, async: false, success: function(result) {
+			if(result.status=="success"){
+				var $chatroom = $('<iframe id="chatroom" data-chatroom-password="'+result.password+'" data-chatroom-title="'+fileName+'" data-chatroom-name="'+result.name+'" hidden />');
+				$('#app-content').append($chatroom);
+			}
+
+		}, error: function(xhr, textStatus, errorThrown){
+			password=errorThrown;
+		}});
 	},
 
 
@@ -132,6 +142,7 @@ var odfViewer = {
 		}
 		$('#app-content #controls').removeClass('hidden');
 		$('#richdocumentsframe').remove();
+		$('#chatroom').remove();
 	},
 
 	registerFilesMenu: function() {

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -251,4 +251,40 @@ class DocumentController extends Controller {
 
 		return $response;
 	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function generate($id) {
+		if((!empty($id))) {
+			$view = \OC\Files\Filesystem::getView();
+			try {
+				$path = $view->getPath($id);
+				if ($view->is_file($path) && $view->isReadable($path)) {
+					$secret = \OC::$server->getConfig()->getSystemValue("secret");
+					$instanceID = \OC::$server->getConfig()->getSystemValue("instanceid");
+					$chatRoomPassword = hash('sha512', "chatroom-password".$instanceID.$secret.$id);
+					$chatRoomName = hash('sha512', "chatroom-name".$instanceID.$secret.$id);
+					return  array(
+						'status' => 'success','password' => $chatRoomPassword,'name' => $chatRoomName
+					);
+				} else {
+					return  array(
+						'status' => 'unauthorised'
+					);
+				}
+
+			} catch (\Exception $e) {
+				return  array(
+					'status' => 'unauthorised'
+				);
+			}
+
+		}
+		return  array(
+			'status' => 'no id received'
+		);
+
+	}
+
 }

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -256,35 +256,33 @@ class DocumentController extends Controller {
 	 * @NoAdminRequired
 	 */
 	public function generate($id) {
-		if((!empty($id))) {
-			$view = \OC\Files\Filesystem::getView();
-			try {
-				$path = $view->getPath($id);
-				if ($view->is_file($path) && $view->isReadable($path)) {
-					$secret = \OC::$server->getConfig()->getSystemValue("secret");
-					$instanceID = \OC::$server->getConfig()->getSystemValue("instanceid");
-					$chatRoomPassword = hash('sha512', "chatroom-password".$instanceID.$secret.$id);
-					$chatRoomName = hash('sha512', "chatroom-name".$instanceID.$secret.$id);
-					return  array(
-						'status' => 'success','password' => $chatRoomPassword,'name' => $chatRoomName
-					);
-				} else {
-					return  array(
-						'status' => 'unauthorised'
-					);
-				}
 
-			} catch (\Exception $e) {
-				return  array(
-					'status' => 'unauthorised'
-				);
-			}
-
+		if (empty($id)) {
+			return  array(
+				'status' => 'error',
+				'message' => 'no id received');
 		}
-		return  array(
-			'status' => 'no id received'
-		);
-
+		$view = \OC\Files\Filesystem::getView();
+		try {
+			$path = $view->getPath($id);
+			if ($view->is_file($path) && $view->isReadable($path)) {
+				$secret = \OC::$server->getConfig()->getSystemValue('secret');
+				$instanceID = \OC::$server->getConfig()->getSystemValue('instanceid');
+				$chatRoomPassword = hash('sha512', 'chatroom-password'.$instanceID.$secret.$id);
+				$chatRoomName = hash('sha512','chatroom-name'.$instanceID.$secret.$id);
+				return  array(
+					'status' => 'success',
+					'password' => $chatRoomPassword,
+					'name' => $chatRoomName);
+			} else {
+				return  array(
+					'status' => 'error',
+					'message' => 'user unauthorised to view file');
+			}
+		} catch (\Exception $e) {
+			return  array(
+				'status' => 'error',
+				'message' => 'user unauthorised to view file');
+		}
 	}
-
 }

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -260,7 +260,8 @@ class DocumentController extends Controller {
 		if (empty($id)) {
 			return  array(
 				'status' => 'error',
-				'message' => 'no id received');
+				'message' => 'no id received'
+			);
 		}
 		$view = \OC\Files\Filesystem::getView();
 		try {
@@ -273,16 +274,19 @@ class DocumentController extends Controller {
 				return  array(
 					'status' => 'success',
 					'password' => $chatRoomPassword,
-					'name' => $chatRoomName);
+					'name' => $chatRoomName
+				);
 			} else {
 				return  array(
 					'status' => 'error',
-					'message' => 'user unauthorised to view file');
+					'message' => 'user unauthorised to view file'
+				);
 			}
 		} catch (\Exception $e) {
 			return  array(
 				'status' => 'error',
-				'message' => 'user unauthorised to view file');
+				'message' => 'user unauthorised to view file'
+			);
 		}
 	}
 }


### PR DESCRIPTION
The room name and the password can be used to create a  document group chat in any chat app (jsxc pull request: https://github.com/nextcloud/jsxc.nextcloud/pull/8)
The generated password and name should be unpredictable