### PR TITLE
Show Display Name of user, not its uid in userlist

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -92,7 +92,7 @@ class WopiController extends Controller {
 				'Version' => $version,
 				'UserId' => $res['editor'] !== '' ? $res['editor'] : 'Guest user',
 				'OwnerId' => $res['owner'],
-				'UserFriendlyName' => $res['editor'] !== '' ? $res['editor'] : 'Guest user',
+				'UserFriendlyName' => $res['editor'] !== '' ? \OC_User::getDisplayName($res['editor']) : 'Guest user',
 				'UserCanWrite' => $res['canwrite'] ? true : false,
 				'PostMessageOrigin' => $res['server_host'],
 			]


### PR DESCRIPTION
Fixes #67 in nextcloud 11

(cherry picked from commit 3940ec64c7cf99ffaf70fcfc594fc49e5c2c415a)