### PR TITLE
Create a link back to the Apps pag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Find out more about Nextcloud and Collabora Online, and how to setup an server h
 
 In your Nextcloud, simply navigate to »Apps«, choose the category »Office & text«, find the Collabora Online app and enable it. Then open the administrator settings, navigate to the »Collabora Online« tab and specify your Collabora Online server.
 
-### Nextcloud versions
+### Nextcloud/Collabora Online relation
 
 For the latest information about the Collabora Online and Nextcloud releases, please visit the [Apps page of Collabora](https://apps.nextcloud.com/apps/richdocuments).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ In your Nextcloud, simply navigate to »Apps«, choose the category »Office & t
 
 ### Nextcloud/Collabora Online relation
 
-For the latest information about the Collabora Online and Nextcloud releases, please visit the [Apps page of Collabora](https://apps.nextcloud.com/apps/richdocuments).
+For the latest information about the Collabora Online and Nextcloud releases, please visit the:
+
+[Apps page of Collabora](https://apps.nextcloud.com/apps/richdocuments).
 
 ### Scripted installation (Ubuntu), Server + Nextcloud app
 The developers of the [Nextcloud VM](https://github.com/nextcloud/vm) has made a [script](https://raw.githubusercontent.com/nextcloud/vm/master/apps/collabora.sh) that you can use.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Find out more about Nextcloud and Collabora Online, and how to setup an server h
 
 In your Nextcloud, simply navigate to »Apps«, choose the category »Office & text«, find the Collabora Online app and enable it. Then open the administrator settings, navigate to the »Collabora Online« tab and specify your Collabora Online server.
 
+### Nextcloud versions
+
+For the latest information about the Collabora Online and Nextcloud releases, please visit the [Apps page of Collabora](https://apps.nextcloud.com/apps/richdocuments).
+
 ### Scripted installation (Ubuntu), Server + Nextcloud app
 The developers of the [Nextcloud VM](https://github.com/nextcloud/vm) has made a [script](https://raw.githubusercontent.com/nextcloud/vm/master/apps/collabora.sh) that you can use.
 Please remember to check the the variables in the script to suit your config before you run it, though it should work out of the box on all Ubuntu servers from 16.04 an upwards.


### PR DESCRIPTION
For people who came across the github page first, link back to the apps page of Nextcloud to see the relation between the Nextcloud release and Collobora.