### PR TITLE
Fix z-index of the richdocuments frame for NC13

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -89,7 +89,7 @@ var odfViewer = {
 			FileList.setViewerMode(true);
 		}
 
-		var $iframe = $('<iframe id="richdocumentsframe" allowfullscreen style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:51;" src="'+viewer+'" />');
+		var $iframe = $('<iframe id="richdocumentsframe" allowfullscreen style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:60;" src="'+viewer+'" />');
 		if ($('#isPublic').val()) {
 			// force the preview to adjust its height
 			$('#preview').append($iframe).css({height: '100%'});


### PR DESCRIPTION
Fix overlays z-index to avoid the controls div from Nextcloud 13 overlaying the viewer.

Before:
![bildschirmfoto vom 2018-01-11 09-00-15](https://user-images.githubusercontent.com/3404133/34814491-21d6f0b0-f6ae-11e7-9ef1-4959593b2284.png)

After:
![bildschirmfoto vom 2018-01-11 09-00-47](https://user-images.githubusercontent.com/3404133/34814490-21bb8e38-f6ae-11e7-97c4-e74255a0fee1.png)

