### PR TITLE
Fix settings canonical webroot

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -53,8 +53,8 @@ class SettingsController extends Controller{
 	public function getSettings() {
 		return new JSONResponse([
 			'wopi_url' => $this->appConfig->getAppValue('wopi_url'),
-			'use_groups' => $this->appConfig->getAppValue('use_groups'),
 			'edit_groups' => $this->appConfig->getAppValue('edit_groups'),
+			'use_groups' => $this->appConfig->getAppValue('use_groups'),
 			'doc_format' => $this->appConfig->getAppValue('doc_format'),
 		]);
 	}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -51,6 +51,7 @@ class Admin implements ISettings {
 				'use_groups' => $this->config->getAppValue('richdocuments', 'use_groups'),
 				'doc_format' => $this->config->getAppValue('richdocuments', 'doc_format'),
 				'external_apps' => $this->config->getAppValue('richdocuments', 'external_apps'),
+				'canonical_webroot' => $this->config->getAppValue('richdocuments', 'canonical_webroot'),
 			],
 			'blank'
 		);


### PR DESCRIPTION
The `Canonical-Webroot` setting was not read properly on the /settings/admin/richdocuments settings page, this fixes it. Secondly this also fixes the notices when visting the admin page:
```
Undefined index: canonical_webroot at /apps/richdocuments/templates/admin.php#44
```