### PR TITLE
Fix: Undefined index: canonical_webroot

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -249,6 +249,7 @@ class DocumentController extends Controller {
 					'urlsrc' => $urlSrc,
 					'path' => '/',
 					'instanceId' => $this->settings->getSystemValue('instanceid'),
+					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 				];
 
 				$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');


### PR DESCRIPTION
The public page uses the document template but doesn't set the canonical_webroot properly.