### PR TITLE
No need for allow inline script since we use a nonce

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -191,7 +191,6 @@ class DocumentController extends Controller {
 			$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
 			$policy = new ContentSecurityPolicy();
 			$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
-			$policy->allowInlineScript(true);
 			$response->setContentSecurityPolicy($policy);
 			return $response;
 		} catch (\Exception $e) {
@@ -255,7 +254,6 @@ class DocumentController extends Controller {
 				$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
 				$policy = new ContentSecurityPolicy();
 				$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
-				$policy->allowInlineScript(true);
 				$response->setContentSecurityPolicy($policy);
 				return $response;
 			}


### PR DESCRIPTION
Function call had been deprecated in NC10 already.
We add a nonce to the inline javascript already. So no need to weaken
the CSP by allowing possible other inline scripts.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>