### PR TITLE
Fix editing on external storage

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -220,9 +220,15 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		// Unless the editor is empty (public link) we modify the files as the current editor
+		$editor = $wopi->getEditorUid();
+		if ($editor === null) {
+			$editor = $wopi->getOwnerUid();
+		}
+
 		try {
 			/** @var File $file */
-			$userFolder = $this->rootFolder->getUserFolder($wopi->getOwnerUid());
+			$userFolder = $this->rootFolder->getUserFolder($editor);
 			$file = $userFolder->getById($fileId)[0];
 
 			if ($isPutRelative) {
@@ -275,13 +281,6 @@ class WopiController extends Controller {
 			}
 
 			$content = fopen('php://input', 'rb');
-			// Setup the FS which is needed to emit hooks (versioning).
-			\OC_Util::tearDownFS();
-			if (!$isPutRelative) {
-				\OC_Util::setupFS($wopi->getOwnerUid());
-			} else {
-				\OC_Util::setupFS($wopi->getEditorUid());
-			}
 
 			// Set the user to register the change under his name
 			$editor = $this->userManager->get($wopi->getEditorUid());

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -37,6 +37,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\AppFramework\Http\StreamResponse;
 use OCP\IUserManager;
+use OCP\IUserSession;
 
 class WopiController extends Controller {
 	/** @var IRootFolder */
@@ -53,6 +54,8 @@ class WopiController extends Controller {
 	private $wopiMapper;
 	/** @var ILogger */
 	private $logger;
+	/** @var IUserSession */
+	private $userSession;
 
 	// Signifies LOOL that document has been changed externally in this storage
 	const LOOL_STATUS_DOC_CHANGED = 1010;
@@ -78,7 +81,8 @@ class WopiController extends Controller {
 								TokenManager $tokenManager,
 								IUserManager $userManager,
 								WopiMapper $wopiMapper,
-								ILogger $logger) {
+								ILogger $logger,
+								IUserSession $userSession) {
 		parent::__construct($appName, $request);
 		$this->rootFolder = $rootFolder;
 		$this->urlGenerator = $urlGenerator;
@@ -87,6 +91,7 @@ class WopiController extends Controller {
 		$this->userManager = $userManager;
 		$this->wopiMapper = $wopiMapper;
 		$this->logger = $logger;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -285,7 +290,7 @@ class WopiController extends Controller {
 			// Set the user to register the change under his name
 			$editor = $this->userManager->get($wopi->getEditorUid());
 			if (!is_null($editor)) {
-				\OC::$server->getUserSession()->setUser($editor);
+				$this->userSession->setUser($editor);
 			}
 
 			$file->putContent($content);


### PR DESCRIPTION
Fixes #184 

Make sure that the file to edit is always obtained as editor.
This makes sure the path is always saved properly and also that all checks can be done in the right order.

To test:

1. create an external storage for userX
2. userX shares the external storage with userY
3. There is some document in the external storage
4. userY edits the document and tries to save it

before: :boom:
now: no-:boom: