### PR TITLE
Start with endpoint for mobile clients

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -135,4 +135,43 @@
 			</index>
 		</declaration>
 	</table>
+
+	<table>
+		<name>*dbprefix*richdocuments_direct</name>
+		<declaration>
+			<field>
+				<name>id</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<autoincrement>1</autoincrement>
+				<unsigned>true</unsigned>
+				<length>4</length>
+			</field>
+			<field>
+				<name>token</name>
+				<type>text</type>
+				<length>64</length>
+			</field>
+			<field>
+				<name>uid</name>
+				<type>text</type>
+				<length>64</length>
+			</field>
+			<field>
+				<name>fileid</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<length>4</length>
+			</field>
+
+			<index>
+				<name>rd_direct_token_idx</name>
+				<unique>true</unique>
+				<field>
+					<name>token</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+		</declaration>
+	</table>
 </database>

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -163,12 +163,28 @@
 				<notnull>true</notnull>
 				<length>4</length>
 			</field>
+			<field>
+				<name>timestamp</name>
+				<type>integer</type>
+				<notnull>true</notnull>
+				<unsigned>true</unsigned>
+				<length>4</length>
+				<default>0</default>
+			</field>
 
 			<index>
 				<name>rd_direct_token_idx</name>
 				<unique>true</unique>
 				<field>
 					<name>token</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+			<index>
+				<name>rd_direct_timestamp_idx</name>
+				<unique>false</unique>
+				<field>
+					<name>timestamp</name>
 					<sorting>ascending</sorting>
 				</field>
 			</index>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Collabora Online</name>
 	<summary>Edit office documents directly in your browser.</summary>
 	<description>This application can connect to a Collabora Online server (WOPI Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.</description>
-	<version>2.0.10</version>
+	<version>2.1.0</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Collabora Online</name>
 	<summary>Edit office documents directly in your browser.</summary>
 	<description>This application can connect to a Collabora Online server (WOPI Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.</description>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -30,5 +30,11 @@ return [
 		//settings
 		['name' => 'settings#setSettings', 'url' => 'ajax/admin.php', 'verb' => 'POST'],
 		['name' => 'settings#getSettings', 'url' => 'ajax/settings.php', 'verb' => 'GET'],
-	]
+
+		//Mobile access
+		['name' => 'directView#show', 'url' => '/direct/{token}', 'verb' => 'GET'],
+	],
+	'ocs' => [
+		['name' => 'OCS#create', 'url' => '/api/v1/document', 'verb' => 'POST'],
+	],
 ];

--- a/js/documents.js
+++ b/js/documents.js
@@ -19,7 +19,7 @@ $.widget('oc.documentGrid', {
 
 	_load : function(fileId) {
 		// Handle guest user case (let users which are able to write set their name)
-		if (window.top.oc_current_user == null && this._getGuestNameCookie() == ''
+		if (!richdocuments_directEdit && window.top.oc_current_user == null && this._getGuestNameCookie() == ''
 				&& (richdocuments_permissions & OC.PERMISSION_UPDATE)) {
 			$('#documentslist').remove();
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -22,6 +22,7 @@
 namespace OCA\Richdocuments\AppInfo;
 
 use OC\AppFramework\Utility\TimeFactory;
+use OCA\Richdocuments\Capabilities;
 use OCA\Richdocuments\WOPI\DiscoveryManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\IAppContainer;
@@ -32,5 +33,7 @@ class Application extends App  {
 
 	public function __construct (array $urlParams = array()) {
 		parent::__construct(self::APPNAME, $urlParams);
+
+		$this->getContainer()->registerCapability(Capabilities::class);
 	}
 }

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Richdocuments;
+
+use OCP\Capabilities\ICapability;
+use OCP\IURLGenerator;
+
+class Capabilities implements ICapability {
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct(IURLGenerator $urlGenerator) {
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	public function getCapabilities() {
+		return [
+			'richdocuments' => [
+				'mimetypes' => [
+					'application/vnd.oasis.opendocument.text',
+					'application/vnd.oasis.opendocument.spreadsheet',
+					'application/vnd.oasis.opendocument.presentation',
+					'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+					'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+					'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+				],
+			],
+		];
+	}
+
+}

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Richdocuments\Controller;
+
+use OCA\Richdocuments\AppConfig;
+use OCA\Richdocuments\Db\DirectMapper;
+use OCA\Richdocuments\TokenManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IConfig;
+use OCP\IRequest;
+
+class DirectViewController extends Controller {
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var TokenManager */
+	private $tokenManager;
+
+	/** @var DirectMapper */
+	private $directMapper;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var AppConfig */
+	private $appConfig;
+
+	public function __construct($appName,
+								IRequest $request,
+								IRootFolder $rootFolder,
+								TokenManager $tokenManager,
+								DirectMapper $directMapper,
+								IConfig $config,
+								AppConfig $appConfig) {
+		parent::__construct($appName, $request);
+
+		$this->rootFolder = $rootFolder;
+		$this->tokenManager = $tokenManager;
+		$this->directMapper = $directMapper;
+		$this->config = $config;
+		$this->appConfig = $appConfig;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @PublicPage
+	 *
+	 * @param string $token
+	 */
+	public function show($token) {
+		try {
+			$direct = $this->directMapper->getBytoken($token);
+		} catch (DoesNotExistException $e) {
+			//TODO show 404
+			throw new \Exception('NOPE!');
+		}
+
+		try {
+			$folder = $this->rootFolder->getUserFolder($direct->getUid());
+			$item = $folder->getById($direct->getFileid())[0];
+			if(!($item instanceof Node)) {
+				throw new \Exception();
+			}
+			list($urlSrc, $token) = $this->tokenManager->getToken($item->getId());
+			$params = [
+				'permissions' => $item->getPermissions(),
+				'title' => $item->getName(),
+				'fileId' => $item->getId() . '_' . $this->config->getSystemValue('instanceid'),
+				'token' => $token,
+				'urlsrc' => $urlSrc,
+				'path' => $folder->getRelativePath($item->getPath()),
+				'instanceId' => $this->config->getSystemValue('instanceid'),
+				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
+				'direct' => true,
+			];
+
+			$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
+			$policy = new ContentSecurityPolicy();
+			$policy->allowInlineScript(true);
+			$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
+			$response->setContentSecurityPolicy($policy);
+			return $response;
+		} catch (\Exception $e) {
+			throw $e;
+		}
+
+	}
+}

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -27,7 +27,9 @@ use OCA\Richdocuments\Db\DirectMapper;
 use OCA\Richdocuments\TokenManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -78,7 +80,7 @@ class DirectViewController extends Controller {
 			$direct = $this->directMapper->getBytoken($token);
 		} catch (DoesNotExistException $e) {
 			//TODO show 404
-			throw new \Exception('NOPE!');
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		try {
@@ -107,7 +109,7 @@ class DirectViewController extends Controller {
 			$response->setContentSecurityPolicy($policy);
 			return $response;
 		} catch (\Exception $e) {
-			throw $e;
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 	}

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -77,7 +77,7 @@ class DirectViewController extends Controller {
 	 */
 	public function show($token) {
 		try {
-			$direct = $this->directMapper->getBytoken($token);
+			$direct = $this->directMapper->getByToken($token);
 		} catch (DoesNotExistException $e) {
 			//TODO show 404
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -83,6 +83,9 @@ class DirectViewController extends Controller {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
+		// Delete the token. They are for 1 time use only
+		$this->directMapper->delete($direct);
+
 		try {
 			$folder = $this->rootFolder->getUserFolder($direct->getUid());
 			$item = $folder->getById($direct->getFileid())[0];

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Richdocuments\Controller;
+
+use OCA\Richdocuments\Db\DirectMapper;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+
+class OCSController extends \OCP\AppFramework\OCSController {
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var string */
+	private $userId;
+
+	/** @var DirectMapper */
+	private $directMapper;
+
+	/** @var IURLGenerator */
+	private $urlGenerator;
+
+	public function __construct($appName,
+								IRequest $request,
+								IRootFolder $rootFolder,
+								$userId,
+								DirectMapper $directMapper,
+								IURLGenerator $urlGenerator) {
+		parent::__construct($appName, $request);
+
+		$this->rootFolder = $rootFolder;
+		$this->userId = $userId;
+		$this->directMapper = $directMapper;
+		$this->urlGenerator = $urlGenerator;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @param int $fileId
+	 */
+	public function create($fileId) {
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($this->userId);
+			$nodes = $userFolder->getById($fileId);
+
+			if ($nodes === []) {
+				throw new NotFoundException();
+			}
+
+			$node = $nodes[0];
+			if ($node instanceof Folder) {
+				throw new OCSBadRequestException('Cannot view folder');
+			}
+
+			//TODO check if we can even edit this file with collabora
+			
+			$direct = $this->directMapper->newDirect($this->userId, $fileId);
+
+			return new DataResponse([
+				'url' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.directView.show', [
+					'token' => $direct->getToken()
+				])
+			]);
+		} catch (NotFoundException $e) {
+			throw new OCSNotFoundException();
+		}
+	}
+}

--- a/lib/Db/Direct.php
+++ b/lib/Db/Direct.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Richdocuments\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method void setToken(string $token)
+ * @method string getToken()
+ * @method void setUid(string $uid)
+ * @method string getUid()
+ * @method void setFileid(int $fileid)
+ * @method int getFileid()
+ */
+class Direct extends Entity {
+	/** @var string */
+	protected $token;
+
+	/** @var string */
+	protected $uid;
+
+	/** @var int */
+	protected $fileid;
+
+	public function __construct() {
+		$this->addType('token', 'string');
+		$this->addType('uid', 'string');
+		$this->addType('fileid', 'int');
+	}
+}

--- a/lib/Db/Direct.php
+++ b/lib/Db/Direct.php
@@ -32,6 +32,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getUid()
  * @method void setFileid(int $fileid)
  * @method int getFileid()
+ * @method void setTimestamp(int $timestamp)
+ * @method int getTimestamp()
  */
 class Direct extends Entity {
 	/** @var string */
@@ -43,9 +45,13 @@ class Direct extends Entity {
 	/** @var int */
 	protected $fileid;
 
+	/** @var int */
+	protected $timestamp;
+
 	public function __construct() {
 		$this->addType('token', 'string');
 		$this->addType('uid', 'string');
 		$this->addType('fileid', 'int');
+		$this->addType('timestamp', 'int');
 	}
 }

--- a/lib/Db/DirectMapper.php
+++ b/lib/Db/DirectMapper.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Richdocuments\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\Mapper;
+use OCP\IDBConnection;
+use OCP\Security\ISecureRandom;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+
+class DirectMapper extends Mapper {
+
+	/** @var ISecureRandom */
+	protected $random;
+
+	public function __construct(IDBConnection $db, ISecureRandom $random) {
+		parent::__construct($db, 'richdocuments_direct', Direct::class);
+
+		$this->random = $random;
+	}
+
+	/**
+	 * @param string $uid
+	 * @param int $fileid
+	 * @return Direct
+	 */
+	public function newDirect($uid, $fileid) {
+		$direct = new Direct();
+		$direct->setUid($uid);
+		$direct->setFileid($fileid);
+		$direct->setToken($this->random->generate(64, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER));
+
+		$direct = $this->insert($direct);
+		return $direct;
+	}
+
+	/**
+	 * @param string $token
+	 * @return Direct
+	 */
+	public function getBytoken($token) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from('richdocuments_direct')
+			->where($qb->expr()->eq('token', $qb->createNamedParameter($token)));
+
+		$cursor = $qb->execute();
+		$row = $cursor->fetch();
+		$cursor->closeCursor();
+
+		//There can only be one as the token is unique
+		if ($row === false) {
+			throw new DoesNotExistException('Could not find token.');
+		}
+
+		return Direct::fromRow($row);
+	}
+}

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -7,6 +7,7 @@
 	var richdocuments_path = '<?php p($_['path']) ?>';
 	var instanceId = '<?php p($_['instanceId']) ?>';
 	var richdocuments_canonical_webroot = '<?php p($_['canonical_webroot']) ?>';
+	var richdocuments_directEdit = <?php isset($_['direct']) ? p('true') : p('false') ?>;
 </script>
 
 <?php


### PR DESCRIPTION
This will allow mobile client to edit using collabora as well.

### Overview
Via capabilities the client can see that the richdocuments app is installed.
Via a call to the collabora app it can see which mimetypes are supported.

This also introduces a new OCS endpoint that `<server>/ocs/v2.php/apps/richdocuments/api/v1/document` A post to this endpoint with `fileId=<fileId>` will do the required verification and preparations. An url is returned in the response. All the client has to do is open this url in a webview.

### Todo

- [x] Add capability
  * Shows mimetypes
- [x] Add OCS endpoint to request URL
- [x] Cleanup
- [ ] Improve JS
- [x] Add lifetime to token
- [ ] Add job to cleanup tokens
- [ ] Extract common code with the normal endpoint
- [ ] Check if we need to disable some functionality on mobile

### Future work

- [ ] Support user-key server-side encryption?
- [ ] When closing the collabora view the process consumes 100% cpu
  * I think we can ignore this when we can just relay the close event to the mobile clients. Should still fix it at some point but not that urgent.
