### PR TITLE
Revert "No need for allow inline script since we use a nonce"

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -188,6 +188,7 @@ class DocumentController extends Controller {
 			$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
 			$policy = new ContentSecurityPolicy();
 			$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
+			$policy->allowInlineScript(true);
 			$response->setContentSecurityPolicy($policy);
 			return $response;
 		} catch (\Exception $e) {
@@ -251,6 +252,7 @@ class DocumentController extends Controller {
 				$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
 				$policy = new ContentSecurityPolicy();
 				$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
+				$policy->allowInlineScript(true);
 				$response->setContentSecurityPolicy($policy);
 				return $response;
 			}


### PR DESCRIPTION
Reverts nextcloud/richdocuments#212

Else Edge does :boom:
We first need a proper solution for this server side.