### PR TITLE
Allow creation of OOXML docs if app not in default location

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -51,11 +51,11 @@ $eventDispatcher->addListener(
 );
 
 if (class_exists('\OC\Files\Type\TemplateManager')) {
-    $manager = \OC_Helper::getFileTemplateManager();
+	$manager = \OC_Helper::getFileTemplateManager();
 
-    $manager->registerTemplate('application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'apps/richdocuments/assets/docxtemplate.docx');
-    $manager->registerTemplate('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'apps/richdocuments/assets/xlsxtemplate.xlsx');
-    $manager->registerTemplate('application/vnd.openxmlformats-officedocument.presentationml.presentation', 'apps/richdocuments/assets/pptxtemplate.pptx');
+	$manager->registerTemplate('application/vnd.openxmlformats-officedocument.wordprocessingml.document', dirname(__DIR__) . '/assets/docxtemplate.docx');
+	$manager->registerTemplate('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', dirname(__DIR__) . '/assets/xlsxtemplate.xlsx');
+	$manager->registerTemplate('application/vnd.openxmlformats-officedocument.presentationml.presentation', dirname(__DIR__) . '/assets/pptxtemplate.pptx');
 }
 
 // Whitelist the wopi URL for iframes, required for Firefox

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -355,7 +355,7 @@ class DocumentController extends Controller {
 		}
 
 		if (!$content){
-			$content = file_get_contents(dirname(__DIR__) . self::ODT_TEMPLATE_PATH);
+			$content = file_get_contents(dirname(dirname(__DIR__)) . self::ODT_TEMPLATE_PATH);
 		}
 
 		if ($content) {


### PR DESCRIPTION
Fixes #118

In case the apps folder is not /apps (the docker container for example).
The template manager will not work with that path then obviously. This
makes sure the path can always be found.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>