### PR TITLE
Center the name input of a public edit

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -520,3 +520,7 @@ document p{
 .oc-dialog .oc-dialog-buttonrow .cancel {
 	float:left;
 }
+
+#documents-content {
+	margin: 0px auto;
+}


### PR DESCRIPTION
Fixes #237
Else it looks rather out of place


Before:
![before](https://user-images.githubusercontent.com/45821/44267327-0a4fd700-a22e-11e8-8456-8207ec25858e.png)

After:
![after](https://user-images.githubusercontent.com/45821/44267330-0de35e00-a22e-11e8-8d9a-e92d9573c8d4.png)
