### PR TITLE
Strip the service root prefixes in the Collabora Online wopi_url.

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -150,6 +150,20 @@ class DocumentController extends Controller {
 	}
 
 	/**
+	 * Strips the path and query parameters from the URL.
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	private function domainOnly($url) {
+		$parsed_url = parse_url($url);
+		$scheme = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+		$host   = isset($parsed_url['host']) ? $parsed_url['host'] : '';
+		$port   = isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+		return "$scheme$host$port";
+	}
+
+	/**
 	 * @NoAdminRequired
 	 *
 	 * @param string $fileId
@@ -187,7 +201,7 @@ class DocumentController extends Controller {
 
 			$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
 			$policy = new ContentSecurityPolicy();
-			$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
+			$policy->addAllowedFrameDomain($this->domainOnly($this->appConfig->getAppValue('wopi_url')));
 			$policy->allowInlineScript(true);
 			$response->setContentSecurityPolicy($policy);
 			return $response;
@@ -251,7 +265,7 @@ class DocumentController extends Controller {
 
 				$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
 				$policy = new ContentSecurityPolicy();
-				$policy->addAllowedFrameDomain($this->appConfig->getAppValue('wopi_url'));
+				$policy->addAllowedFrameDomain($this->domainOnly($this->appConfig->getAppValue('wopi_url')));
 				$policy->allowInlineScript(true);
 				$response->setContentSecurityPolicy($policy);
 				return $response;


### PR DESCRIPTION
Otherwise we cannot set the content security policy correctly.