### PR TITLE
documents-overlay does not cover toolbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,7 +224,7 @@
 
 #documents-overlay,  #documents-overlay-below{
     position: fixed;
-    top: 45px;
+    top: 0;
     left: 0;
     width: 100%;
     height: 100%;
@@ -236,7 +236,7 @@
 
 #documents-overlay-below{
 	right: 72px;
-	top: 45px;
+	top: 0;
     filter:alpha(opacity=100);
     opacity: 1;
 	background:#fff;


### PR DESCRIPTION
Need to use 0 px margin here otherwise this document-overlay does not cover the toolbar / menubar.
This document-overlay is expected to be displayed during loading the document and it should hide the building toolbar / menubar.