### PR TITLE
Move to compiled handlebars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ package_name=$(app_name)
 cert_dir=$(HOME)/.nextcloud/certificates
 occ=$(CURDIR)/../core/occ
 
+handlebars-templates:
+	handlebars -n OCA.RichDocuments.Templates js/templates/ -f js/templates.js
+
 appstore:
 	mkdir -p $(sign_dir)
 	rsync -a \

--- a/js/documents.js
+++ b/js/documents.js
@@ -155,25 +155,6 @@ var documentsMain = {
 						'<div id="revViewer"></div>' +
 						'</div>',
 
-		revHistoryContainerTemplate: '<div id="revPanelContainer" class="loleaflet-font">' +
-			'<div id="revPanelHeader">' +
-			'<h2>Revision History</h2>' +
-			'<span>{{filename}}</span>' +
-			'<a class="closeButton"><img src={{closeButtonUrl}} width="22px" height="22px"></a>' +
-			'</div>' +
-			'<div id="revisionsContainer" class="loleaflet-font">' +
-			'<ul></ul>' +
-			'</div>' +
-			'<input type="button" id="show-more-versions" class="loleaflet-font" value="{{moreVersionsLabel}}" />' +
-			'</div>',
-
-		revHistoryItemTemplate: '<li>' +
-			'<a href="{{downloadUrl}}" class="downloadVersion has-tooltip" title="' + t('richdocuments', 'Download this revision') + '"><img src="{{downloadIconUrl}}" />' +
-			'<a class="versionPreview"><span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span></a>' +
-			'<a href="{{restoreUrl}}" class="restoreVersion has-tooltip" title="' + t('richdocuments', 'Restore this revision') + '"><img src="{{restoreIconUrl}}" />' +
-			'</a>' +
-			'</li>',
-
 		/* Previous window title */
 		mainTitle : '',
 		/* Number of revisions already loaded */
@@ -272,12 +253,13 @@ var documentsMain = {
 					});
 			}
 
-			var revHistoryItemTemplate = Handlebars.compile(documentsMain.UI.revHistoryItemTemplate);
-			var html = revHistoryItemTemplate({
+			var html = OCA.RichDocuments.Templates.revHistoryItem({
 				downloadUrl: downloadUrl,
 				downloadIconUrl: OC.imagePath('core', 'actions/download'),
+				downloadTXT: t('richdocuments', 'Download this revision'),
 				restoreUrl: restoreUrl,
 				restoreIconUrl: OC.imagePath('core', 'actions/history'),
+				restoreTXT: t('richdocuments', 'Restore this revision'),
 				relativeTimestamp: relativeTimestamp,
 				formattedTimestamp: formattedTimestamp
 			});
@@ -318,8 +300,7 @@ var documentsMain = {
 		showRevHistory: function(documentPath) {
 			$(document.body).prepend(documentsMain.UI.viewContainer);
 
-			var revHistoryContainerTemplate = Handlebars.compile(documentsMain.UI.revHistoryContainerTemplate);
-			var revHistoryContainer = revHistoryContainerTemplate({
+			var revHistoryContainer = OCA.RichDocuments.Templates.revHistoryContainer({
 				filename: documentsMain.fileName,
 				moreVersionsLabel: t('richdocuments', 'More versions…'),
 				closeButtonUrl: OC.imagePath('core', 'actions/close')

--- a/js/templates.js
+++ b/js/templates.js
@@ -1,0 +1,35 @@
+(function() {
+  var template = Handlebars.template, templates = OCA.RichDocuments.Templates = OCA.RichDocuments.Templates || {};
+templates['revHistoryContainer'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<div id=\"revPanelContainer\" class=\"loleaflet-font\">\n	<div id=\"revPanelHeader\">\n		<h2>Revision History</h2>\n		<span>"
+    + alias4(((helper = (helper = helpers.filename || (depth0 != null ? depth0.filename : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"filename","hash":{},"data":data}) : helper)))
+    + "</span>\n		<a class=\"closeButton\"><img src="
+    + alias4(((helper = (helper = helpers.closeButtonUrl || (depth0 != null ? depth0.closeButtonUrl : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"closeButtonUrl","hash":{},"data":data}) : helper)))
+    + " width=\"22px\" height=\"22px\"></a>\n	</div>\n	<div id=\"revisionsContainer\" class=\"loleaflet-font\">\n		<ul></ul>\n	</div>\n	<input type=\"button\" id=\"show-more-versions\" class=\"loleaflet-font\" value=\""
+    + alias4(((helper = (helper = helpers.moreVersionsLabel || (depth0 != null ? depth0.moreVersionsLabel : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"moreVersionsLabel","hash":{},"data":data}) : helper)))
+    + "\" />\n</div>\n";
+},"useData":true});
+templates['revHistoryItem'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<li>\n	<a href=\""
+    + alias4(((helper = (helper = helpers.downloadUrl || (depth0 != null ? depth0.downloadUrl : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"downloadUrl","hash":{},"data":data}) : helper)))
+    + "\" class=\"downloadVersion has-tooltip\" title=\""
+    + alias4(((helper = (helper = helpers.downloadTXT || (depth0 != null ? depth0.downloadTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"downloadTXT","hash":{},"data":data}) : helper)))
+    + "\">\n		<img src=\""
+    + alias4(((helper = (helper = helpers.downloadIconUrl || (depth0 != null ? depth0.downloadIconUrl : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"downloadIconUrl","hash":{},"data":data}) : helper)))
+    + "\" />\n		<a class=\"versionPreview\"><span class=\"versiondate has-tooltip\" title=\""
+    + alias4(((helper = (helper = helpers.formattedTimestamp || (depth0 != null ? depth0.formattedTimestamp : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"formattedTimestamp","hash":{},"data":data}) : helper)))
+    + "\">"
+    + alias4(((helper = (helper = helpers.relativeTimestamp || (depth0 != null ? depth0.relativeTimestamp : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"relativeTimestamp","hash":{},"data":data}) : helper)))
+    + "</span></a>\n		<a href=\""
+    + alias4(((helper = (helper = helpers.restoreUrl || (depth0 != null ? depth0.restoreUrl : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"restoreUrl","hash":{},"data":data}) : helper)))
+    + "\" class=\"restoreVersion has-tooltip\" title=\""
+    + alias4(((helper = (helper = helpers.restoreTXT || (depth0 != null ? depth0.restoreTXT : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"restoreTXT","hash":{},"data":data}) : helper)))
+    + "\"><img src=\""
+    + alias4(((helper = (helper = helpers.restoreIconUrl || (depth0 != null ? depth0.restoreIconUrl : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"restoreIconUrl","hash":{},"data":data}) : helper)))
+    + "\" />\n	</a>\n</li>\n";
+},"useData":true});
+})();

--- a/js/templates/revHistoryContainer.handlebars
+++ b/js/templates/revHistoryContainer.handlebars
@@ -1,0 +1,11 @@
+<div id="revPanelContainer" class="loleaflet-font">
+	<div id="revPanelHeader">
+		<h2>Revision History</h2>
+		<span>{{filename}}</span>
+		<a class="closeButton"><img src={{closeButtonUrl}} width="22px" height="22px"></a>
+	</div>
+	<div id="revisionsContainer" class="loleaflet-font">
+		<ul></ul>
+	</div>
+	<input type="button" id="show-more-versions" class="loleaflet-font" value="{{moreVersionsLabel}}" />
+</div>

--- a/js/templates/revHistoryItem.handlebars
+++ b/js/templates/revHistoryItem.handlebars
@@ -1,0 +1,7 @@
+<li>
+	<a href="{{downloadUrl}}" class="downloadVersion has-tooltip" title="{{downloadTXT}}">
+		<img src="{{downloadIconUrl}}" />
+		<a class="versionPreview"><span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span></a>
+		<a href="{{restoreUrl}}" class="restoreVersion has-tooltip" title="{{restoreTXT}}"><img src="{{restoreIconUrl}}" />
+	</a>
+</li>

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -13,6 +13,7 @@
 <?php
 style( 'richdocuments', 'style' );
 script('richdocuments', 'documents');
+script('richdocuments', 'templates');
 ?>
 <div id="documents-content">
 	<ul class="documentslist">


### PR DESCRIPTION
The CSP in NC15 will be stricter so compiling at runtime won't work
anymore.

Generate the precompiled tempaltes by installing handlebars and running:
handlebars -n OCA.RichDocuments.Templates js/templates/ -f js/templates.js

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>