### PR TITLE
Do not show loading screen if we need a nickname

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -613,7 +613,7 @@ var documentsMain = {
 
 		documentsMain.show(fileId);
 
-		if (fileId) {
+		if (fileId && Number.isInteger(Number(fileId))) {
 			documentsMain.overlay.documentOverlay('show');
 			documentsMain.prepareSession();
 		}


### PR DESCRIPTION
Fixes #280

If we require the user to enter a password. We should not show the
loading screen. As this overlays the input field as well.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>