### PR TITLE
Do not clear asset on HEAD request

### DIFF
--- a/lib/Controller/AssetsController.php
+++ b/lib/Controller/AssetsController.php
@@ -103,8 +103,11 @@ class AssetsController extends Controller {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		// Clear the assets so we can only fetch it once
-		$this->assetMapper->delete($asset);
+		// Do not clear the asset on HEAD requests
+		if ($this->request->getMethod() === 'GET') {
+			// Clear the assets so we can only fetch it once
+			$this->assetMapper->delete($asset);
+		}
 
 		$userFolder = $this->rootFolder->getUserFolder($asset->getUid());
 		$nodes = $userFolder->getById($asset->getFileid());


### PR DESCRIPTION
If Collabora sends a head request to obtain info about the assets we
should not directly delete it. Instead just let it be if it is a HEAD
request.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>