### PR TITLE
Do not show overlay if we request the nickname

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -618,7 +618,7 @@ var documentsMain = {
 
 		documentsMain.show(fileId);
 
-		if (fileId && Number.isInteger(Number(fileId))) {
+		if (fileId && Number.isInteger(Number(fileId)) && $('#nickname').length === 0) {
 			documentsMain.overlay.documentOverlay('show');
 			documentsMain.prepareSession();
 		}


### PR DESCRIPTION
If sharinga a directory with RW permissions and the directory contains
an editable file. The nickname field was hidden behind the spinner.

Now we check if the nickname field is there as well.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>