### PR TITLE
Use nextcloud versions sidebar tab

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -139,7 +139,6 @@
 
 #revViewer{
         position: relative;
-        margin-right: 250px;
         height: 100%;
 }
 
@@ -156,70 +155,20 @@
 	overflow-y: auto;
 }
 
-/* Title */
-#revPanelHeader{
-    height: 69px;
-    border-bottom: 1px solid #ddd;
-    margin: 0 0;
-    box-sizing: border-box;
-    padding-left: 15px;
-    padding-top: 15px;
-}
-
-#revPanelHeader h2{
-    margin: 0 0;
-}
 
 /* For close button image */
-#revPanelHeader img{
-    position: absolute;
-    right: 5px;
-    top: 10px;
+#revViewerContainer .closeButton {
+	position: absolute;
+	right: 0;
+	top: 0;
+	width: 20px;
+	height: 24px;
+	z-index: 1;
+	border: none;
 }
 
 .loleaflet-font{
     font-family: "Segoe UI", Tahoma, Arial, Helvetica, sans-serif !important;
-}
-
-#revisionsContainer{
-    list-style: none;
-}
-
-#revisionsContainer li{
-    width: 100%;
-    cursor: default;
-    height: 45px;
-    float: left;
-    border-bottom: 1px solid #ddd;
-    box-sizing: border-box;
-    padding: 10px 0;
-}
-
-#revisionsContainer li:first-child .restoreVersion{
-    display: none;
-}
-
-#revisionsContainer a{
-    padding-left: 15px;
-    opacity: 0.5;
-}
-
-#revisionsContainer a:hover{
-    opacity: 1;
-}
-
-#revisionsContainer li:hover, #revisionsContainer li.active{
-    background-color: rgba(0, 0, 0, 0.1);
-}
-
-.restoreVersion{
-    position: absolute;
-    right: 15px;
-}
-
-#show-more-versions{
-    width: 100%;
-    padding: 10px;
 }
 
 #documents-overlay, #documents-overlay-below{

--- a/css/viewer/odfviewer.css
+++ b/css/viewer/odfviewer.css
@@ -56,13 +56,13 @@
   opacity: 0.8;
 }
 
+#versionsTabView li {
+  padding-left: 15px;
+  margin-left: -15px;
+}
 
 #versionsTabView li.active {
-  border-left: 3px solid var(--color-primary);
-  margin-left: -15px;
+  border-left: 3px solid var(--color-primary, #000);
   padding-left: 12px;
-}
-#versionsTabView li.active .revertVersion {
-  margin-right: -25px;
 }
 

--- a/css/viewer/odfviewer.css
+++ b/css/viewer/odfviewer.css
@@ -66,3 +66,6 @@
   padding-left: 12px;
 }
 
+#currentVersion li {
+  border-bottom: 1px solid rgba(100,100,100,.1);
+}

--- a/css/viewer/odfviewer.css
+++ b/css/viewer/odfviewer.css
@@ -55,3 +55,14 @@
 .richdocuments-avatar.read-only {
   opacity: 0.8;
 }
+
+
+#versionsTabView li.active {
+  border-left: 3px solid var(--color-primary);
+  margin-left: -15px;
+  padding-left: 12px;
+}
+#versionsTabView li.active .revertVersion {
+  margin-right: -25px;
+}
+

--- a/js/documents.js
+++ b/js/documents.js
@@ -318,17 +318,19 @@ var documentsMain = {
 				documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Host_VersionRestore', {Status: 'Pre_Restore'});
 
 				var version = e.currentTarget.parentElement.parentElement.dataset.revision;
-				var restoreUrl = OC.generateUrl('apps/files_versions/ajax/rollbackVersion.php?file={file}&revision={revision}',
-					{
-						file: documentPath, revision: version
-					});
+				var restoreUrl = OC.linkToRemoteBase('dav') + '/versions/' + parent.OC.getCurrentUser().uid
+					+ '/versions/' + documentsMain.originalFileId + '/' + version;
+
 				documentsMain.$deferredVersionRestoreAck = $.Deferred();
 				jQuery.when(documentsMain.$deferredVersionRestoreAck).
 				done(function(args) {
 					// restore selected version
 					$.ajax({
-						type: 'GET',
+						type: 'MOVE',
 						url: restoreUrl,
+						headers: {
+							Destination: OC.linkToRemote('dav') + '/versions/' + parent.OC.getCurrentUser().uid + '/restore/target'
+						},
 						success: function(response) {
 							if (response.status === 'error') {
 								documentsMain.UI.notify(t('richdocuments', 'Failed to revert the document to older version'));
@@ -339,6 +341,9 @@ var documentsMain = {
 							documentsMain.overlay.documentOverlay('hide');
 
 							parent.OC.Apps.hideAppSidebar();
+						},
+						error: function() {
+							documentsMain.UI.notify(t('richdocuments', 'Failed to revert the document to older version'));
 						}
 					});
 				});

--- a/js/documents.js
+++ b/js/documents.js
@@ -219,6 +219,8 @@ var documentsMain = {
 			if (documentsMain.isViewerMode) {
 				$('#revViewer').remove();
 				$('#revViewerContainer').prepend($('<div id="revViewer">'));
+			} else {
+				this.addCurrentVersion();
 			}
 
 			// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
@@ -295,6 +297,12 @@ var documentsMain = {
 			$(parent.document.querySelector('#content')).off('mousedown.revisions');
 		},
 
+		addCurrentVersion: function() {
+			var preview = OC.MimeType.getIconUrl(parent.OCA.Files.App.fileList._currentFileModel.get('mimetype'));
+			parent.$('#versionsTabView').prepend('<ul id="currentVersion"><li data-revision="0" class="active"><div><div class="preview-container"><img src="' + preview + '" width="44" /></div><div class="version-container">\n' +
+				'<div><a class="downloadVersion">' + t('richdocuments', 'Current version') + '</a></div></div></li></ul>');
+		},
+
 		showVersionPreview: function (e) {
 			e.preventDefault();
 			documentsMain.UI.loadRevViewerContainer();
@@ -310,7 +318,7 @@ var documentsMain = {
 			);
 
 			// mark only current <li> as active
-			$(element.parentElement).find('li').removeClass('active');
+			$(element.parentElement.parentElement).find('li').removeClass('active');
 			$(element).addClass('active');
 		},
 
@@ -736,7 +744,7 @@ var documentsMain = {
 		documentsMain.isViewerMode = false;
 		documentsMain.UI.revisionsStart = 0;
 		parent.$('#versionsTabView .active').removeClass('active');
-
+		parent.$('#versionsTabView #currentVersion').remove();
 		$('#loleafletframe').focus();
 	},
 

--- a/js/documents.js
+++ b/js/documents.js
@@ -270,7 +270,6 @@ var documentsMain = {
 		showRevHistory: function(documentPath) {
 			// TODO: make sure this also works if using the sidebar with the share icon and navigating to versions then
 			parent.FileList.showDetailsView(documentsMain.fileName, 'versionsTabView');
-			this.addVersionSidebarEvents();
 			this.loadRevViewerContainer();
 			// Load current revision
 			// TODO: add entry to versions
@@ -304,11 +303,11 @@ var documentsMain = {
 				$(element).addClass('active');
 			};
 
-			$(parent.document.querySelector('#content')).on('click', '#app-sidebar .preview-container', showVersionPreview);
-			$(parent.document.querySelector('#content')).on('click', '#app-sidebar .downloadVersion', showVersionPreview);
+			$(parent.document.querySelector('#content')).on('click.revisions', '#app-sidebar .preview-container', showVersionPreview);
+			$(parent.document.querySelector('#content')).on('click.revisions', '#app-sidebar .downloadVersion', showVersionPreview);
 
 			// Use mousedown event to overwrite behavior of the versions app
-			$(parent.document.querySelector('#content')).on('mousedown', '#app-sidebar .revertVersion', function(e) {
+			$(parent.document.querySelector('#content')).on('mousedown.revisions', '#app-sidebar .revertVersion', function(e) {
 				e.preventDefault();
 				e.stopPropagation();
 
@@ -353,6 +352,12 @@ var documentsMain = {
 					documentsMain.$deferredVersionRestoreAck.resolve();
 				}
 			});
+		},
+
+		removeVersionSidebarEvents: function() {
+			$(parent.document.querySelector('#content')).off('click.revisions');
+			$(parent.document.querySelector('#content')).off('click.revisions');
+			$(parent.document.querySelector('#content')).off('mousedown.revisions');
 		},
 
 		showEditor : function(title, fileId, action){
@@ -695,6 +700,7 @@ var documentsMain = {
 
 		parent.document.title = documentsMain.UI.mainTitle;
 		parent.postMessage('close', '*');
+		this.removeVersionSidebarEvents();
 	},
 
 	onCloseViewer: function() {

--- a/js/documents.js
+++ b/js/documents.js
@@ -285,7 +285,6 @@ var documentsMain = {
 
 		addVersionSidebarEvents: function() {
 			var self = this;
-			console.log(parent.document.querySelector('#app-sidebar'));
 			var showVersionPreview = function (e) {
 				e.preventDefault();
 				self.loadRevViewerContainer();
@@ -305,10 +304,11 @@ var documentsMain = {
 				$(element).addClass('active');
 			};
 
-			$(parent.document.querySelector('#app-sidebar')).on('click', '.preview-container', showVersionPreview);
-			$(parent.document.querySelector('#app-sidebar')).on('click', '.downloadVersion', showVersionPreview);
+			$(parent.document.querySelector('#content')).on('click', '#app-sidebar .preview-container', showVersionPreview);
+			$(parent.document.querySelector('#content')).on('click', '#app-sidebar .downloadVersion', showVersionPreview);
 
-			$(parent.document.querySelector('#app-sidebar')).on('click', '.revertVersion', function(e) {
+			// Use mousedown event to overwrite behavior of the versions app
+			$(parent.document.querySelector('#content')).on('mousedown', '#app-sidebar .revertVersion', function(e) {
 				e.preventDefault();
 				e.stopPropagation();
 


### PR DESCRIPTION
Implements #286 

@rullzer Is the dav endpoint for versions also available for Nextcloud 13,14? Otherwise this would be a 15 only change.

![image](https://user-images.githubusercontent.com/3404133/50102489-7ca8e600-0225-11e9-8267-0801906236e8.png)


ToDo:
- [x] Remove current version indicator after closing the viewer
- [x] Add current version entry to the list of versions