### PR TITLE
Fix showing the files sidebar on Nextcloud 15

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -110,11 +110,12 @@ var odfViewer = {
 				var $button = $('<div class="richdocuments-sharing"><a class="icon-shared icon-white"></a></div>');
 				$('.header-right').prepend($button);
 				$button.on('click', function() {
-					if (!$('#app-sidebar').hasClass('disappear') || $('#app-content').hasClass('with-app-sidebar')) {
+					if ($('#app-sidebar').is(':visible')) {
 						OC.Apps.hideAppSidebar();
 						return;
 					}
 					FileList.showDetailsView(fileName, 'shareTabView');
+					OC.Apps.showAppSidebar();
 				});
 				$('.searchbox').hide();
 				$('#app-navigation').addClass('hidden');


### PR DESCRIPTION
The class `with-app-sidebar` is not available anymore when the sidebar is shown in the files app on Nextcloud 15.