### PR TITLE
Fetch capabilities from collabora and store them in appdata

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -23,19 +23,48 @@
 
 namespace OCA\Richdocuments;
 
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Capabilities\ICapability;
+use OCP\Files\IAppData;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 
 class Capabilities implements ICapability {
 
-	/** @var IURLGenerator */
-	private $urlGenerator;
+	/** @var IConfig */
+	private $config;
+	/** @var IClientService */
+	private $clientService;
+	/** @var ITimeFactory */
+	private $timeFactory;
+	/** @var ISimpleFolder */
+	private $appData;
 
-	public function __construct(IURLGenerator $urlGenerator) {
-		$this->urlGenerator = $urlGenerator;
+	/**
+	 * Capabilities constructor.
+	 *
+	 * @param IConfig $config
+	 * @param IClientService $clientService
+	 * @param IAppData $appData
+	 * @param ITimeFactory $timeFactory
+	 * @throws \OCP\Files\NotPermittedException
+	 */
+	public function __construct(IConfig $config, IClientService $clientService, IAppData $appData, ITimeFactory $timeFactory) {
+		$this->config = $config;
+		$this->clientService = $clientService;
+		try {
+			$this->appData = $appData->getFolder('richdocuments');
+		} catch (NotFoundException $e) {
+			$this->appData = $appData->newFolder('richdocuments');
+		}
+		$this->timeFactory = $timeFactory;
 	}
 
 	public function getCapabilities() {
+		$collaboraCapabilities = $this->getCollaboraCapabilities();
 		return [
 			'richdocuments' => [
 				'mimetypes' => [
@@ -46,8 +75,43 @@ class Capabilities implements ICapability {
 					'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 					'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 				],
+				'collabora' => $collaboraCapabilities !== null ? $collaboraCapabilities : [],
+				'direct_editing' => $collaboraCapabilities !== null // TODO: true if version >= 4.0 if version is available
 			],
 		];
 	}
 
+	/**
+	 * @return array|null
+	 * @throws \OCP\Files\NotPermittedException
+	 */
+	private function getCollaboraCapabilities() {
+		try {
+			$file = $this->appData->getFile('capabilities.json');
+			$decodedFile = \json_decode($file->getContent(), true);
+			if($decodedFile['timestamp'] + 3600 > $this->timeFactory->getTime()) {
+				return \json_decode($decodedFile['data'], true);
+			}
+		} catch (NotFoundException $e) {
+			$file = $this->appData->newFile('capabilities.json');
+		}
+		$remoteHost = $this->config->getAppValue('richdocuments', 'wopi_url');
+		$capabilitiesEndpoint = $remoteHost . '/hosting/capabilities';
+
+		$client = $this->clientService->newClient();
+		try {
+			$response = $client->get($capabilitiesEndpoint);
+		} catch (\Exception $e) {
+			return null;
+		}
+
+		$responseBody = $response->getBody();
+		$file->putContent(
+			\json_encode([
+				'data' => $responseBody,
+				'timestamp' => $this->timeFactory->getTime(),
+			])
+		);
+		return \json_decode($responseBody, true);
+	}
 }

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -75,14 +75,15 @@ class Capabilities implements ICapability {
 					'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 					'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 				],
-				'collabora' => $collaboraCapabilities !== null ? $collaboraCapabilities : [],
-				'direct_editing' => $collaboraCapabilities !== null // TODO: true if version >= 4.0 if version is available
+				'collabora' => $collaboraCapabilities,
+				'direct_editing' => false, //TODO: fix once proper capability is available
+				'templates' => false, //TODO: fix once proper capability is available
 			],
 		];
 	}
 
 	/**
-	 * @return array|null
+	 * @return array
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	private function getCollaboraCapabilities() {
@@ -102,7 +103,7 @@ class Capabilities implements ICapability {
 		try {
 			$response = $client->get($capabilitiesEndpoint);
 		} catch (\Exception $e) {
-			return null;
+			return [];
 		}
 
 		$responseBody = $response->getBody();


### PR DESCRIPTION
- [x] Fetch collabora capabilities and store them in app data
- [x] Add collabora capabilities to the richdocument capabilities
- [ ] Wait for version capability to be available and make direct_editing depend on that


```
        "richdocuments": {
          "mimetypes": [
            "application/vnd.oasis.opendocument.text",
            "application/vnd.oasis.opendocument.spreadsheet",
            "application/vnd.oasis.opendocument.presentation",
            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
          ],
          "collabora": {
            "convert-to": {
              "available": false
            }
          },
          "direct_editing": false
        },
```

Fixes #318 