### PR TITLE
Improve current editor listing in Nextcloud header

### DIFF
--- a/css/viewer/odfviewer.scss
+++ b/css/viewer/odfviewer.scss
@@ -56,7 +56,7 @@
       border-left: 3px solid var(--color-primary, $color-primary);
     }
 
-    div.label {
+    .label {
       padding: 6px;
       flex-grow: 1;
 
@@ -66,6 +66,10 @@
         padding-left: 10px;
         vertical-align: top;
       }
+    }
+    label.label::before {
+      margin-right: 16px;
+      margin-left: 7px;
     }
     .icon-close {
       padding: 8px;

--- a/css/viewer/odfviewer.scss
+++ b/css/viewer/odfviewer.scss
@@ -44,7 +44,31 @@
   z-index:110;
 }
 
-.richdocuments-avatar {
+#editors-menu {
+  min-width: 200px;
+}
+
+#editors-menu ul li {
+  display: flex;
+  padding: 3px;
+
+  div.label {
+    padding: 6px;
+    flex-grow: 1;
+
+    .icon-play-next {
+      opacity: .5;
+      display: inline-block;
+      padding-left: 10px;
+      vertical-align: top;
+    }
+  }
+  .icon-close {
+    padding: 8px;
+  }
+}
+
+#richdocuments-avatars > .richdocuments-avatar {
   float: right;
   border-radius: 50%;
   margin: 8px;
@@ -52,7 +76,7 @@
   box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
   position: relative;
 }
-.richdocuments-avatar.read-only {
+#richdocuments-avatars > .richdocuments-avatar.read-only {
   opacity: 0.8;
 }
 

--- a/css/viewer/odfviewer.scss
+++ b/css/viewer/odfviewer.scss
@@ -46,38 +46,47 @@
 
 #editors-menu {
   min-width: 200px;
-}
+  top: 50px;
 
-#editors-menu ul li {
-  display: flex;
-  padding: 3px;
+  ul li {
+    display: flex;
+    padding: 3px;
+    border-left: 3px solid transparent;
+    &.active {
+      border-left: 3px solid var(--color-primary, $color-primary);
+    }
 
-  div.label {
-    padding: 6px;
-    flex-grow: 1;
+    div.label {
+      padding: 6px;
+      flex-grow: 1;
 
-    .icon-play-next {
-      opacity: .5;
-      display: inline-block;
-      padding-left: 10px;
-      vertical-align: top;
+      .icon-play-next {
+        opacity: .5;
+        display: inline-block;
+        padding-left: 10px;
+        vertical-align: top;
+      }
+    }
+    .icon-close {
+      padding: 8px;
     }
   }
-  .icon-close {
-    padding: 8px;
-  }
 }
 
-#richdocuments-avatars > .richdocuments-avatar {
-  float: right;
-  border-radius: 50%;
-  margin: 8px;
-  margin-left: -20px;
-  box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
+#richdocuments-avatars {
   position: relative;
-}
-#richdocuments-avatars > .richdocuments-avatar.read-only {
-  opacity: 0.8;
+
+  & > .richdocuments-avatar {
+    float: right;
+    border-radius: 50%;
+    margin: 8px;
+    margin-left: -20px;
+    box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
+    position: relative;
+    &.read-only {
+      opacity: 0.8;
+    }
+  }
 }
 
 #versionsTabView li {

--- a/js/documents.js
+++ b/js/documents.js
@@ -213,7 +213,9 @@ var documentsMain = {
 
 			}
 			label.click(function() {
+				parent.$('#editors-menu').find('li').removeClass('active');
 				documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Action_FollowUser', {ViewId: view.ViewId, Follow: true});
+				entry.addClass('active');
 			});
 			entry.append(label);
 
@@ -227,9 +229,17 @@ var documentsMain = {
 			return entry;
 		},
 
+		/**
+		 * @param {View} view
+		 * @returns {jQuery|HTMLElement}
+		 * @private
+		 */
 		_avatarForView: function(view) {
 			var avatarContainer = $('<div class="richdocuments-avatar"><div class="avatar" title="' + view.UserName + '" data-user="' + view.UserId + '"></div></div>');
 			var avatar = avatarContainer.find('.avatar');
+			avatar.css({'border-color': view.Color,
+				'border-width':'2px',
+				'border-style':'solid'});
 			if (view.ReadOnly === '1') {
 				avatarContainer.addClass('read-only');
 				$(avatar).attr('title', view.UserName + ' ' + t('richdocuments', '(read only)'));
@@ -246,7 +256,7 @@ var documentsMain = {
 		renderAvatars: function() {
 			var avatardiv = parent.$('#header .header-right #richdocuments-avatars');
 			avatardiv.empty();
-			var popover = $('<div id="editors-menu" class="menu"><ul></ul></div>');
+			var popover = $('<div id="editors-menu" class="popovermenu menu-center"><ul></ul></div>');
 
 			var users = [];
 			// Add new avatars
@@ -270,6 +280,15 @@ var documentsMain = {
 					avatardiv.append(this._avatarForView(view));
 				}
 			};
+
+			var followCurrentEditor = $('<li><div class="label">' + t('richdocuments', 'Follow current editor') + '</div></li>');
+			followCurrentEditor.click(function() {
+				popover.find('li.active').removeClass('active');
+				documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Action_FollowUser', {Follow: true});
+				followCurrentEditor.addClass('active');
+			});
+			popover.find('ul').append(followCurrentEditor);
+
 			avatardiv.append(popover)
 		},
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -12,7 +12,7 @@ script('files', 'jquery.fileupload');
 			title="<?php p($l->t('Open documentation'));?>"
 			href="https://nextcloud.github.io/richdocuments/app_settings"></a>
 	</h2>
-	
+
 	<br/>
 	<label for="wopi_url"><?php p($l->t('Collabora Online server')) ?></label>
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width: 300px; display: block;">


### PR DESCRIPTION
- [x] Limit avatar list in header to 3
- [x] Show popover with a full list of editing users
- [x] Follow user activities by clicking the name
- [x] Allow to remove the user from collabora by clicking the x icon
- [x] Indicate current following user
- [x] Add option to follow the current editor
- [x] Add color indicator for editors
- [x] Update on changes by FollowUser_Changed post message

![image](https://user-images.githubusercontent.com/3404133/50897183-a5c72b80-140b-11e9-925b-40c8c1f34038.png)

Fixes #320 