### PR TITLE
Richdocument on Android did not work in groupfolders

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -133,6 +133,7 @@ class TokenManager {
 		if (is_null($owneruid)) {
 			$owner = $file->getOwner();
 			if (is_null($owner)) {
+				// Editor UID instead of owner UID in case owner is null e.g. group folders
 				$owneruid = $editoruid;
 			} else {
 				$owneruid = $owner->getUID();

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -131,7 +131,12 @@ class TokenManager {
 		$file = $rootFolder->getById($fileId)[0];
 		// If its a public share, use the owner from the share, otherwise check the file object
 		if (is_null($owneruid)) {
-			$owneruid = $file->getOwner()->getUID();
+			$owner = $file->getOwner();
+			if (is_null($owner)) {
+				$owneruid = $editoruid;
+			} else {
+				$owneruid = $owner->getUID();
+			}
 		}
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');//$this->request->getServerProtocol() . '://' . $this->request->getServerHost();
 


### PR DESCRIPTION
## Problem

After clicking some odt file in a group folder, on NextCloud for Android, 3.4.1 from Google Play, had stopped on loading screen, with the following log on a server.

```
Error: Call to a member function getUID() on null

/var/www/html/apps/richdocuments/lib/Controller/DirectViewController.php - line 117:
OCA\Richdocuments\TokenManager->getToken("*** sensiti ... *")

/var/www/html/lib/private/AppFramework/Http/Dispatcher.php - line 166:
OCA\Richdocuments\Controller\DirectViewController->show("ILhabMOLwOY ... j")

/var/www/html/lib/private/AppFramework/Http/Dispatcher.php - line 99:
OC\AppFramework\Http\Dispatcher->executeController(OCA\Richdocu ... {}, "show")

/var/www/html/lib/private/AppFramework/App.php - line 118:
OC\AppFramework\Http\Dispatcher->dispatch(OCA\Richdocu ... {}, "show")

/var/www/html/lib/private/AppFramework/Routing/RouteActionHandler.php - line 47:
OC\AppFramework\App::main("OCA\\Richdo ... r", "show", OC\AppFramew ... {}, { token: "IL ... "})

&lt;&lt;closure&gt;&gt;
OC\AppFramework\Routing\RouteActionHandler->__invoke({ token: "IL ... "})

/var/www/html/lib/private/Route/Router.php - line 297:
call_user_func(OC\AppFramew ... {}, { token: "IL ... "})

/var/www/html/lib/base.php - line 987:
OC\Route\Router->match("/apps/richd ... j")

/var/www/html/index.php - line 42:
OC::handleRequest()
```

My testing server environment:

- Ubuntu 18.04
- PHP 7.2 from apt
- Both of below:
  - NextCloud 15.0.0 stable
  - nextcloud/server, nextcloud/logreader, nextcloud/richdocuments, nextcloud/groupfolders, all from master

## This Pull Request

It seems `$file` in `getToken` in `lib/TokenManager.php`, line 131, `isinstanceof \OCP\Files\File`, but this returns `null` to `getOwner`. I felt it is natural that a group folder does not to have owner ID, but I'm not sure.

This seems to have to be a valid uid, so I tried to put editor's uid instead of actual owner, and this seemed to work at least in my environment.

I also confirmed that it works when one is editing on mobile, and another login user is editing on Firefox on PC. However, I'm not sure it works in every environments.

I'm not familiar with NextCloud, so I'm not sure:

- Is it really a bug of nextcloud/richdocuments, not one of nextcloud/groupfolders? Is it correct that `FileInfo` returns `null`?
- Does anything bad happens if `$owneruid` here is not the correct owner uid?
- Is this change is correct in any other ways?

I think at least something should be changed in order to fix this bug, bug I'm not sure this is the best way.

Please take a look at this fixation.