### PR TITLE
Fix issues with capabilities

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -343,11 +343,17 @@ $(document).ready(function() {
 		// register() needs to be re-run to re-register the fileActions.
 		odfViewer.register();
 
-		$.get(
-			OC.filePath('richdocuments', 'ajax', 'settings.php'),
-			{},
-			odfViewer.registerFilesMenu
-		);
+		var getSettings = $.get(OC.filePath('richdocuments', 'ajax', 'settings.php'));
+		var getCapabilities = $.Deferred().resolve();
+
+		if (typeof oc_capabilities === 'undefined') {
+			getCapabilities = $.get(OC.linkToOCS('cloud', 2) + 'capabilities?format=json', function (data) {
+				oc_capabilities = data.ocs.data.capabilities;
+				console.log(oc_capabilities);
+			})
+		}
+		$.when(getSettings, getCapabilities).done(odfViewer.registerFilesMenu)
+
 	}
 });
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -97,6 +97,9 @@ class Capabilities implements ICapability {
 			$file = $this->appData->newFile('capabilities.json');
 		}
 		$remoteHost = $this->config->getAppValue('richdocuments', 'wopi_url');
+		if ($remoteHost === '') {
+			return [];
+		}
 		$capabilitiesEndpoint = $remoteHost . '/hosting/capabilities';
 
 		$client = $this->clientService->newClient();


### PR DESCRIPTION
- Fetch capabilities from OCS endpoint if oc_capabilities global isn't available (Nextcloud 13)
- Only do the request against the collabora capabilities endpoint, if there is a remote host configured