### PR TITLE
Don't ask for users before document is loaded

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -596,9 +596,6 @@ var documentsMain = {
 
 				// Tell the LOOL iframe that we are ready now
 				documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Host_PostmessageReady', {});
-
-				// Ask for all the participants
-				documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Get_Views', {});
 			});
 
 			// submit that


### PR DESCRIPTION
richdocuments was asking for users before Collabora Online was initialized properly and following message was visible in the console:
"LibreOffice Online not loaded yet. Listen for App_LoadingStatus (Document_Loaded) event before using PostMessage API. Ignoring post message 'Get_Views'."