### PR TITLE
Restore public page when closing collabora

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -153,6 +153,14 @@ var odfViewer = {
 		$('#richdocuments-avatars').remove();
 		$('.searchbox').show();
 
+		if ($('#isPublic').val()) {
+			$('#content').removeClass('full-height');
+			$('footer').removeClass('hidden');
+			$('#imgframe').removeClass('hidden');
+			$('.directLink').removeClass('hidden');
+			$('.directDownload').removeClass('hidden');
+		}
+
 		OC.Util.History.replaceState();
 	},
 


### PR DESCRIPTION
Otherwise users end on an empty page when closing the editor.