### PR TITLE
Use templates shipped with richdocuments for new files

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -58,6 +58,10 @@ if (class_exists('\OC\Files\Type\TemplateManager')) {
 	$manager->registerTemplate('application/vnd.openxmlformats-officedocument.wordprocessingml.document', dirname(__DIR__) . '/assets/docxtemplate.docx');
 	$manager->registerTemplate('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', dirname(__DIR__) . '/assets/xlsxtemplate.xlsx');
 	$manager->registerTemplate('application/vnd.openxmlformats-officedocument.presentationml.presentation', dirname(__DIR__) . '/assets/pptxtemplate.pptx');
+	$manager->registerTemplate('application/vnd.oasis.opendocument.presentation', dirname(__DIR__) . '/assets/presentation.otp');
+	$manager->registerTemplate('application/vnd.oasis.opendocument.text', dirname(__DIR__) . '/assets/document.ott');
+	$manager->registerTemplate('application/vnd.oasis.opendocument.spreadsheet', dirname(__DIR__) . '/assets/spreadsheet.ots');
+
 }
 
 // Whitelist the wopi URL for iframes, required for Firefox


### PR DESCRIPTION
Otherwise templates from 'core/templates/filetemplates/' are used if there is no template selector shown.

Signed-off-by: Julius Härtl <jus@bitgrid.net>