### PR TITLE
Check if loading the document is sucessful

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -122,6 +122,12 @@ var odfViewer = {
 		OC.addStyle('richdocuments', 'mobile');
 
 		var $iframe = $('<iframe id="richdocumentsframe" scrolling="no" allowfullscreen src="'+viewer+'" />');
+		$.get(viewer, function() {
+			$iframe.src = viewer;
+		}) .fail(function() {
+			odfViewer.onClose();
+			OC.Notification.showTemporary('Failed to load Collabora online - please try again later');
+		});
 		$('body').css('overscroll-behavior-y', 'none');
 		if ($('#isPublic').val()) {
 			// force the preview to adjust its height


### PR DESCRIPTION
Unfortunately iframes do not have any onError event, so we need to have a separate call to check if the document returns a proper 200 status code.

If there is an error we show a message and go back to the file list.

Fixes #330 