### PR TITLE
Use proper string for document template selection

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -775,6 +775,9 @@ var documentsMain = {
 				t('richdocuments', 'Save As'),
 				function(result, value) {
 					if (result === true && value) {
+						if (type === 'text') {
+							type = 'document';
+						}
 						var dir = parent.$('#dir').val();
 						var url = OC.generateUrl('/apps/files/?dir=' + dir + '&richdocuments_create=' + type + '&richdocuments_filename=' + encodeURI(value));
 						var win = window.open(url, '_blank');


### PR DESCRIPTION
The post message uses `text` as type, while we use `document` when loading the template picker. 