### PR TITLE
Show last saved and current version in version sidebar

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -440,8 +440,8 @@ var documentsMain = {
 			this.loadRevViewerContainer();
 			// Load current revision
 			// TODO: add entry to versions
-			var fileId = documentsMain.fileId + '_' + 0;
-			var title = documentsMain.fileName + ' - ' + 0;
+			var fileId = documentsMain.fileId;
+			var title = documentsMain.fileName;
 			documentsMain.UI.showViewer(
 				fileId, title
 			);
@@ -464,8 +464,13 @@ var documentsMain = {
 
 		addCurrentVersion: function() {
 			var preview = OC.MimeType.getIconUrl(documentsMain.fileModel.get('mimetype'));
-			parent.$('#versionsTabView').prepend('<ul id="currentVersion"><li data-revision="0" class="active"><div><div class="preview-container"><img src="' + preview + '" width="44" /></div><div class="version-container">\n' +
+			parent.$('#versionsTabView').prepend('<ul id="lastSavedVersion"><li data-revision="0"><div><div class="preview-container"><img src="' + preview + '" width="44" /></div><div class="version-container">\n' +
+				'<div><a class="downloadVersion"><span class="versiondate has-tooltip live-relative-timestamp" data-timestamp="1551294326000"></span></div></div></li></ul>');
+			parent.$('#versionsTabView').prepend('<ul id="currentVersion"><li data-revision="" class="active"><div><div class="preview-container"><img src="' + preview + '" width="44" /></div><div class="version-container">\n' +
 				'<div><a class="downloadVersion">' + t('richdocuments', 'Current version') + '</a></div></div></li></ul>');
+			parent.$('.live-relative-timestamp').each(function() {
+				$(this).text(OC.Util.relativeModifiedDate(parseInt($(this).attr('data-timestamp'), 10)));
+			});
 		},
 
 		showVersionPreview: function (e) {
@@ -476,8 +481,12 @@ var documentsMain = {
 				element = e.currentTarget.parentElement.parentElement.parentElement.parentElement;
 			}
 			var version = element.dataset.revision;
-			var fileId = documentsMain.fileId + '_' + version;
-			var title = documentsMain.fileName + ' - ' + version;
+			var fileId = documentsMain.fileId;
+			var title = documentsMain.fileName;
+			if (version !== '') {
+				fileId += '_' + version;
+				title += '_' + version;
+			}
 			documentsMain.UI.showViewer(
 				fileId, title
 			);


### PR DESCRIPTION
The version sidebar doesn't contain an entry for the last saved version, so we add one for that as well. Fixed https://github.com/nextcloud/richdocuments/issues/373

- [x] Get timestamp from current version