### PR TITLE
Hide sidebar when closing the viewer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -159,8 +159,8 @@
 /* For close button image */
 #revViewerContainer .closeButton {
 	position: absolute;
-	right: 0;
-	top: 0;
+	right: 2px;
+	top: 5px;
 	width: 20px;
 	height: 24px;
 	z-index: 1;

--- a/js/documents.js
+++ b/js/documents.js
@@ -949,6 +949,7 @@ var documentsMain = {
 		documentsMain.UI.revisionsStart = 0;
 		parent.$('#versionsTabView .active').removeClass('active');
 		parent.$('#versionsTabView #currentVersion').remove();
+		parent.OC.Apps.hideAppSidebar();
 		$('#loleafletframe').focus();
 	},
 


### PR DESCRIPTION
Fixes https://github.com/nextcloud/richdocuments/issues/342

This PR closes the sidebar when closing the revision preview. However we don't close the viewer when closing the sidebar for now, since the sidebar is indipendent from the actual revision preview and can also be used for other actions like share/commenting, even if the revision view is open.