### PR TITLE
Scale frame to 100% height on mobile

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -10,4 +10,9 @@
 	#content {
 		padding-top: 0;
 	}
+
+	#richdocumentsframe {
+		height: 100vh;
+	}
+
 }


### PR DESCRIPTION
This fixes a height issue of the collabora frame on windows smaller then 768px, where we need to set the width property to 100% after 76e9c3b4