### PR TITLE
allow nextcloud in an iframe

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -19,7 +19,7 @@ $.widget('oc.documentGrid', {
 
 	_load : function(fileId) {
 		// Handle guest user case (let users which are able to write set their name)
-		if (!richdocuments_directEdit && window.top.oc_current_user == null && this._getGuestNameCookie() == ''
+		if (!richdocuments_directEdit && window.parent.oc_current_user == null && this._getGuestNameCookie() == ''
 				&& (richdocuments_permissions & OC.PERMISSION_UPDATE)) {
 			$('#documentslist').remove();
 


### PR DESCRIPTION
I had nextcloud in an iframe, so window.top was not returning the nextcloud contentWindow making oc_current_user unavailable. Using window.parent instead fixes the problem.

I don't think richdocuments is ever loaded where nextcloud isn't the parent, so my change shouldn't cause any problems.