### PR TITLE
Add option to disable certificate validation

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -27,10 +27,11 @@ var documentsSettings = {
 	},
 
 	save : function() {
-		$('#wopi_apply').attr('disabled', true);
+		$('#wopi_apply, #disable_certificate_verification').attr('disabled', true);
 		var data = {
-			wopi_url  : $('#wopi_url').val().replace(/\/$/, '')
-		};
+			wopi_url: $('#wopi_url').val().replace(/\/$/, ''),
+			disable_certificate_verification: document.getElementById('disable_certificate_verification').checked
+		}
 
 		OC.msg.startAction('#documents-admin-msg', t('richdocuments', 'Saving…'));
 		$.post(
@@ -55,7 +56,7 @@ var documentsSettings = {
 	},
 
 	afterSave : function(response){
-		$('#wopi_apply').attr('disabled', false);
+		$('#wopi_apply, #disable_certificate_verification').attr('disabled', false);
 		OC.msg.finishedAction('#documents-admin-msg', response);
 	},
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -69,6 +69,7 @@ class SettingsController extends Controller{
 	public function getSettings() {
 		return new JSONResponse([
 			'wopi_url' => $this->appConfig->getAppValue('wopi_url'),
+			'disable_certificate_verification' => $this->appConfig->getAppValue('disable_certificate_verification'),
 			'edit_groups' => $this->appConfig->getAppValue('edit_groups'),
 			'use_groups' => $this->appConfig->getAppValue('use_groups'),
 			'doc_format' => $this->appConfig->getAppValue('doc_format'),
@@ -77,6 +78,7 @@ class SettingsController extends Controller{
 
 	/**
 	 * @param string $wopi_url
+	 * @param string $disable_certificate_verification
 	 * @param string $edit_groups
 	 * @param string $use_groups
 	 * @param string $doc_format
@@ -85,6 +87,7 @@ class SettingsController extends Controller{
 	 * @return JSONResponse
 	 */
 	public function setSettings($wopi_url,
+	                            $disable_certificate_verification,
 	                            $edit_groups,
 	                            $use_groups,
 	                            $doc_format,
@@ -99,6 +102,13 @@ class SettingsController extends Controller{
 			if ($this->request->getServerProtocol() !== substr($wopi_url, 0, $colon)){
 				$message = $this->l10n->t('Saved with error: Collabora Online should use the same protocol as the server installation.');
 			}
+		}
+
+		if ($disable_certificate_verification !== null) {
+			$this->appConfig->setAppValue(
+				'disable_certificate_verification',
+				$disable_certificate_verification === 'true' ? 'yes' : ''
+			);
 		}
 
 		if ($edit_groups !== null){

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -67,13 +67,14 @@ class CapabilitiesService {
 		$capabilitiesEndpoint = $remoteHost . '/hosting/capabilities';
 
 		$client = $this->clientService->newClient();
+		$options = ['timeout' => 5];
+
+		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
+		}
+
 		try {
-			$response = $client->get(
-				$capabilitiesEndpoint,
-				[
-					'timeout' => 5,
-				]
-			);
+			$response = $client->get($capabilitiesEndpoint, $options);
 		} catch (\Exception $e) {
 			return [];
 		}

--- a/lib/WOPI/DiscoveryManager.php
+++ b/lib/WOPI/DiscoveryManager.php
@@ -28,7 +28,6 @@ use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\Notification\IApp;
 
 class DiscoveryManager {
 	/** @var IClientService */
@@ -80,11 +79,13 @@ class DiscoveryManager {
 		$wopiDiscovery = $remoteHost . '/hosting/discovery';
 
 		$client = $this->clientService->newClient();
-		try {
-			$response = $client->get($wopiDiscovery);
-		} catch (\Exception $e) {
-			throw $e;
+		$options = [];
+
+		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
 		}
+
+		$response = $client->get($wopiDiscovery, $options);
 
 		$responseBody = $response->getBody();
 		$file->putContent(

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -18,7 +18,7 @@ script('files', 'jquery.fileupload');
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width: 300px; display: block;">
 	<em><?php p($l->t('URL (and port) of the Collabora Online server that provides the editing functionality as a WOPI client.')) ?></em>
 	<br/>
-	<input type="checkbox" class="checkbox" id="disable_certificate_verification" <?php p($_['disable_certificate_verification'] !== '' ? 'checked' : '') ?> />
+	<input type="checkbox" class="checkbox" id="disable_certificate_verification" <?php p($_['disable_certificate_verification'] === 'yes' ? 'checked' : '') ?> />
 	<label for="disable_certificate_verification"><?php p($l->t('Disable certificate verification (insecure)')) ?></label>
 	<div>
 		<em><?php p($l->t('Enable if your Collabora Online server uses a self signed certificate')) ?></em>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -17,7 +17,13 @@ script('files', 'jquery.fileupload');
 	<label for="wopi_url"><?php p($l->t('Collabora Online server')) ?></label>
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width: 300px; display: block;">
 	<em><?php p($l->t('URL (and port) of the Collabora Online server that provides the editing functionality as a WOPI client.')) ?></em>
-	<br/><button type="button" id="wopi_apply"><?php p($l->t('Apply')) ?></button>
+	<br/>
+	<input type="checkbox" class="checkbox" id="disable_certificate_verification" <?php p($_['disable_certificate_verification'] !== '' ? 'checked' : '') ?> />
+	<label for="disable_certificate_verification"><?php p($l->t('Disable certificate verification (insecure)')) ?></label>
+	<div>
+		<em><?php p($l->t('Enable if your Collabora Online server uses a self signed certificate')) ?></em>
+	</div>
+	<button type="button" id="wopi_apply"><?php p($l->t('Apply')) ?></button>
 	<span id="documents-admin-msg" class="msg"></span>
 	<br/>
 	<br/>


### PR DESCRIPTION
* Resolves: #264
* Target version: master 

### Summary

![image](https://user-images.githubusercontent.com/3902676/53301532-49ea2200-3854-11e9-946f-40193e03981d.png)


Add option to disable certificate validation for internal nextcloud <-> collabora connections. Useful if you use self signed certificates or your collabora certificate is not trusted by your nextcloud server.

### TODO

- [ ] Test with Nextcloud 13 (don't have a running test setup)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
