### PR TITLE
Check via discovery if collabora server is available before opening

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -46,6 +46,7 @@ return [
 		['name' => 'settings#setPersonalSettings', 'url' => 'ajax/personal.php', 'verb' => 'POST'],
 		['name' => 'settings#setSettings', 'url' => 'ajax/admin.php', 'verb' => 'POST'],
 		['name' => 'settings#getSettings', 'url' => 'ajax/settings.php', 'verb' => 'GET'],
+		['name' => 'settings#checkSettings', 'url' => 'settings/check', 'verb' => 'GET'],
 
 		//Mobile access
 		['name' => 'directView#show', 'url' => '/direct/{token}', 'verb' => 'GET'],

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -130,7 +130,7 @@ var odfViewer = {
 		OC.addStyle('richdocuments', 'mobile');
 
 		var $iframe = $('<iframe id="richdocumentsframe" scrolling="no" allowfullscreen src="'+viewer+'" />');
-		$.get(viewer, function() {
+		$.get(OC.generateUrl('/apps/richdocuments/settings/check'), function() {
 			$iframe.src = viewer;
 		}) .fail(function() {
 			odfViewer.onClose();

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -14,6 +14,8 @@ namespace OCA\Richdocuments\Controller;
 use OCA\Richdocuments\Service\CapabilitiesService;
 use OCA\Richdocuments\WOPI\DiscoveryManager;
 use \OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use \OCP\IRequest;
 use \OCP\IL10N;
@@ -59,6 +61,24 @@ class SettingsController extends Controller{
 		$this->discoveryManager = $discoveryManager;
 		$this->userId = $userId;
 		$this->capabilitiesService = $capabilitiesService;
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 * @throws \Exception
+	 */
+	public function checkSettings() {
+		try {
+			$response = $this->discoveryManager->fetchFromRemote();
+		} catch (\Exception $e) {
+			return new DataResponse([
+				'status' => $e->getCode(),
+				'message' => $e->getMessage()
+			], $e->getCode());
+		}
+
+		return new DataResponse();
 	}
 
 	/**

--- a/lib/WOPI/DiscoveryManager.php
+++ b/lib/WOPI/DiscoveryManager.php
@@ -75,17 +75,7 @@ class DiscoveryManager {
 			$file = $this->appData->newFile('discovery.xml');
 		}
 
-		$remoteHost = $this->config->getAppValue('richdocuments', 'wopi_url');
-		$wopiDiscovery = $remoteHost . '/hosting/discovery';
-
-		$client = $this->clientService->newClient();
-		$options = [];
-
-		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
-			$options['verify'] = false;
-		}
-
-		$response = $client->get($wopiDiscovery, $options);
+		$response = $this->fetchFromRemote();
 
 		$responseBody = $response->getBody();
 		$file->putContent(
@@ -95,6 +85,28 @@ class DiscoveryManager {
 			])
 		);
 		return $responseBody;
+	}
+
+	/**
+	 * @return \OCP\Http\Client\IResponse
+	 * @throws \Exception
+	 */
+	public function fetchFromRemote() {
+		$remoteHost = $this->config->getAppValue('richdocuments', 'wopi_url');
+		$wopiDiscovery = $remoteHost . '/hosting/discovery';
+
+		$client = $this->clientService->newClient();
+		$options = ['timeout' => 5];
+
+		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
+		}
+
+		try {
+			return $client->get($wopiDiscovery, $options);
+		} catch (\Exception $e) {
+			throw $e;
+		}
 	}
 
 	public function refretch() {


### PR DESCRIPTION
Another attempt to fix #330 Unfortunately we cannot check the loading status of a iframe, so we actually need to call the collabora server before showing the document. 

The check is achieved by sending a request to the discovery endpoint, if that fails, we know that collabora isn't reachable, hide the viewer and show an error.