### PR TITLE
Fetch proper file info for files that are out of view after reload

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -872,7 +872,7 @@ var documentsMain = {
 		}
 
 		documentsMain.ready = true;
-		if (parent && documentsMain.getFileList() !== null) {
+		if (parent && documentsMain.getFileList() !== null && typeof documentsMain.getFileList() !== 'undefined') {
 			documentsMain.getFileList().reload();
 			parent.document.title = documentsMain.documentTitle + ' - ' + documentsMain.UI.mainTitle;
 		}

--- a/js/documents.js
+++ b/js/documents.js
@@ -929,7 +929,7 @@ var documentsMain = {
 
 	getFileModel: function() {
 		if (documentsMain.getFileList()) {
-			documentsMain.getFileList()._updateDetailsView(documentsMain.fileName, false);
+			documentsMain.getFileList().scrollTo([documentsMain.fileName, '']);
 			var fileModel = documentsMain.getFileList().getModelForFile(documentsMain.fileName);
 			if (fileModel) {
 				documentsMain.fileModel = fileModel;


### PR DESCRIPTION
Reloading the file list will cause the file model to be missing, therefore we need to call scrollTo to load the full file list and have it accessible.