### PR TITLE
Check if we are in direct editing mode

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -169,6 +169,9 @@ var documentsMain = {
 	},
 
 	getFileList: function() {
+		if (window === parent) {
+			return null;
+		}
 		if (parent.OCA.Files.App) {
 			return parent.OCA.Files.App.fileList;
 		}

--- a/js/documents.js
+++ b/js/documents.js
@@ -1011,17 +1011,13 @@ var documentsMain = {
 
 $(document).ready(function() {
 
-	if (!OCA.Files) {
-		OCA.Files = {};
-		OCA.Files.App = {};
-		OCA.Files.App.fileList = FileList;
+	if (!OCA.RichDocuments) {
+		OCA.RichDocuments = {};
 	}
 
 	if (!OC.Share) {
 		OC.Share = {};
 	}
-
-	window.Files = FileList;
 
 	OCA.RichDocuments.documentsMain = documentsMain;
 
@@ -1033,9 +1029,3 @@ $(document).ready(function() {
 
 	documentsMain.onStartup();
 });
-
-(function() {
-	if (!OCA.RichDocuments) {
-		OCA.RichDocuments = {};
-	}
-})();


### PR DESCRIPTION
Fixes mobile editing (again :see_no_evil:) 

@rullzer I will look into getting some e2e tests done for this, since all the interaction between the richdocuments frame and the parent nextcloud frame are petty error prone.