### PR TITLE
Only try to generate previews if convert-to is available

### DIFF
--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -22,6 +22,7 @@
 namespace OCA\Richdocuments\Preview;
 
 use OC\Preview\Provider;
+use OCA\Richdocuments\Capabilities;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 
@@ -33,13 +34,24 @@ abstract class Office extends Provider {
 	/** @var IConfig */
 	private $config;
 
-	public function __construct(IClientService $clientService, IConfig $config) {
+	/** @var array */
+	private $capabilitites;
+
+	public function __construct(IClientService $clientService, IConfig $config, Capabilities $capabilities) {
 		$this->clientService = $clientService;
 		$this->config = $config;
+		$this->capabilitites = $capabilities->getCapabilities()['richdocuments'];
 	}
 
 	private function getWopiURL() {
 		return $this->config->getAppValue('richdocuments', 'wopi_url');
+	}
+
+	public function isAvailable(\OCP\Files\FileInfo $file) {
+		if (isset($this->capabilitites['collabora']['convert-to'])) {
+			return $this->capabilitites['collabora']['convert-to'];
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/nextcloud/richdocuments/issues/421

We should only try to generate previews if convert-to is true on the collabora capabilities.