### PR TITLE
Use error instead of exception template

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -133,17 +133,9 @@ class DocumentController extends Controller {
 				} catch (\Exception $e) {
 					$this->logger->logException($e, ['app'=>'richdocuments']);
 					$params = [
-						'remoteAddr' => $this->request->getRemoteAddress(),
-						'requestID' => $this->request->getId(),
-						'debugMode' => $this->settings->getSystemValue('debug'),
-						'errorClass' => get_class($e),
-						'errorCode' => $e->getCode(),
-						'errorMsg' => $e->getMessage(),
-						'file' => $e->getFile(),
-						'line' => $e->getLine(),
-						'trace' => $e->getTraceAsString()
+						'errors' => [['error' => $e->getMessage()]]
 					];
-					return new TemplateResponse('core', 'exception', $params, 'guest');
+					return new TemplateResponse('core', 'error', $params, 'guest');
 				}
 			}
 
@@ -213,17 +205,9 @@ class DocumentController extends Controller {
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app'=>'richdocuments']);
 			$params = [
-				'remoteAddr' => $this->request->getRemoteAddress(),
-				'requestID' => $this->request->getId(),
-				'debugMode' => $this->settings->getSystemValue('debug'),
-				'errorClass' => get_class($e),
-				'errorCode' => $e->getCode(),
-				'errorMsg' => $e->getMessage(),
-				'file' => $e->getFile(),
-				'line' => $e->getLine(),
-				'trace' => $e->getTraceAsString()
+				'errors' => [['error' => $e->getMessage()]]
 			];
-			return new TemplateResponse('core', 'exception', $params, 'guest');
+			return new TemplateResponse('core', 'error', $params, 'guest');
 		}
 
 		return new TemplateResponse('core', '403', [], 'guest');
@@ -326,17 +310,9 @@ class DocumentController extends Controller {
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app'=>'richdocuments']);
 			$params = [
-				'remoteAddr' => $this->request->getRemoteAddress(),
-				'requestID' => $this->request->getId(),
-				'debugMode' => $this->settings->getSystemValue('debug'),
-				'errorClass' => get_class($e),
-				'errorCode' => $e->getCode(),
-				'errorMsg' => $e->getMessage(),
-				'file' => $e->getFile(),
-				'line' => $e->getLine(),
-				'trace' => $e->getTraceAsString()
+				'errors' => [['error' => $e->getMessage()]]
 			];
-			return new TemplateResponse('core', 'exception', $params, 'guest');
+			return new TemplateResponse('core', 'error', $params, 'guest');
 		}
 
 		return new TemplateResponse('core', '403', [], 'guest');


### PR DESCRIPTION
* Resolves: #264 
* Target version: master 

### Summary

Don't log `Cannot declare class GuzzleHttp\Handler\CurlFactory` anymore. 

#### How to reproduce:

1. Set ip:port for collabora to something unreachable
2. Try to open a document
3. See `Cannot declare class GuzzleHttp\Handler\CurlFactory` in nextcloud.log.

#### Why is this happening?

https://github.com/nextcloud/server/issues/14330#issuecomment-476339722 for more details.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
