### PR TITLE
Use valid HTTP status codes

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -75,7 +75,7 @@ class SettingsController extends Controller{
 			return new DataResponse([
 				'status' => $e->getCode(),
 				'message' => $e->getMessage()
-			], $e->getCode());
+			], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 
 		return new DataResponse();


### PR DESCRIPTION
Else if the error code is not set it is 0 which is not at all a valid
status code.
