### PR TITLE
Prevent editor iframe from being scrolled away from

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -13,6 +13,7 @@
 
 	#richdocumentsframe {
 		height: 100vh;
+		position: fixed;
 	}
 
 }


### PR DESCRIPTION
* Should fix https://github.com/nextcloud/richdocuments/issues/476
* Target version: master 

### Summary

Adding `position: fixed` to the whole iframe will keep it in the viewport, even if the whole webpage is scrolled (e.g. with cursor keys from a on-screen keyboard)

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
