### PR TITLE
dont rely on OC.addStyles.loaded to remove css

### DIFF
--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -145,7 +145,7 @@ var odfViewer = {
 			FileList.setViewerMode(false);
 			FileList.reload();
 		}
-		$('link[href="' + OC.addStyle.loaded.pop() + '"]').remove();
+		$('link[href*="richdocuments/css/mobile"]').remove();
 		$('#app-content #controls').removeClass('hidden');
 		$('#richdocumentsframe').remove();
 		$('#app-navigation').removeClass('hidden');


### PR DESCRIPTION
this is removed with nc17 and causes a white screen when closing the editor

Signed-off-by: Robin Appelman <robin@icewind.nl>
