### PR TITLE
Fix preview generation on object storage

### DIFF
--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -58,7 +58,18 @@ abstract class Office extends Provider {
 	 * {@inheritDoc}
 	 */
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
-		$stream = $fileview->fopen($path, 'r');
+		$fileInfo = $fileview->getFileInfo($path);
+		if (!$fileInfo) {
+			return false;
+		}
+
+		$useTempFile = $fileInfo->isEncrypted() || !$fileInfo->getStorage()->isLocal();
+		if ($useTempFile) {
+			$fileName = $fileview->toTmpFile($path);
+			$stream = fopen($fileName, 'r');
+		} else {
+			$stream = $fileview->fopen($path, 'r');
+		}
 
 		$client = $this->clientService->newClient();
 		$options = ['timeout' => 10];

--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -59,7 +59,7 @@ abstract class Office extends Provider {
 	 */
 	public function getThumbnail($path, $maxX, $maxY, $scalingup, $fileview) {
 		$fileInfo = $fileview->getFileInfo($path);
-		if (!$fileInfo) {
+		if (!$fileInfo || $fileInfo->getSize() === 0) {
 			return false;
 		}
 


### PR DESCRIPTION
- Don't generate preview for empty files
- Copy file to temp file for encrypted / object storage