### PR TITLE
Start with new template creation mechanism

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -76,6 +76,12 @@
 				<length>4</length>
 			</field>
 			<field>
+				<name>template_id</name>
+				<type>integer</type>
+				<notnull>false</notnull>
+				<length>4</length>
+			</field>
+			<field>
 				<name>hide_download</name>
 				<type>boolean</type>
 				<default>false</default>
@@ -159,7 +165,12 @@
 				<notnull>false</notnull>
 				<length>4</length>
 			</field>
-
+			<field>
+				<name>template_id</name>
+				<type>integer</type>
+				<notnull>false</notnull>
+				<length>4</length>
+			</field>
 			<index>
 				<name>rd_direct_token_idx</name>
 				<unique>true</unique>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Collabora Online</name>
 	<summary>Edit office documents directly in your browser.</summary>
 	<description>This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.</description>
-	<version>3.4.6</version>
+	<version>3.4.7</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -44,6 +44,7 @@ return [
 		['name' => 'wopi#getFile', 'url' => 'wopi/files/{fileId}/contents', 'verb' => 'GET'],
 		['name' => 'wopi#putFile', 'url' => 'wopi/files/{fileId}/contents', 'verb' => 'POST'],
 		['name' => 'wopi#putRelativeFile', 'url' => 'wopi/files/{fileId}', 'verb' => 'POST'],
+		['name' => 'wopi#getTemplate', 'url' => 'wopi/template/{fileId}', 'verb' => 'GET'],
 
 		//settings
 		['name' => 'settings#setPersonalSettings', 'url' => 'ajax/personal.php', 'verb' => 'POST'],

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -105,13 +105,14 @@ class Capabilities implements ICapability {
 				'mimetypesNoDefaultOpen' => self::MIMETYPES_OPTIONAL,
 				'collabora' => $collaboraCapabilities,
 				'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) ? : false,
-				'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) ? : false,
+				'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ? : false,
 				'productName' => isset($collaboraCapabilities['productName']) ? $collaboraCapabilities['productName'] : $this->l10n->t('Collabora Online'),
 			],
 		];
 	}
 
 	/**
+	 * TODO: use CapabilitiesService
 	 * @return array
 	 * @throws \OCP\Files\NotPermittedException
 	 */

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -114,7 +114,8 @@ class DirectViewController extends Controller {
 			}
 
 			try {
-				list($urlSrc, $token) = $this->tokenManager->getTokenForTemplate($item, $direct->getUid(), $direct->getTemplateDestination(), true);
+
+				list($urlSrc, $wopi) = $this->tokenManager->getTokenForTemplate($item, $direct->getUid(), $direct->getTemplateDestination(), true);
 			} catch (\Exception $e) {
 				return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 			}
@@ -136,7 +137,7 @@ class DirectViewController extends Controller {
 					return $response;
 				}
 
-				list($urlSrc, $token) = $this->tokenManager->getToken($item->getId(), null, $direct->getUid(), true);
+				list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($item->getId(), null, $direct->getUid(), true);
 			} catch (\Exception $e) {
 				$params = [
 					'errors' => [['error' => $e->getMessage()]]
@@ -151,8 +152,8 @@ class DirectViewController extends Controller {
 			$params = [
 				'permissions' => $item->getPermissions(),
 				'title' => $item->getName(),
-				'fileId' => $item->getId() . '_' . $this->config->getSystemValue('instanceid'),
-				'token' => $token,
+				'fileId' => $wopi->getFileid() . '_' . $this->config->getSystemValue('instanceid'),
+				'token' => $wopi->getToken(),
 				'urlsrc' => $urlSrc,
 				'path' => $relativePath,
 				'instanceId' => $this->config->getSystemValue('instanceid'),

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -306,13 +306,16 @@ class DocumentController extends Controller {
 		$file = $folder->newFile($fileName);
 
 		$template = $this->templateManager->get($templateId);
-		list($urlSrc, $token) = $this->tokenManager->getTokenForTemplate($template, $this->uid, $file->getId());
+		list($urlSrc, $wopi) = $this->tokenManager->getTokenForTemplate($template, $this->uid, $file->getId());
+
+		$wopiFileId = $template->getId() . '-' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid');
+		$wopiFileId = $wopi->getFileid() . '_' . $this->settings->getSystemValue('instanceid');
 
 		$params = [
 			'permissions' => $template->getPermissions(),
 			'title' => $fileName,
-			'fileId' => $template->getId() . '-' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid'),
-			'token' => $token,
+			'fileId' => $wopiFileId,
+			'token' => $wopi->getToken(),
 			'urlsrc' => $urlSrc,
 			'path' => $userFolder->getRelativePath($file->getPath()),
 			'instanceId' => $this->settings->getSystemValue('instanceid'),

--- a/lib/Db/Direct.php
+++ b/lib/Db/Direct.php
@@ -36,6 +36,8 @@ use OCP\AppFramework\Db\Entity;
  * @method int getTimestamp()
  * @method void setTemplateDestination(int $fileId)
  * @method int getTemplateDestination()
+ * @method void setTemplateId(int $fileId)
+ * @method int getTemplateId()
  */
 class Direct extends Entity {
 	/** @var string */
@@ -53,11 +55,15 @@ class Direct extends Entity {
 	/** @var int */
 	protected $templateDestination;
 
+	/** @var int */
+	protected $templateId;
+
 	public function __construct() {
 		$this->addType('token', 'string');
 		$this->addType('uid', 'string');
 		$this->addType('fileid', 'int');
 		$this->addType('timestamp', 'int');
 		$this->addType('template_destination', 'int');
+		$this->addType('template_id', 'int');
 	}
 }

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -49,6 +49,8 @@ use OCP\AppFramework\Db\Entity;
  * @method string getGuestDisplayname()
  * @method void setTemplateDestination(int $fileId)
  * @method int getTemplateDestination()
+ * @method void setTemplateId(int $fileId)
+ * @method int getTemplateId()
  */
 class Wopi extends Entity {
 	/** @var string */
@@ -81,6 +83,9 @@ class Wopi extends Entity {
 	/** @var int */
 	protected $templateDestination;
 
+	/** @var int */
+	protected $templateId;
+
 	/** @var bool */
 	protected $hideDownload;
 
@@ -107,6 +112,7 @@ class Wopi extends Entity {
 		$this->addType('expiry', 'int');
 		$this->addType('guest_displayname', 'string');
 		$this->addType('templateDestination', 'int');
+		$this->addType('templateId', 'int');
 		$this->addType('hide_download', 'bool');
 		$this->addType('direct', 'bool');
 
@@ -114,6 +120,10 @@ class Wopi extends Entity {
 
 	public function isTemplateToken() {
 		return $this->getTemplateDestination() !== 0 && $this->getTemplateDestination() !== null;
+	}
+
+	public function hasTemplateId() {
+		return $this->getTemplateId() !== 0 && $this->getTemplateId() !== null;
 	}
 
 }

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -64,7 +64,7 @@ class WopiMapper extends Mapper {
 	 * @param int $templateDestination
 	 * @return Wopi
 	 */
-	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false, $isRemoteToken = false) {
+	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false, $isRemoteToken = false, $templateId = 0) {
 		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
 
 		$wopi = Wopi::fromParams([
@@ -80,7 +80,8 @@ class WopiMapper extends Mapper {
 			'templateDestination' => $templateDestination,
 			'hideDownload' => $hideDownload,
 			'direct' => $direct,
-			'isRemoteToken' => $isRemoteToken
+			'isRemoteToken' => $isRemoteToken,
+			'templateId' => $templateId,
 		]);
 
 		/** @var Wopi $wopi */

--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -21,6 +21,8 @@
  */
 namespace OCA\Richdocuments\Preview;
 
+use GuzzleHttp\Psr7\LimitStream;
+use function GuzzleHttp\Psr7\stream_for;
 use OC\Preview\Provider;
 use OCA\Richdocuments\Capabilities;
 use OCP\Http\Client\IClientService;

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -38,6 +38,8 @@ class CapabilitiesService {
 	private $clientService;
 	/** @var ISimpleFolder */
 	private $appData;
+	/** @var array */
+	private $capabilities;
 
 	public function __construct(IConfig $config, IClientService $clientService, IAppData $appData) {
 		$this->config = $config;
@@ -47,6 +49,34 @@ class CapabilitiesService {
 		} catch (NotFoundException $e) {
 			$this->appData = $appData->newFolder('richdocuments');
 		}
+	}
+
+
+	public function getCapabilities() {
+		if ($this->capabilities) {
+			return $this->capabilities;
+		}
+		try {
+			$file = $this->appData->getFile('capabilities.json');
+			$decodedFile = \json_decode($file->getContent(), true);
+		} catch (NotFoundException $e) {
+			return [];
+		}
+
+		if (!is_array($decodedFile)) {
+			return [];
+		}
+		$this->capabilities = $decodedFile;
+
+		return $this->capabilities;
+	}
+
+	public function hasTemplateSaveAs() {
+		return $this->getCapabilities()['hasTemplateSaveAs'] ?? false;
+	}
+
+	public function hasTemplateSource() {
+		return $this->getCapabilities()['hasTemplateSource'] ?? false;
 	}
 
 	private function getFile() {
@@ -103,4 +133,5 @@ class CapabilitiesService {
 
 		return $ret;
 	}
+
 }


### PR DESCRIPTION
This pull request implements a new template creation mechanism, that will hand over an URL in the TemplateSource entry of CheckFileInfo. If present the file will be downloaded by Collabora during the document creation.

- [X] WOPI endpoint to fetch the template file
- [X] Check for hasTemplateSource capability
- [x] Provide TemplateSource in CheckFileInfo
- [x] Create token with TemplateSource when creating new documents from the web UI
- [x] Create token with TemplateSource when creating new documents from the direct editing API