### PR TITLE
Allow clients to send a Grab_Focus post message

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -1036,6 +1036,10 @@ var documentsMain = {
 			url: url
 		});
 	},
+
+	postGrabFocus: function() {
+		documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Grab_Focus');
+	}
 };
 
 $(document).ready(function() {


### PR DESCRIPTION
Waiting for client implementation to test with:
- [ ] iOS
- [x] Android

@marinofaggiana @tobiasKaminsky Since this might not be available on older richdocuments versions, the integration should call something like this:

```
webview.evaluateJavascript(
  "if (typeof OCA.RichDocuments.documentsMain.postGrabFocus !== 'undefined') {" + 
  "    OCA.RichDocuments.documentsMain.postGrabFocus();" + 
  "}"
);
```