### PR TITLE
Pass rename message to mobile apps

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -915,7 +915,7 @@ var documentsMain = {
 		}
 		// Forward to mobile handler
 		if (window.RichDocumentsMobileInterface && typeof window.RichDocumentsMobileInterface[messageName] !== 'undefined') {
-			window.RichDocumentsMobileInterface[messageName](message);
+			window.RichDocumentsMobileInterface[messageName](attributes);
 		}
 
 		// iOS webkit fallback

--- a/js/documents.js
+++ b/js/documents.js
@@ -626,17 +626,7 @@ var documentsMain = {
 							documentsMain.wopiClientFeatures = msg.Values.Features;
 							documentsMain.overlay.documentOverlay('hide');
 
-							// Forward to mobile handler
-							if (window.RichDocumentsMobileInterface) {
-								window.RichDocumentsMobileInterface.documentLoaded();
-							}
-
-							// iOS webkit fallback
-							if (window.webkit
-								&& window.webkit.messageHandlers
-								&& window.webkit.messageHandlers.RichDocumentsMobileInterface) {
-								window.webkit.messageHandlers.RichDocumentsMobileInterface.postMessage('documentLoaded');
-							}
+							documentsMain.callMobileMessage('documentLoaded');
 						} else if (msg.Values.Status === "Document_Loaded" ) {
 							window.removeEventListener('message', editorInitListener, false);
 							if (documentsMain.getFileList()) {
@@ -735,6 +725,7 @@ var documentsMain = {
 						documentsMain.fileName = args.NewName;
 						documentsMain.getFileList().reload();
 						parent.OC.Apps.hideAppSidebar();
+						documentsMain.callMobileMessage('fileRename', args);
 					} else if (msgId === 'UI_SaveAs') {
 						// TODO Move to file picker dialog with input field
 						OC.dialogs.prompt(
@@ -911,6 +902,27 @@ var documentsMain = {
 			};
 
 			iframe.contentWindow.postMessage(JSON.stringify(msg), '*');
+		}
+	},
+
+	callMobileMessage: function(messageName, attributes) {
+		var message = messageName;
+		if (typeof attributes !== 'undefined') {
+			message = {
+				MessageName: messageName,
+				Values: attributes
+			}
+		}
+		// Forward to mobile handler
+		if (window.RichDocumentsMobileInterface && typeof window.RichDocumentsMobileInterface[messageName] !== 'undefined') {
+			window.RichDocumentsMobileInterface[messageName](message);
+		}
+
+		// iOS webkit fallback
+		if (window.webkit
+			&& window.webkit.messageHandlers
+			&& window.webkit.messageHandlers.RichDocumentsMobileInterface) {
+			window.webkit.messageHandlers.RichDocumentsMobileInterface.postMessage(message);
 		}
 	},
 


### PR DESCRIPTION
Follow up to #524 

This PR adds calling a `fileRename` method on the RichDocumentsMobileInterface so clients can react on file name changes.

The new file name is passed as an argument in the format: 
```
{
	"NewName": "newfile.odt",
}
```

cc @marinofaggiana @tobiasKaminsky 