### PR TITLE
Add DownloadAsPostMessage

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -81,6 +81,12 @@
 				<default>false</default>
 				<notnull>true</notnull>
 			</field>
+			<field>
+				<name>direct</name>
+				<type>boolean</type>
+				<default>false</default>
+				<notnull>true</notnull>
+			</field>
 
 			<index>
 				<name>rd_wopi_token_idx</name>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Collabora Online</name>
 	<summary>Edit office documents directly in your browser.</summary>
 	<description>This application can connect to a Collabora Online server (WOPI Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.</description>
-	<version>3.3.9</version>
+	<version>3.3.9-1</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/js/documents.js
+++ b/js/documents.js
@@ -692,6 +692,19 @@ var documentsMain = {
 							documentsMain.callMobileMessage('downloadAs', args);
 							return;
 						}
+					} else if (msgId === 'File_Rename') {
+						documentsMain.fileModel = null;
+						documentsMain.fileName = args.NewName;
+						if (
+							window.RichDocumentsMobileInterface ||
+							(window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.RichDocumentsMobileInterface)
+						) {
+							documentsMain.callMobileMessage('fileRename', args);
+						} else {
+							documentsMain.getFileList().reload();
+							parent.OC.Apps.hideAppSidebar();
+						}
+						return;
 					}
 
 					// Check for webview handler
@@ -743,12 +756,6 @@ var documentsMain = {
 							documentsMain.getFileList().showDetailsView(documentsMain.fileName, 'shareTabView');
 							parent.OC.Apps.showAppSidebar();
 						}
-					} else if (msgId === 'File_Rename') {
-						documentsMain.fileModel = null;
-						documentsMain.fileName = args.NewName;
-						documentsMain.getFileList().reload();
-						parent.OC.Apps.hideAppSidebar();
-						documentsMain.callMobileMessage('fileRename', args);
 					} else if (msgId === 'UI_SaveAs') {
 						// TODO Move to file picker dialog with input field
 						OC.dialogs.prompt(
@@ -938,7 +945,7 @@ var documentsMain = {
 		}
 		// Forward to mobile handler
 		if (window.RichDocumentsMobileInterface && typeof window.RichDocumentsMobileInterface[messageName] === 'function') {
-			window.RichDocumentsMobileInterface[messageName](attributes);
+			window.RichDocumentsMobileInterface[messageName](JSON.stringify(attributes));
 		}
 
 		// iOS webkit fallback

--- a/js/documents.js
+++ b/js/documents.js
@@ -683,6 +683,17 @@ var documentsMain = {
 						msgId = e.data;
 					}
 
+					if (msgId === 'Download_As') {
+						console.log('download for ' + args.Type + '.  Use this url: ' + args.URL);
+						if (
+							window.RichDocumentsMobileInterface ||
+							(window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.RichDocumentsMobileInterface)
+						) {
+							documentsMain.callMobileMessage('downloadAs', args);
+							return;
+						}
+					}
+
 					// Check for webview handler
 					if (window.RichDocumentsMobileInterface) {
 						if (msgId === 'UI_Close') {
@@ -926,7 +937,7 @@ var documentsMain = {
 			}
 		}
 		// Forward to mobile handler
-		if (window.RichDocumentsMobileInterface && typeof window.RichDocumentsMobileInterface[messageName] !== 'undefined') {
+		if (window.RichDocumentsMobileInterface && typeof window.RichDocumentsMobileInterface[messageName] === 'function') {
 			window.RichDocumentsMobileInterface[messageName](attributes);
 		}
 

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -100,7 +100,7 @@ class DirectViewController extends Controller {
 			}
 
 			try {
-				list($urlSrc, $token) = $this->tokenManager->getTokenForTemplate($item, $direct->getUid(), $direct->getTemplateDestination());
+				list($urlSrc, $token) = $this->tokenManager->getTokenForTemplate($item, $direct->getUid(), $direct->getTemplateDestination(), true);
 			} catch (\Exception $e) {
 				return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 			}
@@ -114,7 +114,7 @@ class DirectViewController extends Controller {
 					throw new \Exception();
 				}
 
-				list($urlSrc, $token) = $this->tokenManager->getToken($item->getId(), null, $direct->getUid());
+				list($urlSrc, $token) = $this->tokenManager->getToken($item->getId(), null, $direct->getUid(), true);
 			} catch (\Exception $e) {
 				return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 			}

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -164,7 +164,8 @@ class WopiController extends Controller {
 			'DisableExport' => $wopi->getHideDownload(),
 			'DisableCopy' => $wopi->getHideDownload(),
 			'HideExportOption' => $wopi->getHideDownload(),
-			'HidePrintOption' => $wopi->getHideDownload()
+			'HidePrintOption' => $wopi->getHideDownload(),
+			'DownloadAsPostMessage' => $wopi->getDirect(),
 		];
 
 		if ($wopi->isTemplateToken()) {

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -84,6 +84,9 @@ class Wopi extends Entity {
 	/** @var bool */
 	protected $hideDownload;
 
+	/** @var bool */
+	protected $direct;
+
 	public function __construct() {
 		$this->addType('owner_uid', 'string');
 		$this->addType('editor_uid', 'string');
@@ -96,6 +99,8 @@ class Wopi extends Entity {
 		$this->addType('guest_displayname', 'string');
 		$this->addType('templateDestination', 'int');
 		$this->addType('hide_download', 'bool');
+		$this->addType('direct', 'bool');
+
 	}
 
 	public function isTemplateToken() {

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -64,7 +64,7 @@ class WopiMapper extends Mapper {
 	 * @param int $templateDestination
 	 * @return Wopi
 	 */
-	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false) {
+	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false) {
 		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
 
 		$wopi = Wopi::fromParams([
@@ -78,7 +78,8 @@ class WopiMapper extends Mapper {
 			'expiry' => $this->timeFactory->getTime() + self::TOKEN_LIFETIME_SECONDS,
 			'guestDisplayname' => $guestDisplayname,
 			'templateDestination' => $templateDestination,
-			'hideDownload' => $hideDownload
+			'hideDownload' => $hideDownload,
+			'direct' => $direct
 		]);
 
 		/** @var Wopi $wopi */

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -95,7 +95,7 @@ class TokenManager {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function getToken($fileId, $shareToken = null, $editoruid = null) {
+	public function getToken($fileId, $shareToken = null, $editoruid = null, $direct = false) {
 		list($fileId,, $version) = Helper::parseFileId($fileId);
 		$owneruid = null;
 		$hideDownload = false;
@@ -169,7 +169,7 @@ class TokenManager {
 			$guest_name = NULL;
 		}
 
-		$wopi = $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, (int)$updatable, $serverHost, $guest_name, 0, $hideDownload);
+		$wopi = $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, (int)$updatable, $serverHost, $guest_name, 0, $hideDownload, $direct);
 
 		try {
 
@@ -182,7 +182,7 @@ class TokenManager {
 		}
 	}
 
-	public function getTokenForTemplate(File $file, $userId, $templateDestination) {
+	public function getTokenForTemplate(File $file, $userId, $templateDestination, $direct = false) {
 		$owneruid = $userId;
 		$editoruid = $userId;
 		$updatable = $file->isUpdateable();
@@ -205,7 +205,7 @@ class TokenManager {
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
-		$wopi = $this->wopiMapper->generateFileToken($file->getId(), $owneruid, $editoruid, 0, (int)$updatable, $serverHost, null, $templateDestination);
+		$wopi = $this->wopiMapper->generateFileToken($file->getId(), $owneruid, $editoruid, 0, (int)$updatable, $serverHost, null, $templateDestination, $direct);
 
 		return [
 			$this->wopiParser->getUrlSrc($file->getMimeType())['urlsrc'],


### PR DESCRIPTION
This implements a `downloadAs` method that is called on the RichDocumentsMobileInterface in the mobile clients when issuing a download/print action. The clients can use the one-time url to handle the actions then.

The arguments are the following:
```
{ Type: 'print', URL: 'https://....' }
{ Type: 'download', URL: 'https://....' }
```

@tobiasKaminsky @marinofaggiana 