### PR TITLE
Federated document editing

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -22,10 +22,7 @@
 
 namespace OCA\Richdocuments\AppInfo;
 
-use OC\Security\CSP\ContentSecurityPolicy;
-use OCA\Federation\TrustedServers;
 use OCA\Richdocuments\PermissionManager;
-use OCA\Richdocuments\Service\FederationService;
 
 $currentUser = \OC::$server->getUserSession()->getUser();
 if($currentUser !== null) {
@@ -64,51 +61,6 @@ if (class_exists('\OC\Files\Type\TemplateManager')) {
 
 }
 
-// Whitelist the public wopi URL for iframes, required for Firefox
-$publicWopiUrl = \OC::$server->getConfig()->getAppValue('richdocuments', 'public_wopi_url', '');
-$publicWopiUrl = $publicWopiUrl === '' ? \OC::$server->getConfig()->getAppValue('richdocuments', 'wopi_url') : $publicWopiUrl;
-if ($publicWopiUrl !== '') {
-	$manager = \OC::$server->getContentSecurityPolicyManager();
-	$policy = new ContentSecurityPolicy();
-	$policy->addAllowedFrameDomain($publicWopiUrl);
-	if (method_exists($policy, 'addAllowedFormActionDomain')) {
-		$policy->addAllowedFormActionDomain($publicWopiUrl);
-	}
-	// TODO: remove this once figured out how to allow redirects with a frame-src nonce
-	$policy->addAllowedFrameDomain('https://nextcloud2.local.dev.bitgrid.net');
-	$manager->addDefaultPolicy($policy);
-}
-
-$path = '';
-try {
-	$path = \OC::$server->getRequest()->getPathInfo();
-} catch (\Exception $e) {}
-if ($path === '/apps/files/') {
-	/** @var FederationService $federationService */
-	$federationService = \OC::$server->query(FederationService::class);
-	$remoteAccess = \OC::$server->getRequest()->getParam('richdocuments_remote_access');
-	/** @var TrustedServers $trustedServers */
-	$trustedServers = \OC::$server->query(TrustedServers::class);
-
-	/*
-	 * if ($remoteAccess && $trustedServers->isTrustedServer($remoteAccess)) {
-		$remoteCollabora = $federationService->getRemoteCollaboraURL($remoteAccess);
-		$policy->addAllowedFrameDomain($remoteAccess);
-		$policy->addAllowedFrameDomain($remoteCollabora);
-	}
-
-	// TODO remove as this doesn't scale
-	// better try to reload with csp set
-	foreach ($trustedServers->getServers() as $server) {
-		$remoteCollabora = $federationService->getRemoteCollaboraURL($server['url']);
-		if ($remoteCollabora !== '') {
-			$policy->addAllowedFrameDomain($server['url']);
-			$policy->addAllowedFrameDomain($remoteCollabora);
-		}
-	}
-	$manager->addDefaultPolicy($policy);
-	*/
-}
-
 $app = new Application();
 $app->registerProvider();
+$app->updateCSP();

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -87,6 +87,25 @@
 				<default>false</default>
 				<notnull>true</notnull>
 			</field>
+			<field>
+				<name>is_remote_token</name>
+				<type>boolean</type>
+				<default>false</default>
+				<notnull>true</notnull>
+			</field>
+			<field>
+				<name>remote_server</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+			</field>
+			<field>
+				<name>remote_server_token</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>32</length>
+			</field>
 
 			<index>
 				<name>rd_wopi_token_idx</name>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -29,6 +29,7 @@ return [
 	'routes' => [
 		//documents
 		['name' => 'document#index', 'url' => 'index', 'verb' => 'GET'],
+		['name' => 'document#remote', 'url' => 'remote', 'verb' => 'GET'],
 		['name' => 'document#template', 'url' => 'indexTemplate', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
 		['name' => 'document#create', 'url' => 'ajax/documents/create', 'verb' => 'POST'],
@@ -54,7 +55,7 @@ return [
 		//assets
 		['name' => 'assets#create', 'url' => 'assets', 'verb' => 'POST'],
 		['name' => 'assets#get', 'url' => 'assets/{token}', 'verb' => 'GET'],
-		
+
 		// templates
 		['name' => 'templates#getPreview', 'url' => '/template/preview/{fileId}', 'verb' => 'GET'],
 		['name' => 'templates#add', 'url' => '/template', 'verb' => 'POST'],
@@ -63,6 +64,11 @@ return [
 	'ocs' => [
 		['name' => 'OCS#create', 'url' => '/api/v1/document', 'verb' => 'POST'],
 		['name' => 'OCS#getTemplates', 'url' => '/api/v1/templates/{type}', 'verb' => 'GET'],
-		['name' => 'OCS#createFromTemplate', 'url' => '/api/v1/templates/new', 'verb' => 'POST']
+		['name' => 'OCS#createFromTemplate', 'url' => '/api/v1/templates/new', 'verb' => 'POST'],
+
+		['name' => 'Federation#index', 'url' => '/api/v1/federation', 'verb' => 'GET'],
+		['name' => 'Federation#remoteWopiToken', 'url' => '/api/v1/federation', 'verb' => 'POST'],
+		['name' => 'Federation#remoteDirectToken', 'url' => '/api/v1/federation/direct', 'verb' => 'POST'],
+
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -30,6 +30,8 @@ return [
 		//documents
 		['name' => 'document#index', 'url' => 'index', 'verb' => 'GET'],
 		['name' => 'document#remote', 'url' => 'remote', 'verb' => 'GET'],
+		['name' => 'document#open', 'url' => 'open', 'verb' => 'GET'],
+
 		['name' => 'document#template', 'url' => 'indexTemplate', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
 		['name' => 'document#create', 'url' => 'ajax/documents/create', 'verb' => 'POST'],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -85,7 +85,7 @@ class Application extends App {
 
 	}
 
-	public function updateCSP() {
+	public function updateCSP(): void {
 		$container = $this->getContainer();
 
 		$publicWopiUrl = $container->getServer()->getConfig()->getAppValue('richdocuments', 'public_wopi_url', '');
@@ -111,7 +111,7 @@ class Application extends App {
 			$trustedServers = $container->query(TrustedServers::class);
 			/** @var FederationService $federationService */
 			$federationService = $container->query(FederationService::class);
-			$remoteAccess = \OC::$server->getRequest()->getParam('richdocuments_remote_access');
+			$remoteAccess = $container->getServer()->getRequest()->getParam('richdocuments_remote_access');
 
 			if ($remoteAccess && $trustedServers->isTrustedServer($remoteAccess)) {
 				$remoteCollabora = $federationService->getRemoteCollaboraURL($remoteAccess);

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -95,7 +95,7 @@ class DirectViewController extends Controller {
 		}
 
 		// Delete the token. They are for 1 time use only
-		//$this->directMapper->delete($direct);
+		$this->directMapper->delete($direct);
 
 		$folder = $this->rootFolder->getUserFolder($direct->getUid());
 		if ($this->templateManager->isTemplate($direct->getFileid())) {

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -435,7 +435,7 @@ class DocumentController extends Controller {
 				$remoteWopi = $this->federationService->getRemoteFileDetails($remoteServer, $remoteServerToken);
 
 				$uid = $remoteWopi['editorUid'] . '@' . $remoteServer;
-				$wopi->setEditorUid($remoteWopi['editorUid']);
+				$wopi->setEditorUid($shareToken);
 				$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi['canwrite']);
 				$wopi->setRemoteServer($remoteServer);
 				$wopi->setRemoteServerToken($remoteServerToken);

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -190,7 +190,8 @@ class DocumentController extends Controller {
 				$remote = $item->getStorage()->getRemote();
 				$remoteCollabora = $this->federationService->getRemoteCollaboraURL($remote);
 				if ($remoteCollabora !== '') {
-					$dir = $item->getInternalPath() === '' ? '/' : $item->getInternalPath();
+					$fullPath = explode('/', $item->getPath());
+					$dir = implode('/', array_slice($fullPath, 3, -1));
 					$url = '/index.php/apps/files?dir=' . $dir .
 						'&richdocuments_open=' . $item->getName() .
 						'&richdocuments_fileId=' . $fileId .

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -11,11 +11,15 @@
 
 namespace OCA\Richdocuments\Controller;
 
+use OCA\Richdocuments\Db\WopiMapper;
+use OCA\Richdocuments\Service\FederationService;
 use OCA\Richdocuments\TokenManager;
 use OCA\Richdocuments\WOPI\Parser;
 use \OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\Constants;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -54,9 +58,10 @@ class DocumentController extends Controller {
 	private $rootFolder;
 	/** @var \OCA\Richdocuments\TemplateManager */
 	private $templateManager;
+	/** @var FederationService */
+	private $federationService;
 
 	const ODT_TEMPLATE_PATH = '/assets/odttemplate.odt';
-
 
 	/**
 	 * @param string $appName
@@ -71,18 +76,21 @@ class DocumentController extends Controller {
 	 * @param string $UserId
 	 * @param ILogger $logger
 	 */
-	public function __construct($appName,
-								IRequest $request,
-								IConfig $settings,
-								AppConfig $appConfig,
-								IL10N $l10n,
-								IManager $shareManager,
-								TokenManager $tokenManager,
-								IRootFolder $rootFolder,
-								ISession $session,
-								$UserId,
-								ILogger $logger,
-								\OCA\Richdocuments\TemplateManager $templateManager) {
+	public function __construct(
+		$appName,
+		IRequest $request,
+		IConfig $settings,
+		AppConfig $appConfig,
+		IL10N $l10n,
+		IManager $shareManager,
+		TokenManager $tokenManager,
+		IRootFolder $rootFolder,
+		ISession $session,
+		$UserId,
+		ILogger $logger,
+		\OCA\Richdocuments\TemplateManager $templateManager,
+		FederationService $federationService
+	) {
 		parent::__construct($appName, $request);
 		$this->uid = $UserId;
 		$this->l10n = $l10n;
@@ -94,6 +102,7 @@ class DocumentController extends Controller {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->templateManager = $templateManager;
+		$this->federationService = $federationService;
 	}
 
 	/**
@@ -164,7 +173,7 @@ class DocumentController extends Controller {
 	 * @NoAdminRequired
 	 *
 	 * @param string $fileId
-	 * @return TemplateResponse
+	 * @return RedirectResponse|TemplateResponse
 	 */
 	public function index($fileId) {
 		try {
@@ -172,6 +181,25 @@ class DocumentController extends Controller {
 			$item = $folder->getById($fileId)[0];
 			if(!($item instanceof Node)) {
 				throw new \Exception();
+			}
+			/**
+			 * Open file from remote collabora
+			 */
+			if ($item->getStorage()->instanceOfStorage(\OCA\Files_Sharing\External\Storage::class)) {
+				$remote = $item->getStorage()->getRemote();
+				$remoteCollabora = $this->federationService->getRemoteCollaboraURL($remote);
+				if ($remoteCollabora !== '') {
+					$wopi = $this->tokenManager->getRemoteToken($item);
+					$url = $remote . 'index.php/apps/richdocuments/remote?shareToken=' . $item->getStorage()->getToken() .
+						'&remoteServer=' . $wopi->getServerHost() .
+						'&remoteServerToken=' . $wopi->getToken();
+					if ($item->getInternalPath() !== '') {
+						$url .= '&filePath=' . $item->getInternalPath();
+					}
+					$response = new RedirectResponse($url);
+					$response->addHeader('X-Frame-Options', 'ALLOW');
+					return $response;
+				}
 			}
 			list($urlSrc, $token) = $this->tokenManager->getToken($item->getId());
 			$params = [
@@ -217,10 +245,15 @@ class DocumentController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * Create a new file from a template
+	 *
 	 * @param int $templateId
 	 * @param string $fileName
 	 * @param string $dir
 	 * @return TemplateResponse
+	 * @throws NotFoundException
+	 * @throws NotPermittedException
+	 * @throws \OCP\Files\InvalidPathException
 	 */
 	public function template($templateId, $fileName, $dir) {
 		if (!$this->templateManager->isTemplate($templateId)) {
@@ -265,6 +298,7 @@ class DocumentController extends Controller {
 
 	/**
 	 * @PublicPage
+	 * @NoCSRFRequired
 	 *
 	 * @param string $shareToken
 	 * @param string $fileName
@@ -307,6 +341,88 @@ class DocumentController extends Controller {
 				$policy->addAllowedFrameDomain($this->domainOnly($this->appConfig->getAppValue('public_wopi_url')));
 				$policy->allowInlineScript(true);
 				$response->setContentSecurityPolicy($policy);
+				return $response;
+			}
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app'=>'richdocuments']);
+			$params = [
+				'errors' => [['error' => $e->getMessage()]]
+			];
+			return new TemplateResponse('core', 'error', $params, 'guest');
+		}
+
+		return new TemplateResponse('core', '403', [], 'guest');
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * @param string $shareToken
+	 * @param string $remoteWopiToken
+	 * @return TemplateResponse
+	 * @throws \Exception
+	 */
+	// TODO: we need to use the file apth instead of the file id, since the id is not available on remote servers
+	public function remote($shareToken, $remoteServer, $remoteServerToken, $filePath = null) {
+		$manager = \OC::$server->getContentSecurityPolicyManager();
+		$policy = new \OC\Security\CSP\ContentSecurityPolicy();
+		$policy->addAllowedFrameAncestorDomain('https://*');
+		$manager->addDefaultPolicy($policy);
+
+		try {
+			$share = $this->shareManager->getShareByToken($shareToken);
+			// not authenticated ?
+			if($share->getPassword()){
+				if (!$this->session->exists('public_link_authenticated')
+					|| $this->session->get('public_link_authenticated') !== (string)$share->getId()
+				) {
+					throw new \Exception('Invalid password');
+				}
+			}
+
+			$node = $share->getNode();
+			if ($filePath !== null) {
+				$node = $node->get($filePath);
+			}
+
+			if ($node instanceof Node) {
+				list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($node->getId(), $shareToken, $this->uid);
+
+				$remoteWopi = $this->federationService->getRemoteFileDetails($remoteServer, $remoteServerToken);
+
+				$uid = $remoteWopi['editorUid'] . '@' . $remoteServer;
+				$wopi->setEditorUid($remoteWopi['editorUid']);
+				$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi['canwrite']);
+				$wopi->setRemoteServer($remoteServer);
+				$wopi->setRemoteServerToken($remoteServerToken);
+				$wopi->setGuestDisplayname($uid);
+				$mapper = \OC::$server->query(WopiMapper::class);
+				$mapper->update($wopi);
+
+				$permissions = $share->getPermissions();
+				if (!$remoteWopi['canwrite']) {
+					$permissions = $permissions & ~ Constants::PERMISSION_UPDATE;
+				}
+
+				$params = [
+					'permissions' => $permissions,
+					'title' => $node->getName(),
+					'fileId' => $node->getId() . '_' . $this->settings->getSystemValue('instanceid'),
+					'token' => $token,
+					'urlsrc' => $urlSrc,
+					'path' => '/',
+					'instanceId' => $this->settings->getSystemValue('instanceid'),
+					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
+					'userId' => $uid
+				];
+
+				$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
+				$policy = new ContentSecurityPolicy();
+				$policy->addAllowedFrameDomain($this->domainOnly($this->appConfig->getAppValue('wopi_url')));
+				$policy->allowInlineScript(true);
+				$response->setContentSecurityPolicy($policy);
+				$response->addHeader('X-Frame-Options', 'ALLOW');
 				return $response;
 			}
 		} catch (\Exception $e) {

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Richdocuments\Controller;
+
+
+use OCA\Richdocuments\Db\WopiMapper;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\IConfig;
+use OCP\IRequest;
+
+class FederationController extends \OCP\AppFramework\OCSController {
+
+	/** @var IConfig */
+	private $config;
+
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		IConfig $config,
+		WopiMapper $wopiMapper
+	) {
+		parent::__construct($appName, $request);
+		$this->config   = $config;
+		$this->wopiMapper = $wopiMapper;
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 */
+	public function index() {
+		return new DataResponse([
+			'wopi_url' => $this->config->getAppValue('richdocuments', 'wopi_url')
+		]);
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * Check the file info of a remote accessing a file
+	 *
+	 * this is used to make sure we respect reshares of federated shares with the
+	 * applied permissions and also have information about the actual editor
+	 *
+	 * @param $token
+	 * @return DataResponse
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 */
+	public function remoteWopiToken($token) {
+		$wopi = $this->wopiMapper->getWopiForToken($token);
+		return new DataResponse([
+			'ownerUid' => $wopi->getOwnerUid(),
+			'editorUid' => $wopi->getEditorUid(),
+			'canwrite' => $wopi->getCanwrite(),
+			'hideDownload' => $wopi->getHideDownload(),
+			'direct' => $wopi->getDirect(),
+			'serverHost' => $wopi->getServerHost(),
+			'guestDisplayname' => $wopi->getGuestDisplayname()
+		]);
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * Check the file info of a remote accessing a file
+	 *
+	 * this is used to make sure we respect reshares of federated shares with the
+	 * applied permissions and also have information about the actual editor
+	 *
+	 * @param $shareToken
+	 * @param $filePath
+	 * @return DataResponse
+	 * @throws OCSNotFoundException
+	 * @throws \OCP\Files\NotFoundException
+	 * @throws \OCP\Share\Exceptions\ShareNotFound
+	 */
+	private function remoteDirectToken($shareToken, $filePath) {
+		$this->shareManager = \OC::$server->getShareManager();
+		try {
+			$share = $this->shareManager->getShareByToken($shareToken);
+			$file = $share->getNode()->get($filePath);
+			//TODO check if we can even edit this file with collabora
+			$direct = $this->directMapper->newDirect($this->userId, $file);
+			// TODO: convert to remote token if needed
+
+			return new DataResponse([
+				'url' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.directView.show', [
+					'token' => $direct->getToken()
+				])
+			]);
+		} catch (NotFoundException $e) {
+			throw new OCSNotFoundException();
+		}
+	}
+
+
+}

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -109,29 +109,7 @@ class OCSController extends \OCP\AppFramework\OCSController {
 				throw new OCSBadRequestException('Cannot view folder');
 			}
 
-			/**
-			 * Open file from remote collabora
-			 */
-			if ($node->getStorage()->instanceOfStorage(\OCA\Files_Sharing\External\Storage::class)) {
-				$remote = $node->getStorage()->getRemote();
-				$remoteCollabora = $this->federationService->getRemoteDirectToken($remote);
-				if ($remoteCollabora !== '') {
-					$wopi = $this->tokenManager->getRemoteToken($item);
-					$url = $remote . 'index.php/apps/richdocuments/remote?shareToken=' . $item->getStorage()->getToken() .
-						'&remoteServer=' . $wopi->getServerHost() .
-						'&remoteServerToken=' . $wopi->getToken();
-					if ($item->getInternalPath() !== '') {
-						$url .= '&filePath=' . $item->getInternalPath();
-					}
-					$response = new RedirectResponse($url);
-					$response->addHeader('X-Frame-Options', 'ALLOW');
-					return $response;
-				}
-			}
-
-			//TODO check if we can even edit this file with collabora
 			$direct = $this->directMapper->newDirect($this->userId, $fileId);
-			// TODO: convert to remote token if needed
 
 			return new DataResponse([
 				'url' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.directView.show', [

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -291,6 +291,7 @@ class WopiController extends Controller {
 		}
 
 		// Unless the editor is empty (public link) we modify the files as the current editor
+		// TODO: properly access the file though the share token for remote files
 		$editor = $wopi->getEditorUid();
 		if ($editor === null || $wopi->getRemoteServer() !== '') {
 			$editor = $wopi->getOwnerUid();

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -116,7 +116,7 @@ class WopiController extends Controller {
 		list($fileId, , $version) = Helper::parseFileId($fileId);
 
 		try {
-			$wopi = $this->wopiMapper->getPathForToken($access_token);
+			$wopi = $this->wopiMapper->getWopiForToken($access_token);
 		} catch (DoesNotExistException $e) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -199,7 +199,7 @@ class WopiController extends Controller {
 							$access_token) {
 		list($fileId, , $version) = Helper::parseFileId($fileId);
 
-		$wopi = $this->wopiMapper->getPathForToken($access_token);
+		$wopi = $this->wopiMapper->getWopiForToken($access_token);
 
 		if ((int)$fileId !== $wopi->getFileid()) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
@@ -262,7 +262,7 @@ class WopiController extends Controller {
 		$isPutRelative = ($this->request->getHeader('X-WOPI-Override') === 'PUT_RELATIVE');
 		$isRenameFile = ($this->request->getHeader('X-WOPI-Override') === 'RENAME_FILE');
 
-		$wopi = $this->wopiMapper->getPathForToken($access_token);
+		$wopi = $this->wopiMapper->getWopiForToken($access_token);
 		if (!$wopi->getCanwrite()) {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
@@ -370,7 +370,7 @@ class WopiController extends Controller {
 	public function putRelativeFile($fileId,
 					$access_token) {
 		list($fileId, ,) = Helper::parseFileId($fileId);
-		$wopi = $this->wopiMapper->getPathForToken($access_token);
+		$wopi = $this->wopiMapper->getWopiForToken($access_token);
 		$isRenameFile = ($this->request->getHeader('X-WOPI-Override') === 'RENAME_FILE');
 
 		if (!$wopi->getCanwrite()) {

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -87,6 +87,15 @@ class Wopi extends Entity {
 	/** @var bool */
 	protected $direct;
 
+	/** @var bool */
+	protected $isRemoteToken;
+
+	/** @var string */
+	protected $remoteServer;
+
+	/** @var string */
+	protected $remoteServerToken;
+
 	public function __construct() {
 		$this->addType('owner_uid', 'string');
 		$this->addType('editor_uid', 'string');

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -64,7 +64,7 @@ class WopiMapper extends Mapper {
 	 * @param int $templateDestination
 	 * @return Wopi
 	 */
-	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false) {
+	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false, $isRemoteToken = false) {
 		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
 
 		$wopi = Wopi::fromParams([
@@ -79,7 +79,8 @@ class WopiMapper extends Mapper {
 			'guestDisplayname' => $guestDisplayname,
 			'templateDestination' => $templateDestination,
 			'hideDownload' => $hideDownload,
-			'direct' => $direct
+			'direct' => $direct,
+			'isRemoteToken' => $isRemoteToken
 		]);
 
 		/** @var Wopi $wopi */
@@ -89,6 +90,13 @@ class WopiMapper extends Mapper {
 	}
 
 	/**
+	 * @deprecated
+	 * @param $token
+	 */
+	public function getPathForToken($token) {
+		return $this->getWopiForToken($token);
+	}
+	/**
 	 * Given a token, validates it and
 	 * constructs and validates the path.
 	 * Returns the path, if valid, else false.
@@ -97,7 +105,7 @@ class WopiMapper extends Mapper {
 	 * @throws DoesNotExistException
 	 * @return Wopi
 	 */
-	public function getPathForToken($token) {
+	public function getWopiForToken($token) {
 
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -28,6 +28,7 @@ use OCA\Federation\TrustedServers;
 use OCP\AppFramework\QueryException;
 use OCP\Http\Client\IClientService;
 use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\ILogger;
 
 class FederationService {
@@ -41,8 +42,8 @@ class FederationService {
 	/** @var TrustedServers */
 	private $trustedServers;
 
-	public function __construct(ICache $cache, IClientService $clientService, ILogger $logger) {
-		$this->cache = $cache;
+	public function __construct(ICacheFactory $cacheFactory, IClientService $clientService, ILogger $logger) {
+		$this->cache = $cacheFactory->createLocal('richdocuments_remote/');
 		$this->clientService = $clientService;
 		$this->logger = $logger;
 		try {

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Richdocuments\Service;
+
+
+use OCA\Federation\TrustedServers;
+use OCP\AppFramework\QueryException;
+use OCP\Http\Client\IClientService;
+use OCP\ICache;
+use OCP\ILogger;
+
+class FederationService {
+
+	/** @var ICache */
+	private $cache;
+	/** @var IClientService */
+	private $clientService;
+	/** @var ILogger  */
+	private $logger;
+	/** @var TrustedServers */
+	private $trustedServers;
+
+	public function __construct(ICache $cache, IClientService $clientService, ILogger $logger) {
+		$this->cache = $cache;
+		$this->clientService = $clientService;
+		$this->logger = $logger;
+		try {
+			$this->trustedServers = \OC::$server->query( \OCA\Federation\TrustedServers::class);
+		} catch (QueryException $e) {}
+	}
+
+	public function getRemoteCollaboraURL($remote) {
+		if ($this->trustedServers === null || !$this->trustedServers->isTrustedServer($remote)) {
+			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote . ' - Remote is not a trusted server');
+			return '';
+		}
+		if ($remoteCollabora = $this->cache->get('richdocuments_remote/' . $remote)) {
+			return $remoteCollabora;
+		}
+		try {
+			$client = $this->clientService->newClient();
+			$response = $client->get($remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation?format=json', ['timeout' => 5]);
+			$data = \json_decode($response->getBody(), true);
+			$remoteCollabora = $data['ocs']['data']['wopi_url'];
+			$this->cache->get('richdocuments_remote/' . $remote, $remoteCollabora, 3600);
+			return $remoteCollabora;
+		} catch (\Throwable $e) {
+			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote);
+			$this->cache->get('richdocuments_remote/' . $remote, '', 300);
+		}
+		return '';
+	}
+
+	public function getRemoteDirectUrl($remote, $shareToken, $filePath) {
+		if ($this->getRemoteCollaboraURL() === '') {
+			return '';
+		}
+		try {
+			$client = $this->clientService->newClient();
+			$response = $client->post($remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation/direct?format=json', [
+				'timeout' => 5,
+				'body' => [
+					'shareToken' => $shareToken,
+					'filePath' => $filePath
+				]
+			]);
+			$data = \json_decode($response->getBody(), true);
+			return $data['ocs']['data'];
+		} catch (\Throwable $e) {
+			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote);
+		}
+		return null;
+	}
+
+	public function getRemoteFileDetails($remote, $remoteToken) {
+		if ($this->trustedServers === null || !$this->trustedServers->isTrustedServer($remote)) {
+			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote . ' - Remote is not a trusted server');
+			return null;
+		}
+		try {
+			$client = $this->clientService->newClient();
+			$response = $client->post($remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation?format=json', [
+				'timeout' => 5,
+				'body' => [
+					'token' => $remoteToken
+				]
+			]);
+			$data = \json_decode($response->getBody(), true);
+			return $data['ocs']['data'];
+		} catch (\Throwable $e) {
+			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote);
+		}
+		return null;
+	}
+}

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -232,4 +232,19 @@ class TokenManager {
 		$this->wopiMapper->update($wopi);
 		return $wopi;
 	}
+
+	/**
+	 * @param Node $node
+	 * @return Wopi
+	 */
+	public function getRemoteTokenFromDirect(Node $node, $editorUid) {
+		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, $editorUid, true, true);
+		$wopi->setIsRemoteToken(true);
+		$wopi->setRemoteServer($node->getStorage()->getRemote());
+
+		$this->wopiMapper->update($wopi);
+		return $wopi;
+	}
+
+
 }

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -189,6 +189,17 @@ class TokenManager {
 		}
 	}
 
+	public function updateToRemoteToken(Wopi $wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi) {
+		$uid = $remoteWopi['editorUid'] . '@' . $remoteServer;
+		$wopi->setEditorUid($shareToken);
+		$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi['canwrite']);
+		$wopi->setRemoteServer($remoteServer);
+		$wopi->setRemoteServerToken($remoteServerToken);
+		$wopi->setGuestDisplayname($uid);
+		$this->wopiMapper->update($wopi);
+		return $wopi;
+	}
+
 	public function getTokenForTemplate(File $file, $userId, $templateDestination, $direct = false) {
 		$owneruid = $userId;
 		$editoruid = $userId;

--- a/src/document.js
+++ b/src/document.js
@@ -167,7 +167,7 @@ const documentsMain = {
 				+ '<input name="access_token" value="' + accessToken + '" type="hidden"/></form>'
 
 			// iframe that contains the Collabora Online
-			var frame = '<iframe id="loleafletframe" name="loleafletframe" scrolling="no" allowfullscreen style="width:100%;height:100%;position:absolute;" />'
+			var frame = '<iframe id="loleafletframe" name="loleafletframe" nonce="' + btoa(getRequestToken()) + '" scrolling="no" allowfullscreen style="width:100%;height:100%;position:absolute;" />'
 
 			$('#mainContainer').append(form)
 			$('#mainContainer').append(frame)

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -37,6 +37,14 @@ export default {
 		this.fileName = fileName
 		this.fileId = fileId
 		this.sendPostMessage = sendPostMessage
+	},
+
+	initAfterReady() {
+		try {
+			documentsMain = document.getElementById('richdocumentsframe').contentWindow.documentsMain
+		} catch (e) {
+			console.debug('[FilesAppIntegration] failed to access documentsMain')
+		}
 
 		if (typeof this.getFileList() !== 'undefined') {
 			this.getFileModel()
@@ -52,14 +60,6 @@ export default {
 			this._addHeaderShareButton()
 			this._addHeaderFileActions()
 			this.addVersionSidebarEvents()
-		}
-	},
-
-	initAfterReady() {
-		try {
-			documentsMain = document.getElementById('richdocumentsframe').contentWindow.documentsMain
-		} catch (e) {
-			console.debug('[FilesAppIntegration] failed to access documentsMain')
 		}
 	},
 

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -56,7 +56,11 @@ export default {
 	},
 
 	initAfterReady() {
-		documentsMain = document.getElementById('richdocumentsframe').contentWindow.documentsMain
+		try {
+			documentsMain = document.getElementById('richdocumentsframe').contentWindow.documentsMain
+		} catch (e) {
+			console.debug('[FilesAppIntegration] failed to access documentsMain')
+		}
 	},
 
 	close() {

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -100,12 +100,12 @@ const odfViewer = {
 
 		const reloadForFederationCSP = (fileName) => {
 			const preloadId = Preload.open ? parseInt(Preload.open.id) : -1
-			const fileModel = FileList.getModelForFile(fileName)
-			const shareOwnerId = fileModel.get('shareOwnerId')
+			const fileModel = FileList.findFile(fileName)
+			const shareOwnerId = fileModel.shareOwnerId
 			if (typeof shareOwnerId !== 'undefined') {
 				const lastIndex = shareOwnerId.lastIndexOf('@')
 				// only redirect if remote file, not opened though reload and csp blocks the request
-				if (shareOwnerId.substr(lastIndex).indexOf('/') !== -1 && fileModel.get('id') !== preloadId) {
+				if (shareOwnerId.substr(lastIndex).indexOf('/') !== -1 && fileModel.id !== preloadId) {
 					canAccessCSP('https://' + shareOwnerId.substr(lastIndex) + '/status.php', () => {
 						window.location = OC.generateUrl('/apps/richdocuments/open?fileId=' + fileId)
 					})


### PR DESCRIPTION
## Requirements

Collabora currently sets a frame-ancestors CSP so in order to work with all Nextcloud instances the following needs to be set in loolwsd.xml:

      <frame_ancestors>https://*</frame_ancestors>

## TODO

- [x] Get rid of `parent.*` calls in documents.js and use proper postMessages
- [x] Reload files list to get the proper CSP set
- [x] Direct editing
- [x] Set proper WOPI token parameters for federated editors
- [x] Use proper addressbook information for remote editors
- [x] Access file though share token instead of the owners root
- [x] Use dependency injection in various places where it isn't used

## Limitations
- Creating on federated folders will still open newly created documents on the local collabora instance since there is no way we can obtain the template otherwise (This can be fixed once https://github.com/nextcloud/richdocuments/pull/514 is ready)
- Editing remote documents requires a page reload to set a proper CSP. We could set allowed frame domains for some domains per default for GS but I would do that in a later step maybe.