### PR TITLE
Loading time improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,10 +25,6 @@ body {
 	vertical-align: top;
 }
 
-.documentslist .progress{
-	border: 1px solid #e8e8e8;
-}
-
 .documentslist .progress div{
 	margin-top: 144px;
 	text-align: center;
@@ -52,7 +48,6 @@ body {
 	width: 200px;
 	background-repeat: no-repeat;
 	background-size: 200px;
-	border: 1px solid #e8e8e8;
 }
 .document a:hover {
 	border: 1px solid #818181;

--- a/css/viewer.scss
+++ b/css/viewer.scss
@@ -37,7 +37,6 @@
 #richdocumentsframe {
   background-color: #fff;
   width:100%;
-  /** TODO: This will probably look odd on 13 */
   height: calc(100vh - 50px);
   display:block;
   position:absolute;

--- a/js/documents.js
+++ b/js/documents.js
@@ -1074,7 +1074,6 @@ var documentsMain = {
 	},
 
 	show: function(fileId){
-		documentsMain.UI.showProgress(t('richdocuments', 'Loading documents…'));
 		documentsMain.docs.documentGrid('render', fileId);
 		documentsMain.UI.hideProgress();
 	},

--- a/js/documents.js
+++ b/js/documents.js
@@ -1105,6 +1105,7 @@ $(document).ready(function() {
 
 	documentsMain.docs = $('.documentslist').documentGrid();
 	documentsMain.overlay = $('<div id="documents-overlay" class="icon-loading"></div><div id="documents-overlay-below" class="icon-loading-dark"></div>').documentOverlay();
+	documentsMain.overlay.hide();
 
 	$('li.document a').tooltip({fade: true, live: true});
 

--- a/js/documents.js
+++ b/js/documents.js
@@ -567,7 +567,7 @@ var documentsMain = {
 			}
 
 			if (!documentsMain.renderComplete) {
-				setTimeout(function() { documentsMain.UI.showEditor(title, action); }, 500);
+				setTimeout(function() { documentsMain.UI.showEditor(title, action); }, 10);
 				console.log('Waiting for page to render…');
 				return;
 			}

--- a/js/documents.js
+++ b/js/documents.js
@@ -580,9 +580,6 @@ var documentsMain = {
 			$(document.body).addClass("claro");
 			$(document.body).prepend(documentsMain.UI.container);
 
-			documentsMain.documentTitle = title;
-			parent.document.title = documentsMain.documentTitle + ' - ' + documentsMain.UI.mainTitle;
-
 			// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
 			var wopiurl = window.location.protocol + '//' + window.location.host + OC.getRootPath() + '/index.php/apps/richdocuments/wopi/files/' + documentsMain.fileId;
 			var wopisrc = encodeURIComponent(wopiurl);
@@ -926,10 +923,6 @@ var documentsMain = {
 		}
 
 		documentsMain.ready = true;
-		if (parent && documentsMain.getFileList() !== null && typeof documentsMain.getFileList() !== 'undefined') {
-			documentsMain.getFileList().reload();
-			parent.document.title = documentsMain.documentTitle + ' - ' + documentsMain.UI.mainTitle;
-		}
 	},
 
 	WOPIPostMessage: function(iframe, msgId, values) {

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -20,6 +20,7 @@ var Preload = {
 var odfViewer = {
 	isDocuments : false,
 	nextcloudVersion: 0,
+	receivedLoading: false,
 	supportedMimes: OC.getCapabilities().richdocuments.mimetypes.concat(OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen),
 	excludeMimeFromDefaultOpen: OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen,
 	register : function() {
@@ -65,6 +66,7 @@ var odfViewer = {
 			var fileId = context.fileId || context.$file.attr('data-id');
 			var templateId = context.templateId;
 		}
+		odfViewer.receivedLoading = false;
 
 		var viewer;
 		if($('#isPublic').val() === '1') {
@@ -96,17 +98,20 @@ var odfViewer = {
 		if(context) {
 			FileList.setViewerMode(true);
 			FileList.setPageTitle(fileName);
+			FileList.showMask();
 		}
 
 		OC.addStyle('richdocuments', 'mobile');
 
 		var $iframe = $('<iframe id="richdocumentsframe" nonce="' + btoa(OC.requestToken) + '" scrolling="no" allowfullscreen src="'+viewer+'" />');
-		$.get(OC.generateUrl('/apps/richdocuments/settings/check'), function() {
-			$iframe.src = viewer;
-		}) .fail(function() {
-			odfViewer.onClose();
-			OC.Notification.showTemporary(t('richdocuments', 'Failed to load {productName} - please try again later', {productName: OC.getCapabilities().richdocuments.productName || 'Collabora Online'}));
-		});
+		odfViewer.loadingTimeout = setTimeout(function() {
+			if (!odfViewer.receivedLoading) {
+				odfViewer.onClose();
+				OC.Notification.showTemporary(t('richdocuments', 'Failed to load {productName} - please try again later', {productName: OC.getCapabilities().richdocuments.productName || 'Collabora Online'}));
+			}
+		}, 15000);
+		$iframe.src = viewer;
+
 		$('body').css('overscroll-behavior-y', 'none');
 		var viewport = document.querySelector("meta[name=viewport]");
 		viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
@@ -124,6 +129,7 @@ var odfViewer = {
 		} else {
 			$('body').css('overflow', 'hidden');
 			$('#app-content').append($iframe);
+			$iframe.hide();
 			if ($('header').length) {
 				var $button = $('<div class="richdocuments-sharing"><a class="icon-shared icon-white"></a></div>');
 				$('.header-right').prepend($button);
@@ -137,7 +143,6 @@ var odfViewer = {
 					OC.Apps.showAppSidebar();
 				});
 				$('.searchbox').hide();
-				$('#app-navigation').addClass('hidden');
 			}
 		}
 
@@ -145,15 +150,16 @@ var odfViewer = {
 	},
 
 	onClose: function() {
+		clearTimeout(odfViewer.loadingTimeout)
 		if(typeof FileList !== "undefined") {
 			FileList.setViewerMode(false);
 			FileList.reload();
 			FileList.setPageTitle();
 		}
+		odfViewer.receivedLoading = false;
 		$('link[href*="richdocuments/css/mobile"]').remove();
 		$('#app-content #controls').removeClass('hidden');
 		$('#richdocumentsframe').remove();
-		$('#app-navigation').removeClass('hidden');
 		$('.richdocuments-sharing').remove();
 		$('#richdocuments-avatars').remove();
 		$('#richdocuments-actions').remove();
@@ -399,7 +405,10 @@ $(document).ready(function() {
 		if (e.data === 'close') {
 			odfViewer.onClose();
 		} else if(e.data === 'loading') {
+			odfViewer.receivedLoading = true;
+			$('#richdocumentsframe').show();
 			$('#content').removeClass('loading');
+			FileList.hideMask();
 		}
 	}, false);
 });

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -95,6 +95,7 @@ var odfViewer = {
 
 		if(context) {
 			FileList.setViewerMode(true);
+			FileList.setPageTitle(fileName);
 		}
 
 		OC.addStyle('richdocuments', 'mobile');
@@ -147,6 +148,7 @@ var odfViewer = {
 		if(typeof FileList !== "undefined") {
 			FileList.setViewerMode(false);
 			FileList.reload();
+			FileList.setPageTitle();
 		}
 		$('link[href*="richdocuments/css/mobile"]').remove();
 		$('#app-content #controls').removeClass('hidden');


### PR DESCRIPTION

- Adjust showEditor timeout, to recheck faster if the rendering has completed
- Do not reload files list on initial load 
- Remove additional check call and show error if no collabora loaded and switch to timeout based approach
- Fix styling of inbetween loading step

There is some more room for improvement since our integration still uses a jquery UI component to show the loading indicator inside of the frame, which takes quite long execution times. But this is out of scope for a patch release and will be tackled when refactoring the frontend code in #541 