### PR TITLE
Fallback to regular wopi url if the public_wopi_url is not set

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -63,7 +63,8 @@ if (class_exists('\OC\Files\Type\TemplateManager')) {
 }
 
 // Whitelist the public wopi URL for iframes, required for Firefox
-$publicWopiUrl = \OC::$server->getConfig()->getAppValue('richdocuments', 'public_wopi_url');
+$publicWopiUrl = \OC::$server->getConfig()->getAppValue('richdocuments', 'public_wopi_url', '');
+$publicWopiUrl = $publicWopiUrl === '' ? \OC::$server->getConfig()->getAppValue('richdocuments', 'wopi_url') : $publicWopiUrl;
 if ($publicWopiUrl !== '') {
 	$manager = \OC::$server->getContentSecurityPolicyManager();
 	$policy = new ContentSecurityPolicy();


### PR DESCRIPTION
Fixes a bug from #483 

When the app has already been configured the public_wopi_url was not set, so this PR will make sure we fallback to the regular url in those cases.