### PR TITLE
Bugfix: with PHP > 7 the app cannot be enabled anymore

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -85,7 +85,7 @@ class Application extends App {
 
 	}
 
-	public function updateCSP(): void {
+	public function updateCSP() {
 		$container = $this->getContainer();
 
 		$publicWopiUrl = $container->getServer()->getConfig()->getAppValue('richdocuments', 'public_wopi_url', '');


### PR DESCRIPTION
"TypeError: Return value of OCA\Richdocuments\AppInfo\Application::updateCSP() must be an instance of OCA\Richdocuments\AppInfo\void, none returned"

* Resolves: #594

Tested on our production platform.
