### PR TITLE
Lower log level if the token does not exist

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -148,6 +148,9 @@ class WopiController extends Controller {
 		} catch (NotFoundException $e) {
 			$this->logger->debug($e->getMessage(), ['app' => 'richdocuments', '']);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		} catch (DoesNotExistException $e) {
+			$this->logger->debug($e->getMessage(), ['app' => 'richdocuments', '']);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' => 'richdocuments']);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);


### PR DESCRIPTION
Catched by sentry but no need to have this at error level, the forbidden http response and logging at debug level should be enough.