### PR TITLE
Revert "Do not use template shipped by core"

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -533,7 +533,15 @@ class DocumentController extends Controller {
 			], Http::STATUS_BAD_REQUEST);
 		}
 
-		$content = file_get_contents(dirname(dirname(__DIR__)) . self::ODT_TEMPLATE_PATH);
+		$content = '';
+		if (class_exists(TemplateManager::class)){
+			$manager = \OC_Helper::getFileTemplateManager();
+			$content = $manager->getTemplate($mimetype);
+		}
+
+		if (!$content){
+			$content = file_get_contents(dirname(dirname(__DIR__)) . self::ODT_TEMPLATE_PATH);
+		}
 
 		if ($content) {
 			$file->putContent($content);


### PR DESCRIPTION
Needs some more work and also breaks compatibility to Collabora 3.x where template support isn't available.