### PR TITLE
Yet another fix for the file list handling

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -286,7 +286,8 @@ const odfViewer = {
 								odfViewer.onEdit(filename, {
 									fileId: -1,
 									dir: $('#dir').val(),
-									templateId: templateId
+									templateId: templateId,
+									fileList: FileList
 								})
 							} else {
 								OC.dialogs.alert(response.data.message, t('core', 'Could not create file'))
@@ -383,7 +384,8 @@ const odfViewer = {
 			FileList.$fileList.one('updated', function() {
 				odfViewer.onEdit(Preload.open.filename, {
 					fileId: Preload.open.id,
-					dir: document.getElementById('dir').value
+					dir: document.getElementById('dir').value,
+					fileList: FileList
 				})
 			})
 		}


### PR DESCRIPTION
Missing part from https://github.com/nextcloud/richdocuments/pull/651 to make sure the fileapp context is also provided for creating files