### PR TITLE
Force read operation to trigger audit log when issuing a token

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -167,6 +167,11 @@ class TokenManager {
 				$owneruid = $owner->getUID();
 			}
 		}
+
+		// force read operation to trigger possible audit logging
+		$fp = $file->fopen('r');
+		fclose($fp);
+
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');//$this->request->getServerProtocol() . '://' . $this->request->getServerHost();
 
 		if ($this->userId === null && isset($_COOKIE['guestUser']) && $_COOKIE['guestUser'] !== '') {


### PR DESCRIPTION
When opening a file in collabora it is only read once from the storage with no user context. This PR makes sure we trigger the read hook being called for each token generation so the admin_audit log properly lists access to files.