### PR TITLE
Make sure files created from the same template have a different WOPI file id

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -32,7 +32,7 @@ return [
 		['name' => 'document#remote', 'url' => 'remote', 'verb' => 'GET'],
 		['name' => 'document#open', 'url' => 'open', 'verb' => 'GET'],
 
-		['name' => 'document#template', 'url' => 'indexTemplate', 'verb' => 'GET'],
+		['name' => 'document#createFromTemplate', 'url' => 'indexTemplate', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
 		['name' => 'document#create', 'url' => 'ajax/documents/create', 'verb' => 'POST'],
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -233,7 +233,7 @@ class DocumentController extends Controller {
 				return $response;
 			}
 
-			list($urlSrc, $token) = $this->tokenManager->getToken($item->getId());
+			list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($item->getId());
 			$params = [
 				'permissions' => $item->getPermissions(),
 				'title' => $item->getName(),
@@ -287,7 +287,7 @@ class DocumentController extends Controller {
 	 * @throws NotPermittedException
 	 * @throws \OCP\Files\InvalidPathException
 	 */
-	public function template($templateId, $fileName, $dir) {
+	public function createFromTemplate($templateId, $fileName, $dir) {
 		if (!$this->templateManager->isTemplate($templateId)) {
 			return new TemplateResponse('core', '403', [], 'guest');
 		}
@@ -311,7 +311,7 @@ class DocumentController extends Controller {
 		$params = [
 			'permissions' => $template->getPermissions(),
 			'title' => $fileName,
-			'fileId' => $template->getId() . '_' . $this->settings->getSystemValue('instanceid'),
+			'fileId' => $template->getId() . '-' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid'),
 			'token' => $token,
 			'urlsrc' => $urlSrc,
 			'path' => $userFolder->getRelativePath($file->getPath()),

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -25,6 +25,7 @@ class Helper {
 	 */
 	public static function parseFileId($fileId) {
 		$arr = explode('_', $fileId);
+		$templateId = null;
 		if (count($arr) === 1) {
 			$fileId = $arr[0];
 			$instanceId = '';
@@ -38,10 +39,15 @@ class Helper {
 			throw new \Exception('$fileId has not the expected format');
 		}
 
+		if (strpos($fileId, '-') !== false) {
+			list($fileId, $templateId) = explode('/', $fileId);
+		}
+
 		return [
 			$fileId,
 			$instanceId,
 			$version,
+			$templateId
 		];
 	}
 


### PR DESCRIPTION
The issue with the current file creation mechanism from templates is that we open the template file in Collabora. When multiple users create a file from the same template they end up in the same session in collabora as the file id from the template is the same.

Until https://github.com/nextcloud/richdocuments/pull/514 is done and for backward compatibility to Collabora Online < 4.2 this PR adds the actual output file id to the constructed file id in the WOPIsrc so that there is one document editing session for each file creation.