### PR TITLE
Admin resources in app store should point to Github repo

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@
 	</types>
 	<documentation>
 		<user>https://nextcloud.com/collaboraonline/</user>
-		<admin>https://nextcloud.com/collaboraonline/</admin>
+		<admin>https://github.com/nextcloud/richdocuments/wiki</admin>
 	</documentation>
 	<category>office</category>
 	<category>integration</category>


### PR DESCRIPTION
In the App Store appearance, both the users' and the admins' resources were linking to the same page on the Nextcloud website. Yet for admins it would be more streamlined to be directed to the Github repository and its wiki.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
