### PR TITLE
Make sure Firefox doesn't navigate out of the current directory

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -194,7 +194,6 @@ const odfViewer = {
 		}
 
 		OC.Util.History.replaceState()
-		location.hash = ''
 
 		FilesAppIntegration.close()
 	},


### PR DESCRIPTION
Fixes #644 

From @danxuliu in https://github.com/nextcloud/richdocuments/issues/644#issuecomment-558178333

> If I am not mistaken the problem comes from [`location.hash = ""`](https://github.com/nextcloud/richdocuments/blob/8b7cb593cfd7a96746bd3aab087b5464af7185d9/src/viewer.js#L197) and the fact that some browsers (like Firefox) trigger `onpopstate` and some browsers (like Chromium) do not (you can [try it here](https://jsfiddle.net/mgs0r9fy/)).

> The Files app [listens to _popstate_ events](https://github.com/nextcloud/server/blob/master/apps/files/js/app.js#L200) and [triggers _urlChanged_ events](https://github.com/nextcloud/server/blob/master/apps/files/js/app.js#L297), which cause [the file list to change to the new directory](https://github.com/nextcloud/server/blob/master/apps/files/js/filelist.js#L736). When the _RichDocuments_ viewer is closed it [first clears the state (the _?dir=/XXX&fileid=YYY_ part) of the URL](https://github.com/nextcloud/richdocuments/blob/8b7cb593cfd7a96746bd3aab087b5464af7185d9/src/viewer.js#L196) (note that this [does not trigger an _onpopstate_ event](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate)) and then sets `location.hash = ""`. In Chromium no `popstate` event is triggered, so everything works as expected. But in Firefox this triggers a `popstate` event, and as the state was cleared the URL now refers to the root folder and the file list changes to it.
