### PR TITLE
Introduce a user scope service to properly perform actions

### DIFF
--- a/lib/Controller/AssetsController.php
+++ b/lib/Controller/AssetsController.php
@@ -24,6 +24,7 @@
 namespace OCA\Richdocuments\Controller;
 
 use OCA\Richdocuments\Db\AssetMapper;
+use OCA\Richdocuments\Service\UserScopeService;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
@@ -55,12 +56,14 @@ class AssetsController extends Controller {
 								AssetMapper $assetMapper,
 								IRootFolder $rootFolder,
 								$userId,
+								UserScopeService $userScopeService,
 								IURLGenerator $urlGenerator) {
 		parent::__construct($appName, $request);
 
 		$this->assetMapper = $assetMapper;
 		$this->rootFolder = $rootFolder;
 		$this->userId = $userId;
+		$this->userScopeService = $userScopeService;
 		$this->urlGenerator = $urlGenerator;
 	}
 
@@ -81,7 +84,7 @@ class AssetsController extends Controller {
 		}
 
 		$asset = $this->assetMapper->newAsset($this->userId, $node->getId());
-		
+
 		return new JSONResponse([
 			'url' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.assets.get', [
 				'token' => $asset->getToken(),
@@ -109,6 +112,8 @@ class AssetsController extends Controller {
 			$this->assetMapper->delete($asset);
 		}
 
+
+		$this->userScopeService->setUserScope($asset->getUid());
 		$userFolder = $this->rootFolder->getUserFolder($asset->getUid());
 		$nodes = $userFolder->getById($asset->getFileid());
 

--- a/lib/Service/UserScopeService.php
+++ b/lib/Service/UserScopeService.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Richdocuments\Service;
+
+
+use OCP\IUserManager;
+use OCP\IUserSession;
+
+class UserScopeService {
+
+	public function __construct(IUserSession $userSession, IUserManager $userManager) {
+		$this->userSession = $userSession;
+		$this->userManager = $userManager;
+	}
+
+	/**
+	 * Set a valid user in IUserSession since lots of server logic is relying on obtaining
+	 * the current acting user from that
+	 *
+	 * @param $uid
+	 * @throws \InvalidArgumentException
+	 */
+	public function setUserScope(string $uid) {
+		$user = $this->userManager->get($uid);
+		if ($user === null) {
+			throw new \InvalidArgumentException('No user found for the uid ' . $uid);
+		}
+		$this->userSession->setUser($user);
+	}
+}


### PR DESCRIPTION
This makes sure that any code that uses the current user in IUserSession will get a proper result in wopi/asset requests. 

Example bug:
- Set a image file readonly in a groupfolder with ACl
- Try to insert the image into a collabora document

Before:
- Groupfolders checks for the current user which is not set and therefore the file cannot be obtained

After:
- Inserting the image works as expected