### PR TITLE
Properly setup the filesystem for put operations

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -444,9 +444,9 @@ class WopiController extends Controller {
 			}
 
 			$content = fopen('php://input', 'rb');
-
 			// Set the user to register the change under his name
 			$this->userScopeService->setUserScope($wopi->getEditorUid());
+			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getOwnerUid());
 
 			try {
 				$this->retryOperation(function () use ($file, $content){
@@ -480,6 +480,8 @@ class WopiController extends Controller {
 	 * Expects a valid token in access_token parameter.
 	 * Just actually routes to the PutFile, the implementation of PutFile
 	 * handles both saving and saving as.* Given an access token and a fileId, replaces the files with the request body.
+	 *
+	 * FIXME Cleanup this code as is a lot of shared logic between putFile and putRelativeFile
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
@@ -582,9 +584,9 @@ class WopiController extends Controller {
 			}
 
 			$content = fopen('php://input', 'rb');
-
 			// Set the user to register the change under his name
 			$this->userScopeService->setUserScope($wopi->getEditorUid());
+			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getOwnerUid());
 
 			try {
 				$this->retryOperation(function () use ($file, $content){

--- a/lib/Service/UserScopeService.php
+++ b/lib/Service/UserScopeService.php
@@ -48,4 +48,17 @@ class UserScopeService {
 		}
 		$this->userSession->setUser($user);
 	}
+
+	/**
+	 * Setup the FS which is needed to emit hooks
+	 *
+	 * This is required for versioning/activity as the legacy filesystem hooks
+	 * are not emitted if filesystem operations are executed though \OCP\Files\Node\File
+	 *
+	 * @param string $owner
+	 */
+	public function setFilesystemScope(string $owner): void {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($owner);
+	}
 }


### PR DESCRIPTION
This is required for versioning/activity as the legacy filesystem hooks
are not emitted otherwise, if filesystem operations are executed though
the \OCP\Files\Node\File API
