### PR TITLE
Missing () in condition

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -197,7 +197,7 @@ const documentsMain = {
 						PostMessages.unregisterPostMessageHandler(editorInitListener)
 
 						// Hide buttons when using the mobile app integration
-						if (isDirectEditing) {
+						if (isDirectEditing()) {
 							PostMessages.sendWOPIPostMessage('loolframe', 'Hide_Button', { id: 'fullscreen' })
 							PostMessages.sendWOPIPostMessage('loolframe', 'Hide_Menu_Item', { id: 'fullscreen' })
 						}


### PR DESCRIPTION
* Resolves: Full Screen menu and toolbar button was uncondionally hidden
