### PR TITLE
Remove template id after first save

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -467,7 +467,10 @@ class WopiController extends Controller {
 
 				return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $url ], Http::STATUS_OK);
 			}
-
+			if ($wopi->hasTemplateId()) {
+				$wopi->setTemplateId(null);
+				$this->wopiMapper->update($wopi);
+			}
 			return new JSONResponse(['LastModifiedTime' => Helper::toISO8601($file->getMTime())]);
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['level' => ILogger::ERROR,	'app' => 'richdocuments', 'message' => 'getFile failed']);


### PR DESCRIPTION
If a collabora server is temporarily unavailable and the document tries to reconnect afterwards, there is no need to keep a token related to a template the file has been saved for the first time.