### PR TITLE
Properly check for a set guest name when obtaining the file

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -391,6 +391,10 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		// Set the user to register the change under his name
+		$this->userScopeService->setUserScope($wopi->getEditorUid());
+		$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
+
 		try {
 			if ($isPutRelative) {
 				// the new file needs to be installed in the current user dir
@@ -444,9 +448,6 @@ class WopiController extends Controller {
 			}
 
 			$content = fopen('php://input', 'rb');
-			// Set the user to register the change under his name
-			$this->userScopeService->setUserScope($wopi->getEditorUid());
-			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
 
 			try {
 				$this->retryOperation(function () use ($file, $content){

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -656,7 +656,7 @@ class WopiController extends Controller {
 			$editor = $wopi->getEditorUid();
 
 			// Use the actual file owner no editor is available
-			if ($editor === null || $wopi->getGuestDisplayname() === null) {
+			if ($editor === null || $wopi->getGuestDisplayname() !== null) {
 				$editor = $wopi->getOwnerUid();
 			}
 

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -446,7 +446,7 @@ class WopiController extends Controller {
 			$content = fopen('php://input', 'rb');
 			// Set the user to register the change under his name
 			$this->userScopeService->setUserScope($wopi->getEditorUid());
-			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getOwnerUid());
+			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
 
 			try {
 				$this->retryOperation(function () use ($file, $content){
@@ -586,7 +586,7 @@ class WopiController extends Controller {
 			$content = fopen('php://input', 'rb');
 			// Set the user to register the change under his name
 			$this->userScopeService->setUserScope($wopi->getEditorUid());
-			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getOwnerUid());
+			$this->userScopeService->setFilesystemScope($wopi->getEditorUid());
 
 			try {
 				$this->retryOperation(function () use ($file, $content){
@@ -653,14 +653,7 @@ class WopiController extends Controller {
 		} else {
 			// Unless the editor is empty (public link) we modify the files as the current editor
 			// TODO: add related share token to the wopi table so we can obtain the
-			$editor = $wopi->getEditorUid();
-
-			// Use the actual file owner no editor is available
-			if ($editor === null || $wopi->getGuestDisplayname() !== null) {
-				$editor = $wopi->getOwnerUid();
-			}
-
-			$userFolder = $this->rootFolder->getUserFolder($editor);
+			$userFolder = $this->rootFolder->getUserFolder($wopi->getUserForFileAccess());
 			$files = $userFolder->getById($wopi->getFileid());
 			if (isset($files[0]) && $files[0] instanceof File) {
 				$file = $files[0];

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -126,4 +126,12 @@ class Wopi extends Entity {
 		return $this->getTemplateId() !== 0 && $this->getTemplateId() !== null;
 	}
 
+	public function isGuest() {
+		return $this->getGuestDisplayname() !== null;
+	}
+
+	public function getUserForFileAccess() {
+		return $this->isGuest() ? $this->getOwnerUid() : $this->getEditorUid();
+	}
+
 }


### PR DESCRIPTION
To reproduce, put a file on external storage and share it with another user that doesn't have access to the external storage. This makes sure that the editor is not falsely overwritten with the owner.