### PR TITLE
Merge pull request #813 from nextcloud/docs

### DIFF
--- a/docs/api_templates.md
+++ b/docs/api_templates.md
@@ -1,0 +1,50 @@
+
+# Templates API
+
+### Listing templates
+
+Send a GET to:
+
+`<server>/ocs/v2.php/apps/richdocuments/api/v1/templates/<type>`
+
+Here type can be:
+
+* document
+* spreadsheet
+* presentation
+
+This returns a list of templates with
+
+* id
+* name
+* link to preview
+* extension
+
+### Template previews
+
+Send a GET to:
+
+`<server>/apps/richdocuments/templates/<id>`
+
+Where `id` is the id of the template obtained in the listing. This returns back
+an image (jpeg or png). For displaying.
+
+### Creating document based on a template
+
+Send a POST to
+
+`<server>/ocs/v2.php/apps/richdocuments/api/v1/templates/new`
+
+with:
+* `path`: the full path relative to the user where to create the document, including new file name
+* `template`: the template id you want to create
+
+## Web frontend
+
+When clicking on a new document a selection popup appears listing the
+available templates.
+
+The user can select a template, possible change the name and create it.
+
+This is similar to the current flow with the difference that the user can now
+select a template.

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,3 @@
+li.toctree-l2:first-child {
+    display: none;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# Collabora Online in Nextcloud
+
+![https://nextcloud.com/wp-content/themes/next/assets/img/features/Collabora_with_Talk_in_sidebar_1.png?x53054](https://nextcloud.com/wp-content/themes/next/assets/img/features/Collabora_with_Talk_in_sidebar_1.png?x53054)
+Collabora Online supports editing your documents in real time with multiple other editors, showing high fidelity, WYSIWYG rendering and preserving the layout and formatting of your documents.
+
+Users can insert and reply to comments and invite others without a Nextcloud account for anonymous editing of files with a public link shared folder.
+
+Collabora Online supports dozens of document formats including DOC, DOCX, PPT, PPTX, XLS, XLSX + ODF, Import/View Visio, Publisher and many more...
+
+Collabora Online Development Edition (CODE) is free and under heavy development, adding features and improvements all the time! Enterprise users have access to the more stable, scalable Collabora Online Enterprise version through a Nextcloud support subscription.
+
+We are able to provide a solution for Online Office for the entire Nextcloud community through our partnership with Collabora in an easy to use docker image for developers and home users. Enterprise users looking for a more reliable solution should contact Nextcloud Sales.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,148 @@
+
+
+# Getting started in 3 steps
+We'll describe how to get Collabora Online running on your server and how to integrate it into your Nextcloud using the docker image Nextcloud and Collabora built.
+
+# Requirements
+To install it the following dependencies are required:
+
+- A host that can run a Docker container
+- A subdomain or a second domain that the Collabora Online server can run on
+- An Apache server with some enabled modules (NGINX instructions in a blog here)
+- A valid SSL certificate for the domain that Collabora Online should run on
+- A valid SSL certificate for your Nextcloud
+
+Note: This guide does NOT cover self-signed certificates. If you use a self-signed certificate then you're mostly on your own ;-)
+
+## Install the Collabora Online server
+
+### Setup using docker
+
+The [collabora/code](https://hub.docker.com/r/collabora/code/) Docker image can be installed to any x86-64 host (e.g. on Linux and Windows 10), and it is fully configurable. For more information about setup and configuration for deployment, please read the [CODE Docker page](https://www.collaboraoffice.com/code/docker/). If you want to try it out quickly, you can set up CODE docker image with file sharing integration in less than 5 minutes in a very basic way, following these instructions: [quick tryout with ownCloud](https://www.collaboraoffice.com/code/quick-tryout-owncloud-docker/) or [quick tryout with Nextcloud](https://www.collaboraoffice.com/code/quick-tryout-nextcloud-docker/).
+
+The following steps will download the Collabora Online docker, make sure to replace "cloud.nextcloud.com" with the host that your own Nextcloud runs on. Also make sure to escape all dots with double backslashes (\), since this string will be evaluated as a regular expression (and your bash 'eats' the first backslash.) If you want to use the docker container with more than one Nextcloud, you'll need to use 'domain=cloud\\.nextcloud\\.com\|second\\.nexcloud\\.com' instead. (All hosts are separated by \|.)
+
+    docker pull collabora/code
+    docker run -t -d -p 127.0.0.1:9980:9980 \
+        -e 'domain=cloud\\.nextcloud\\.com' \
+        --restart always \
+        --cap-add MKNOD \
+        collabora/code
+			
+Optionally, you can select the dictionaries you want with:
+
+            docker run -t -d -p 127.0.0.1:9980:9980 -e 'domain=cloud\\.nextcloud\\.com' -e 'dictionaries=de en es ..' --restart always --cap-add MKNOD collabora/code
+            
+This way you are not only limited to German, English, Italian, French and Spanish.
+
+That will be enough. Once you have done that the server will listen on "localhost:9980". Now we just need to configure the locally installed Apache reverse proxy.
+
+### Setup using packages
+
+As an alternative to Docker image, Collabora provide native Linux packages for selected Linux distributions. If you have Debian 8, Debian 9, Ubuntu 16.04, Ubuntu 18.04, CentOS 7 or openSUSE Leap, please read the [CODE Linux packages](https://www.collaboraoffice.com/code/linux-packages/) page.
+
+
+## Setting up a reverse proxy and SSL
+
+It is highly recommended to set up a reverse proxy in front of CODE, either you run CODE from Docker, or you use native packages. It is easy, and this way CODE can be reached on standard HTTP or HTTPS ports. We provide sample configuration files for Apache2 and Nginx. If you want SSL, we recommend certificates from [Let's Encrypt](https://certbot.eff.org/).
+
+-   [Setting up Apache 2 reverse proxy](https://www.collaboraoffice.com/code/apache-reverse-proxy/)
+-   [Setting up Nginx reverse proxy](https://www.collaboraoffice.com/code/nginx-reverse-proxy/)
+
+Now you can give `https://collabora.example.com` as the WOPI URL in your preferred File Sync and Share solution. See below for specific examples.
+
+
+### Apache guide
+
+On a recent Ubuntu or Debian this should be possible using:
+
+    apt-get install apache2
+    a2enmod proxy
+    a2enmod proxy_wstunnel
+    a2enmod proxy_http
+    a2enmod ssl
+
+Afterward, configure one VirtualHost properly to proxy the traffic. For security reason we recommend to use a subdomain such as office.nextcloud.com instead of running on the same domain. An example config can be found below:
+
+				
+    <VirtualHost *:443>
+    ServerName office.nextcloud.com:443
+
+    # SSL configuration, you may want to take the easy route instead and use Lets Encrypt!
+    SSLEngine on
+    SSLCertificateFile /path/to/signed_certificate
+    SSLCertificateChainFile /path/to/intermediate_certificate
+    SSLCertificateKeyFile /path/to/private/key
+    SSLProtocol             all -SSLv2 -SSLv3
+    SSLCipherSuite ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS
+    SSLHonorCipherOrder     on
+
+    # Encoded slashes need to be allowed
+    AllowEncodedSlashes NoDecode
+
+    # Container uses a unique non-signed certificate
+    SSLProxyEngine On
+    SSLProxyVerify None
+    SSLProxyCheckPeerCN Off
+    SSLProxyCheckPeerName Off
+
+    # keep the host
+    ProxyPreserveHost On
+
+    # static html, js, images, etc. served from loolwsd
+    # loleaflet is the client part of LibreOffice Online
+    ProxyPass           /loleaflet https://127.0.0.1:9980/loleaflet retry=0
+    ProxyPassReverse    /loleaflet https://127.0.0.1:9980/loleaflet
+
+    # WOPI discovery URL
+    ProxyPass           /hosting/discovery https://127.0.0.1:9980/hosting/discovery retry=0
+    ProxyPassReverse    /hosting/discovery https://127.0.0.1:9980/hosting/discovery
+
+    # Main websocket
+    ProxyPassMatch "/lool/(.*)/ws$" wss://127.0.0.1:9980/lool/$1/ws nocanon
+
+    # Admin Console websocket
+    ProxyPass   /lool/adminws wss://127.0.0.1:9980/lool/adminws
+
+    # Download as, Fullscreen presentation and Image upload operations
+    ProxyPass           /lool https://127.0.0.1:9980/lool
+    ProxyPassReverse    /lool https://127.0.0.1:9980/lool
+
+    # Endpoint with information about availability of various features
+    ProxyPass           /hosting/capabilities https://127.0.0.1:9980/hosting/capabilities retry=0
+    ProxyPassReverse    /hosting/capabilities https://127.0.0.1:9980/hosting/capabilities
+    </VirtualHost>
+			
+After configuring these do restart your apache using /etc/init.d/apache2 restart.
+
+## Configure the app in Nextcloud
+
+Go to the Apps section and choose "Office & text"
+Install the "Collabora Online app"
+Admin -> Collabora Online -> Specify the server you have setup before (e.g. "https://office.nextcloud.com")
+
+Congratulations, your Nextcloud has Collabora Online Office integrated!
+
+## Updating the docker image
+
+Occasionally, new versions of this docker image are released with security and feature updates. We will of course let you know when that happens! This is how you upgrade to a new version:
+
+grab new docker image:
+
+    docker pull collabora/code
+
+List docker images:
+
+    docker ps
+
+from the output you can glean the Container ID of your Collabora Online docker image.
+stop and remove the Collabora Online docker image:
+
+    docker stop CONTAINER_ID
+    docker rm CONTAINER_ID
+
+start the new image:
+
+    docker run -t -d -p 127.0.0.1:9980:9980 -e 'domain=cloud\\.nextcloud\\.com' --restart always --cap-add MKNOD collabora/code
+
+Enjoy!

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,0 +1,32 @@
+
+## Troubleshooting
+
+Some common issues:
+
+### Can't configure the URL in the Admin panel.
+
+This is most likely caused by the Documents app being enabled. Disable it and you can set the URL.
+
+### I get connection errors when trying to open documents
+
+
+Be sure to check the error log from docker (docker logs id-of-your-instance). If the logs note something like:
+No acceptable WOPI hosts found matching the target host [YOUR NEXTCLOUD DOMAIN] in config.
+Unauthorized WOPI host. Please try again later and report to your administrator if the issue persists.
+you might have started the docker container with the wrong URL. Be sure to triplecheck that you start it with the URL of your Nextcloud server, not the server where Collabora Online runs on.
+
+### Connection is not allowed errors.
+
+It is possible your firewall is blocking connections. Try to start docker after you started the firewall, it makes changes to your iptables to enable Collabora Online to function.
+
+### We are sorry, this is an unexpected connection error. Please try again. error.
+
+The Collabora Online app doesn't work at the moment, if you enable it only for certain groups. Remove the group filter in the App section.
+
+### Collabora Online doesn't handle my 100 users.
+
+This docker image is designed for home usage with a limited numbers of users and open documents. If you need a more scalable solution, consider a support subscription for a reliable, business-ready online office experience.
+
+#### Collabora Online doesn't work with Encryption.
+
+Yes, this is currently unsupported. Find more questions and answers in the discussion thread on the forums and post a new topic in the Collabora category if you have unanswered questions!

--- a/docs/mobile_flow.md
+++ b/docs/mobile_flow.md
@@ -41,6 +41,21 @@ This will make sure the assets is added to the document.
 
 ### share()
 
-opens the share sidebar for the current file
+opens the share sidebar or dialog for the current file
 
+### documentLoaded()
+
+This method is called once the Collabora has loaded and can take over the loading screen
+
+### paste()
+
+This is triggered to enable integrating applications passing though the clipboard content properly
+
+### fileRename()
+
+Notifies the integrating application that the current file has been renamed.
+
+### downloadAs()
+
+Hands over the link to download a file to the integrating application
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -33,52 +33,6 @@ In the Collabora user settings the user can select a folder from where to load
 templates. This can be any folder the user has access to. So users can share template
 folders among each other.
 
-## API
+### Replacing empty templates
 
-### Listing templates
-
-Send a GET to:
-
-`<server>/ocs/v2.php/apps/richdocuments/api/v1/templates/<type>`
-
-Here type can be:
-
-* document
-* spreadsheet
-* presentation
-
-This returns a list of templates with
-
-* id
-* name
-* link to preview
-* extension
-
-### Template previews
-
-Send a GET to:
-
-`<server>/apps/richdocuments/templates/<id>`
-
-Where `id` is the id of the template obtained in the listing. This returns back
-an image (jpeg or png). For displaying.
-
-### Creating document based on a template
-
-Send a POST to
-
-`<server>/ocs/v2.php/apps/richdocuments/api/v1/templates/new`
-
-with:
-* `path`: the full path relative to the user where to create the document, including new file name
-* `template`: the template id you want to create
-
-## Web frontend
-
-When clicking on a new document a selection popup appears listing the
-available templates.
-
-The user can select a template, possible change the name and create it.
-
-This is similar to the current flow with the difference that the user can now
-select a template.
+Empty template files can be replaced the existing files in `appdata_[instanceid]/richdocuments/empty_templates/`. The files can be reverted to the templates shipped with the release by running the  `occ richdocuments:update-empty-templates` command.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: Collabora Online in Nextcloud
+nav:
+    - Home: index.md
+    - Installation guide: install.md
+    - App settings: app_settings.md
+    - templates.md
+    - API reference:
+        - api_templates.md
+        - mobile_editor.md
+        - asset_api.md
+        - mobile_flow.md
+    - Troubleshooting: issues.md
+theme: readthedocs
+extra_css: 
+    - custom.css


### PR DESCRIPTION
Moving setup documentation to the repo as discussed in https://github.com/nextcloud/nextcloud.com/issues/1110 and prepare to build all documentation markdown files with mkdocs, so we can just let readthedocs publish them.

@tobiasKaminsky We actually link to the Collabora website for the reverse proxy setup, so we don't need to maintain that ourselves: 

-   [Setting up Apache 2 reverse proxy](https://www.collaboraoffice.com/code/apache-reverse-proxy/)
-   [Setting up Nginx reverse proxy](https://www.collaboraoffice.com/code/nginx-reverse-proxy/)

