### PR TITLE
Add frontend hooks and expose config/open methods

### DIFF
--- a/css/viewer.scss
+++ b/css/viewer.scss
@@ -124,8 +124,15 @@
 	padding-left: 12px;
 }
 
-#currentVersion li {
+#currentVersion li,
+#lastSavedVersion li {
 	border-bottom: 1px solid rgba(100,100,100,.1);
+
+	.version-container .downloadVersion {
+		display: flex;
+		flex-direction: column;
+		margin-left: 12px;
+	}
 }
 
 @import 'templatePicker';

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -1,0 +1,120 @@
+## Frontend integration API
+
+### Configuration
+
+The Collabora configuration for creating new files with their mietype and extension per file type is exposed to `OCA.RichDocuments.config.create`.
+
+```json
+{
+  "create": {
+    "document": {
+      "extension": "odt",
+      "mime": "application/vnd.oasis.opendocument.text"
+    },
+    "spreadsheet": {
+      "extension": "ods",
+      "mime": "application/vnd.oasis.opendocument.spreadsheet"
+    },
+    "presentation": {
+      "extension": "odp",
+      "mime": "application/vnd.oasis.opendocument.presentation"
+    }
+  }
+}
+```
+
+### Open viewer
+
+
+The following two methods are exposed in order to manually trigger the Collabora viewer opening a file:
+
+#### Open an existing file
+
+`OCA.RichDocuments.open(params)` will open the Collabora view for an existing file.
+
+Params requires the following properties:
+- fileId: (string) internal file id
+- path: (string) full path to the file
+- shareOwnerId: (string) uid of share owner for shared files
+- fileList: (object) optional file list object (see limitations below when not passing it)
+
+
+```javascript
+OCA.RichDocuments.open({
+	fileId: 1234,
+	path: '/path/to/file.odt',
+	shareOwnerId: 'admin@nextcloud',
+    fileList: FileList
+})
+```
+
+#### Create a new file from a template
+
+`OCA.RichDocuments.openWithTemplate(params)` provides a method to open a Collabora view for a file that should be created from a template. Calling this method requires the file to be already present on the filesytem and shown in the file list.
+
+Params requires the following properties:
+- fileId: (string) internal file id
+- path: (string) full path to the file
+- shareOwnerId: (string) uid of share owner for shared files
+- fileList: (object) optional file list object (see limitations below when not passing it)
+- templateId: (string) file id of the template
+
+```javascript
+OCA.RichDocuments.openWithTemplate({
+	fileId: -1,
+	path: '/path/to/file.odt,
+	templateId: templateId
+})
+```
+
+### Handlers
+
+Handlers provide a way to hook into the files app integration in order to inject custom behaviour during certain actions.
+
+The return value indicates if the default behavour should be blocked (true) or still be executed (false).
+
+The following handlers are currently supported:
+
+- initAfterReady: will be called once the Collabora frame has been loaded
+- close: will be called after the Collabora view has been closed
+- share: will be called before the default share action is triggered
+- rename: will be called before the default rename action is triggered (the new filename is available as a property of the filesAppIntegration parameter)
+- showRevHistory: will be called before the default show revision history action is triggered
+
+The filesAppIntegration parameter can be used to extract the current context of the edited file. The following properties are available for that:
+- fileName
+- fileId
+
+The following code shows an example on how to register the different handlers:
+
+```javascript
+(function() {
+
+	OCA.RichDocuments.FilesAppIntegration.registerHandler('initAfterReady', (filesAppIntegration) => {
+		console.debug('called initAfterReady', filesAppIntegration)
+		return false
+	})
+
+	OCA.RichDocuments.FilesAppIntegration.registerHandler('close', (filesAppIntegration) => {
+		console.debug('called close', filesAppIntegration)
+		return false
+	})
+
+	OCA.RichDocuments.FilesAppIntegration.registerHandler('share', (filesAppIntegration) => {
+		console.debug('called share', filesAppIntegration)
+		return false
+	})
+
+	OCA.RichDocuments.FilesAppIntegration.registerHandler('rename', (filesAppIntegration) => {
+		console.debug('called rename', filesAppIntegration)
+		return false
+	})
+
+
+	OCA.RichDocuments.FilesAppIntegration.registerHandler('showRevHistory', (filesAppIntegration) => {
+		console.debug('called showRevHistory', filesAppIntegration)
+		return false
+	})
+
+})()
+```

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -89,9 +89,13 @@ The following handlers are currently supported:
 
 - initAfterReady: will be called once the Collabora frame has been loaded
 - close: will be called after the Collabora view has been closed
+- saveAs: will be called on a save_as response by collabora
 - share: will be called before the default share action is triggered
 - rename: will be called before the default rename action is triggered (the new filename is available as a property of the filesAppIntegration parameter)
 - showRevHistory: will be called before the default show revision history action is triggered
+- insertGraphic: will be called when an image from the Nextcloud storage should be inserted
+  - Arguments
+    - insertFileFromPath(path): Callback to trigger the actual inserting of the graphic from an absolute file path
 
 In addition, the following handlers can be used to overwrite the handling of file actions that are rendered in the Nextcloud header bar:
 - actionDetails
@@ -101,6 +105,10 @@ In addition, the following handlers can be used to overwrite the handling of fil
 The filesAppIntegration parameter can be used to extract the current context of the edited file. The following properties are available for that:
 - fileName
 - fileId
+
+The callback function of each handler will be called with the following parameters:
+- filesAppIntegration: current instance of the filesAppIntegration object
+- arguments (optional): see list of supported handlers for details
 
 The following code shows an example on how to register the different handlers:
 
@@ -132,6 +140,12 @@ The following code shows an example on how to register the different handlers:
 		console.debug('called showRevHistory', filesAppIntegration)
 		return false
 	})
+
+    OCA.RichDocuments.FilesAppIntegration.registerHandler('insertGraphic', (filesAppIntegration, { insertFileFromPath }) => {
+        const path = prompt('Enter a file path', '')
+        insertFileFromPath(path)
+        return true
+    })
 
 })()
 ```

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -35,15 +35,15 @@ The following two methods are exposed in order to manually trigger the Collabora
 Params requires the following properties:
 - fileId: (string) internal file id
 - path: (string) full path to the file
-- shareOwnerId: (string) uid of share owner for shared files
-- fileList: (object) optional file list object (see limitations below when not passing it)
+- fileModel: (OCA.Files.FileInfoModel) model of the file that will be opened
+- fileList: (object) optional file list object
 
 
 ```javascript
 OCA.RichDocuments.open({
 	fileId: 1234,
 	path: '/path/to/file.odt',
-	shareOwnerId: 'admin@nextcloud',
+	fileModel: new OCA.Files.FileInfoModel({...})
     fileList: FileList
 })
 ```
@@ -55,15 +55,27 @@ OCA.RichDocuments.open({
 Params requires the following properties:
 - fileId: (string) internal file id
 - path: (string) full path to the file
-- shareOwnerId: (string) uid of share owner for shared files
-- fileList: (object) optional file list object (see limitations below when not passing it)
 - templateId: (string) file id of the template
+- fileModel: (OCA.Files.FileInfoModel) model of the file that will be opened
+- fileList: (object) optional file list object
 
 ```javascript
 OCA.RichDocuments.openWithTemplate({
 	fileId: -1,
 	path: '/path/to/file.odt,
-	templateId: templateId
+	templateId: templateId,
+    fileModel: new OCA.Files.FileInfoModel({...})
+})
+```
+
+Changes to the fileModel should be propagated by triggering a backbone `change` event:
+
+```javascript
+window.OCA.RichDocuments.FilesAppIntegration.registerHandler('actionFavorite', (filesAppIntegration) => {
+    // custom logic here
+    // make sure to trigger a change on the file info model object like this:
+    filesAppIntegration.getFileModel().trigger('change', newFileModel)
+    return true
 })
 ```
 
@@ -80,6 +92,11 @@ The following handlers are currently supported:
 - share: will be called before the default share action is triggered
 - rename: will be called before the default rename action is triggered (the new filename is available as a property of the filesAppIntegration parameter)
 - showRevHistory: will be called before the default show revision history action is triggered
+
+In addition, the following handlers can be used to overwrite the handling of file actions that are rendered in the Nextcloud header bar:
+- actionDetails
+- actionDownload
+- actionFavorite
 
 The filesAppIntegration parameter can be used to extract the current context of the edited file. The following properties are available for that:
 - fileName

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -11,6 +11,7 @@
 
 namespace OCA\Richdocuments\Controller;
 
+use OCA\Richdocuments\Events\BeforeFederationRedirectEvent;
 use OCA\Richdocuments\Service\FederationService;
 use OCA\Richdocuments\TokenManager;
 use \OCP\AppFramework\Controller;
@@ -198,6 +199,15 @@ class DocumentController extends Controller {
 						'&richdocuments_open=' . $item->getName() .
 						'&richdocuments_fileId=' . $fileId .
 						'&richdocuments_remote_access=' . $remote;
+
+						$event = new BeforeFederationRedirectEvent(
+							$item, $relative, $remote
+						);
+						$eventDispatcher = \OC::$server->getEventDispatcher();
+						$eventDispatcher->dispatch(BeforeFederationRedirectEvent::class, $event);
+						if ($event->getRedirectUrl()) {
+							$url = $event->getRedirectUrl();
+						}
 					return new RedirectResponse($url);
 				}
 				$this->logger->warning('Failed to connect to remote collabora instance for ' . $fileId);

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -194,9 +194,10 @@ class DocumentController extends Controller {
 				$remoteCollabora = $this->federationService->getRemoteCollaboraURL($remote);
 				if ($remoteCollabora !== '') {
 					$absolute = $item->getParent()->getPath();
-					$relative = $folder->getRelativePath($absolute);
-					$url = '/index.php/apps/files?dir=' . $relative .
-						'&richdocuments_open=' . $item->getName() .
+					$relativeFolderPath = $folder->getRelativePath($absolute);
+					$relativeFilePath = $folder->getRelativePath($item->getPath());
+					$url = '/index.php/apps/files/?dir=' . $relativeFolderPath .
+						'&richdocuments_open=' . $relativeFilePath .
 						'&richdocuments_fileId=' . $fileId .
 						'&richdocuments_remote_access=' . $remote;
 

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -62,9 +62,11 @@ class FederationController extends OCSController {
 	 * @NoCSRFRequired
 	 */
 	public function index() {
-		return new DataResponse([
+		$response = new DataResponse([
 			'wopi_url' => $this->config->getAppValue('richdocuments', 'wopi_url')
 		]);
+		$response->setHeaders(['X-Frame-Options' => 'ALLOW']);
+		return $response;
 	}
 
 	/**

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -393,7 +393,7 @@ class WopiController extends Controller {
 		}
 
 		// Set the user to register the change under his name
-		$this->userScopeService->setUserScope($wopi->getEditorUid());
+		$this->userScopeService->setUserScope($wopi->getUserForFileAccess());
 		$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
 
 		try {

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -161,6 +161,7 @@ class WopiController extends Controller {
 		$guestUserId = 'Guest-' . \OC::$server->getSecureRandom()->generate(8);
 		$user = $this->userManager->get($wopi->getEditorUid());
 		$userDisplayName = $user !== null && !$isPublic ? $user->getDisplayName() : $wopi->getGuestDisplayname();
+		$isVersion = $version !== '0';
 		$response = [
 			'BaseFileName' => $file->getName(),
 			'Size' => $file->getSize(),
@@ -174,10 +175,10 @@ class WopiController extends Controller {
 			'UserCanNotWriteRelative' => \OC::$server->getEncryptionManager()->isEnabled() || $isPublic,
 			'PostMessageOrigin' => $wopi->getServerHost(),
 			'LastModifiedTime' => Helper::toISO8601($file->getMTime()),
-			'SupportsRename' => true,
-			'UserCanRename' => !$isPublic,
+			'SupportsRename' => !$isVersion,
+			'UserCanRename' => !$isPublic && !$isVersion,
 			'EnableInsertRemoteImage' => true,
-			'EnableShare' => true,
+			'EnableShare' => $file->isShareable() && !$isVersion,
 			'HideUserList' => 'desktop',
 			'DisablePrint' => $wopi->getHideDownload(),
 			'DisableExport' => $wopi->getHideDownload(),

--- a/lib/Events/BeforeFederationRedirectEvent.php
+++ b/lib/Events/BeforeFederationRedirectEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OCA\Richdocuments\Events;
+
+
+use OCP\Files\Node;
+use Symfony\Component\EventDispatcher\Event;
+
+class BeforeFederationRedirectEvent extends Event {
+
+    /** @var Node */
+    private $node;
+    /** @var string */
+    private $relativePath;
+    /** @var string|null */
+    private $redirectUrl = null;
+    /** @var string */
+    private $remote;
+
+    public function __construct($node, $relativePath, $remote) {
+        $this->node = $node;
+        $this->relativePath = $relativePath;
+        $this->remote = $remote;
+    }
+
+    public function getRelativePath() {
+        return $this->relativePath;
+    }
+
+    public function getNode() {
+        return $this->node;
+    }
+
+    public function getRemote() {
+        return $this->remote;
+    }
+
+    public function setRedirectUrl($redirectUrl) {
+        $this->redirectUrl = $redirectUrl;
+    }
+
+    public function getRedirectUrl() {
+        return $this->redirectUrl;
+    }
+
+}

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -60,10 +60,14 @@ class FederationService {
 		} catch (QueryException $e) {}
 	}
 
+	/**
+	 * @param $remote
+	 * @return string
+	 * @throws \Exception
+	 */
 	public function getRemoteCollaboraURL($remote) {
 		if ($this->trustedServers === null || !$this->trustedServers->isTrustedServer($remote)) {
-			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote . ' - Remote is not a trusted server');
-			return '';
+			throw new \Exception('Unable to determine collabora URL of remote server ' . $remote . ' - Remote is not a trusted server');
 		}
 		if ($remoteCollabora = $this->cache->get('richdocuments_remote/' . $remote)) {
 			return $remoteCollabora;

--- a/src/document.js
+++ b/src/document.js
@@ -395,7 +395,7 @@ const documentsMain = {
 							t('richdocuments', 'Save As'),
 							function(result, value) {
 								if (result === true && value) {
-									PostMessages.sendWOPIPostMessage('loolframe', 'Action_SaveAs', { 'Filename': value })
+									PostMessages.sendWOPIPostMessage('loolframe', 'Action_SaveAs', { Filename: value, Notify: true })
 								}
 							},
 							true,

--- a/src/document.js
+++ b/src/document.js
@@ -266,6 +266,10 @@ const documentsMain = {
 							PostMessages.sendWOPIPostMessage('loolframe', 'Hide_Menu_Item', { id: 'shareas' })
 						}
 
+						if (Config.get('userId') === null) {
+							PostMessages.sendWOPIPostMessage('loolframe', 'Hide_Menu_Item', { id: 'insertgraphicremote' })
+						}
+
 						break
 					case 'Failed':
 						// Loading failed but editor shows the error

--- a/src/files.js
+++ b/src/files.js
@@ -4,6 +4,7 @@ import Config from './services/config'
 import Types from './helpers/types'
 import FilesAppIntegration from './view/FilesAppIntegration'
 import '../css/viewer.scss'
+import { splitPath } from './helpers'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
 const PostMessages = new PostMessageService({
@@ -44,7 +45,7 @@ const odfViewer = {
 	excludeMimeFromDefaultOpen: OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen,
 	hideDownloadMimes: ['image/jpeg', 'image/svg+xml', 'image/cgm', 'image/vnd.dxf', 'image/x-emf', 'image/x-wmf', 'image/x-wpg', 'image/x-freehand', 'image/bmp', 'image/png', 'image/gif', 'image/tiff', 'image/jpg', 'image/jpeg', 'text/plain', 'application/pdf'],
 
-	register() {
+	registerFileActions() {
 		const EDIT_ACTION_NAME = 'Edit with ' + OC.getCapabilities().richdocuments.productName
 		for (let mime of odfViewer.supportedMimes) {
 			OCA.Files.fileActions.register(
@@ -52,7 +53,11 @@ const odfViewer = {
 				EDIT_ACTION_NAME,
 				OC.PERMISSION_READ,
 				OC.imagePath('core', 'actions/rename'),
-				this.onEdit,
+				(fileName, context) => {
+					const fileModel = context.fileList.findFile(fileName)
+					const shareOwnerId = fileModel.shareOwnerId
+					return this.onEdit(fileName, { ...context, shareOwnerId })
+				},
 				t('richdocuments', 'Edit with {productName}', { productName: OC.getCapabilities().richdocuments.productName })
 			)
 			if (odfViewer.excludeMimeFromDefaultOpen.indexOf(mime) === -1 || isDownloadHidden) {
@@ -82,18 +87,12 @@ const odfViewer = {
 			return
 		}
 		odfViewer.open = true
-		let fileList = null
 		if (context) {
-			fileList = context.fileList
 			var fileDir = context.dir
 			var fileId = context.fileId || context.$file.attr('data-id')
 			var templateId = context.templateId
-			if (context.fileList) {
-				context.fileList.setViewerMode(true)
-				context.fileList.setPageTitle(fileName)
-				context.fileList.showMask()
-			}
 		}
+		FilesAppIntegration.startLoading()
 		odfViewer.receivedLoading = false
 
 		let documentUrl = getDocumentUrlForFile(fileDir, fileId)
@@ -125,14 +124,12 @@ const odfViewer = {
 
 		}
 
-		const reloadForFederationCSP = (fileName) => {
+		const reloadForFederationCSP = (fileName, shareOwnerId) => {
 			const preloadId = Preload.open ? parseInt(Preload.open.id) : -1
-			const fileModel = fileList.findFile(fileName)
-			const shareOwnerId = fileModel.shareOwnerId
 			if (typeof shareOwnerId !== 'undefined') {
 				const lastIndex = shareOwnerId.lastIndexOf('@')
 				// only redirect if remote file, not opened though reload and csp blocks the request
-				if (shareOwnerId.substr(lastIndex).indexOf('/') !== -1 && fileModel.id !== preloadId) {
+				if (shareOwnerId.substr(lastIndex).indexOf('/') !== -1 && fileId !== preloadId) {
 					canAccessCSP('https://' + shareOwnerId.substr(lastIndex) + '/status.php', () => {
 						window.location = OC.generateUrl('/apps/richdocuments/open?fileId=' + fileId)
 					})
@@ -142,7 +139,7 @@ const odfViewer = {
 		}
 
 		if (context) {
-			reloadForFederationCSP(fileName)
+			reloadForFederationCSP(fileName, context.shareOwnerId)
 		}
 
 		$('head').append($('<link rel="stylesheet" type="text/css" href="' + OC.filePath('richdocuments', 'css', 'mobile.css') + '"/>'))
@@ -181,7 +178,6 @@ const odfViewer = {
 			FilesAppIntegration.init({
 				fileName,
 				fileId,
-				fileList,
 				sendPostMessage: (msgId, values) => {
 					PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, msgId, values)
 				}
@@ -283,7 +279,7 @@ const odfViewer = {
 
 					$.post(
 						OC.generateUrl('apps/richdocuments/ajax/documents/create'),
-						{ mimetype: mimetype, filename: filename, dir: $('#dir').val() },
+						{ mimetype: mimetype, filename: filename, dir: document.getElementById('dir').value },
 						function(response) {
 							if (response && response.status === 'success') {
 								FileList.add(response.data, { animate: true, scrollTo: true })
@@ -299,15 +295,15 @@ const odfViewer = {
 					filename = FileList.getUniqueName(filename)
 					$.post(
 						OC.generateUrl('apps/richdocuments/ajax/documents/create'),
-						{ mimetype: mimetype, filename: filename, dir: $('#dir').val() },
+						{ mimetype: mimetype, filename: filename, dir: document.getElementById('dir').value },
 						function(response) {
 							if (response && response.status === 'success') {
 								FileList.add(response.data, { animate: false, scrollTo: false })
-								odfViewer.onEdit(filename, {
+								const path = document.getElementById('dir').value + '/' + filename
+								OCA.RichDocuments.openWithTemplate({
 									fileId: -1,
-									dir: $('#dir').val(),
-									templateId: templateId,
-									fileList: FileList
+									path,
+									templateId: templateId
 								})
 							} else {
 								OC.dialogs.alert(response.data.message, t('core', 'Could not create file'))
@@ -404,8 +400,7 @@ const odfViewer = {
 			FileList.$fileList.one('updated', function() {
 				odfViewer.onEdit(Preload.open.filename, {
 					fileId: Preload.open.id,
-					dir: document.getElementById('dir').value,
-					fileList: FileList
+					dir: document.getElementById('dir').value
 				})
 			})
 		}
@@ -418,6 +413,23 @@ Config.update('ooxml', settings['doc_format'] === 'ooxml')
 window.OCA.RichDocuments = {
 	config: {
 		create: Types.getFileTypes()
+	},
+	open: ({ path, fileId, shareOwnerId }) => {
+		const [dir, file] = splitPath(path)
+		odfViewer.onEdit(file, {
+			fileId,
+			dir,
+			shareOwnerId
+		})
+	},
+	openWithTemplate: ({ path, fileId, templateId, shareOwnerId }) => {
+		const [dir, file] = splitPath(path)
+		odfViewer.onEdit(file, {
+			fileId,
+			dir,
+			templateId,
+			shareOwnerId
+		})
 	}
 }
 
@@ -432,8 +444,8 @@ $(document).ready(function() {
 			odfViewer.supportedMimes.push('text/plain')
 		}
 
+		odfViewer.registerFileActions()
 		odfViewer.registerFilesMenu()
-		odfViewer.register()
 	}
 
 	// Open documents if a public page is opened for a supported mimetype

--- a/src/files.js
+++ b/src/files.js
@@ -161,7 +161,8 @@ const odfViewer = {
 			FilesAppIntegration.init({
 				fileName,
 				fileId,
-				fileList: context.fileList,
+				fileList: context ? context.fileList : undefined,
+				fileModel: context ? context.fileModel : undefined,
 				sendPostMessage: (msgId, values) => {
 					PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, msgId, values)
 				}

--- a/src/files.js
+++ b/src/files.js
@@ -304,6 +304,9 @@ $(document).ready(function() {
 		case 'File_Rename':
 			FilesAppIntegration.rename(args.NewName)
 			break
+		case 'Action_Save_Resp':
+			FilesAppIntegration.saveAs()
+			break
 		case 'close':
 			odfViewer.onClose()
 			break

--- a/src/files.js
+++ b/src/files.js
@@ -208,21 +208,23 @@ window.OCA.RichDocuments = {
 	config: {
 		create: Types.getFileTypes()
 	},
-	open: ({ path, fileId, shareOwnerId }) => {
+	open: ({ path, fileId, shareOwnerId, fileList }) => {
 		const [dir, file] = splitPath(path)
 		odfViewer.onEdit(file, {
 			fileId,
 			dir,
-			shareOwnerId
+			shareOwnerId,
+			fileList
 		})
 	},
-	openWithTemplate: ({ path, fileId, templateId, shareOwnerId }) => {
+	openWithTemplate: ({ path, fileId, templateId, shareOwnerId, fileList }) => {
 		const [dir, file] = splitPath(path)
 		odfViewer.onEdit(file, {
 			fileId,
 			dir,
 			templateId,
-			shareOwnerId
+			shareOwnerId,
+			fileList
 		})
 	},
 	FilesAppIntegration: {

--- a/src/files.js
+++ b/src/files.js
@@ -210,23 +210,25 @@ window.OCA.RichDocuments = {
 	config: {
 		create: Types.getFileTypes()
 	},
-	open: ({ path, fileId, shareOwnerId, fileList }) => {
+	open: ({ path, fileId, shareOwnerId, fileList = {}, fileModel }) => {
 		const [dir, file] = splitPath(path)
 		odfViewer.onEdit(file, {
 			fileId,
 			dir,
 			shareOwnerId,
-			fileList
+			fileList,
+			fileModel
 		})
 	},
-	openWithTemplate: ({ path, fileId, templateId, shareOwnerId, fileList }) => {
+	openWithTemplate: ({ path, fileId, templateId, shareOwnerId, fileList = {}, fileModel }) => {
 		const [dir, file] = splitPath(path)
 		odfViewer.onEdit(file, {
 			fileId,
 			dir,
 			templateId,
 			shareOwnerId,
-			fileList
+			fileList,
+			fileModel
 		})
 	},
 	FilesAppIntegration: {

--- a/src/files.js
+++ b/src/files.js
@@ -93,27 +93,31 @@ const odfViewer = {
 		const canAccessCSP = (url, callback) => {
 			let canEmbed = false
 			let frame = document.createElement('iframe')
-			frame.setAttribute('src', url)
-			frame.setAttribute('onload', () => {
+			frame.style.display = 'none'
+			frame.onload = () => {
 				canEmbed = true
-			})
+			}
 			document.body.appendChild(frame)
+			frame.setAttribute('src', url)
 			setTimeout(() => {
 				if (!canEmbed) {
 					callback()
 				}
 				document.body.removeChild(frame)
-			}, 50)
+			}, 1000)
 
 		}
 
+		// FIXME: Once Nextcloud 16 is minimum requirement we can just pass the allowed domains to initial state
+		// to check then if they are set properly
 		const reloadForFederationCSP = (fileName, shareOwnerId) => {
 			const preloadId = Preload.open ? parseInt(Preload.open.id) : -1
 			if (typeof shareOwnerId !== 'undefined') {
 				const lastIndex = shareOwnerId.lastIndexOf('@')
 				// only redirect if remote file, not opened though reload and csp blocks the request
 				if (shareOwnerId.substr(lastIndex).indexOf('/') !== -1 && fileId !== preloadId) {
-					canAccessCSP('https://' + shareOwnerId.substr(lastIndex) + '/status.php', () => {
+					canAccessCSP('https://' + shareOwnerId.substr(lastIndex) + '/ocs/v2.php/apps/richdocuments/api/v1/federation', () => {
+						console.debug('Cannot load federated instance though CSP, navigating to ', OC.generateUrl('/apps/richdocuments/open?fileId=' + fileId))
 						window.location = OC.generateUrl('/apps/richdocuments/open?fileId=' + fileId)
 					})
 				}

--- a/src/files.js
+++ b/src/files.js
@@ -161,6 +161,7 @@ const odfViewer = {
 			FilesAppIntegration.init({
 				fileName,
 				fileId,
+				fileList: context.fileList,
 				sendPostMessage: (msgId, values) => {
 					PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, msgId, values)
 				}

--- a/src/files.js
+++ b/src/files.js
@@ -430,6 +430,9 @@ window.OCA.RichDocuments = {
 			templateId,
 			shareOwnerId
 		})
+	},
+	FilesAppIntegration: {
+		registerHandler: FilesAppIntegration.registerHandler.bind(FilesAppIntegration)
 	}
 }
 
@@ -484,9 +487,7 @@ $(document).ready(function() {
 			})
 			break
 		case 'File_Rename':
-			FileList.reload()
-			OC.Apps.hideAppSidebar()
-			FilesAppIntegration.fileName = args.NewName
+			FilesAppIntegration.rename(args.NewName)
 			break
 		case 'close':
 			odfViewer.onClose()
@@ -528,5 +529,4 @@ $(document).ready(function() {
 		}
 
 	})
-	window.FilesAppIntegration = FilesAppIntegration
 })

--- a/src/files.js
+++ b/src/files.js
@@ -210,23 +210,23 @@ window.OCA.RichDocuments = {
 	config: {
 		create: Types.getFileTypes()
 	},
-	open: ({ path, fileId, shareOwnerId, fileList = {}, fileModel }) => {
+	open: ({ path, fileId, fileModel, fileList = {} }) => {
 		const [dir, file] = splitPath(path)
 		odfViewer.onEdit(file, {
 			fileId,
 			dir,
-			shareOwnerId,
+			shareOwnerId: fileModel.get('shareOwnerId'),
 			fileList,
 			fileModel
 		})
 	},
-	openWithTemplate: ({ path, fileId, templateId, shareOwnerId, fileList = {}, fileModel }) => {
+	openWithTemplate: ({ path, fileId, templateId, fileModel, fileList = {} }) => {
 		const [dir, file] = splitPath(path)
 		odfViewer.onEdit(file, {
 			fileId,
 			dir,
 			templateId,
-			shareOwnerId,
+			shareOwnerId: fileModel.get('shareOwnerId'),
 			fileList,
 			fileModel
 		})

--- a/src/files.js
+++ b/src/files.js
@@ -1,4 +1,4 @@
-import { getDocumentUrlFromTemplate, getDocumentUrlForPublicFile, getDocumentUrlForFile, getSearchParam } from './helpers/url'
+import { getDocumentUrlFromTemplate, getDocumentUrlForPublicFile, getDocumentUrlForFile } from './helpers/url'
 import PostMessageService from './services/postMessage'
 import Config from './services/config'
 import Preload from './services/preload'
@@ -198,7 +198,7 @@ const odfViewer = {
 		OC.Util.History.replaceState()
 
 		FilesAppIntegration.close()
-	},
+	}
 }
 
 const settings = OC.getCapabilities()['richdocuments']['config'] || {}

--- a/src/files.js
+++ b/src/files.js
@@ -257,17 +257,11 @@ $(document).ready(function() {
 
 	// Open the template picker if there was a create parameter detected on load
 	if (Preload.create && Preload.create.type && Preload.create.filename) {
-		const fileType = Types.getFileType(Preload.create.type, Config.get('ooxml'))
-		NewFileMenu._openTemplatePicker(Preload.create.type, fileType.mime, Preload.create.filename + '.' + fileType.extension)
+		FilesAppIntegration.preloadCreate()
 	}
 
 	if (Preload.open) {
-		FileList.$fileList.one('updated', function() {
-			odfViewer.onEdit(Preload.open.filename, {
-				fileId: Preload.open.id,
-				dir: document.getElementById('dir').value
-			})
-		})
+		FilesAppIntegration.preloadOpen()
 	}
 
 	// Open documents if a public page is opened for a supported mimetype

--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -48,8 +48,8 @@ const setGuestNameCookie = function(username) {
 
 const shouldAskForGuestName = () => {
 	return !mobile.isDirectEditing()
-		&& getCurrentUser() === null
-		&& Config.get('userId') === null
+		&& (!getCurrentUser() || getCurrentUser()?.uid === '')
+		&& !Config.get('userId')
 		&& getGuestNameCookie() === ''
 		&& (Config.get('permissions') & OC.PERMISSION_UPDATE)
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -53,7 +53,14 @@ const getNextcloudVersion = () => {
 	return parseInt(OC.config.version.split('.')[0])
 }
 
+const splitPath = (path) => {
+	const fileName = path.split('\\').pop().split('/').pop()
+	const directory = path.substr(0, (path.length - fileName.length - 1))
+	return [ directory, fileName ]
+}
+
 export {
 	languageToBCP47,
-	getNextcloudVersion
+	getNextcloudVersion,
+	splitPath
 }

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -29,7 +29,7 @@ const getSearchParam = (name) => {
 	if (results === null) {
 		return null
 	}
-	return decodeURI(results[1]) || 0
+	return decodeURI(results[1]) || ''
 }
 
 const getWopiUrl = ({ fileId, title, readOnly, closeButton, revisionHistory }) => {

--- a/src/services/preload.js
+++ b/src/services/preload.js
@@ -1,0 +1,44 @@
+/*
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { getSearchParam } from '../helpers/url'
+
+const preloadCreate = getSearchParam('richdocuments_create')
+const preloadOpen = getSearchParam('richdocuments_open')
+const Preload = {}
+
+if (preloadCreate) {
+	Preload.create = {
+		type: getSearchParam('richdocuments_create'),
+		filename: getSearchParam('richdocuments_filename')
+	}
+}
+
+if (preloadOpen) {
+	Preload.open = {
+		filename: preloadOpen,
+		id: getSearchParam('richdocuments_fileId'),
+		dir: getSearchParam('dir')
+	}
+}
+
+export default Preload

--- a/src/services/preload.js
+++ b/src/services/preload.js
@@ -36,8 +36,7 @@ if (preloadCreate) {
 if (preloadOpen) {
 	Preload.open = {
 		filename: preloadOpen,
-		id: getSearchParam('richdocuments_fileId'),
-		dir: getSearchParam('dir')
+		id: getSearchParam('richdocuments_fileId')
 	}
 }
 

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -26,7 +26,7 @@ export default {
 
 	fileModel: null,
 
-	fileList: FileList,
+	fileList: undefined,
 
 	/* Views: people currently editing the file */
 	views: {},
@@ -35,6 +35,15 @@ export default {
 
 	following: null,
 
+	handlers: {},
+
+	startLoading() {
+		if (this.getFileList()) {
+			this.getFileList().setViewerMode(true)
+			this.getFileList().showMask()
+		}
+	},
+
 	init({ fileName, fileId, sendPostMessage, fileList }) {
 		this.fileName = fileName
 		this.fileId = fileId
@@ -42,10 +51,18 @@ export default {
 		this.sendPostMessage = sendPostMessage
 	},
 
+	registerHandler(event, callback) {
+		this.handlers[event] = callback
+	},
+
 	initAfterReady() {
+		if (this.handlers.initAfterReady && !this.handlers.initAfterReady()) {
+			return
+		}
 		if (typeof this.getFileList() !== 'undefined') {
 			this.getFileModel()
 			this.getFileList().hideMask()
+			this.getFileList().setPageTitle(this.fileName)
 		}
 
 		const headerRight = document.querySelector('#header .header-right')

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -56,9 +56,10 @@ export default {
 	},
 
 	initAfterReady() {
-		if (this.handlers.initAfterReady && !this.handlers.initAfterReady()) {
+		if (this.handlers.initAfterReady && this.handlers.initAfterReady(this)) {
 			return
 		}
+
 		if (typeof this.getFileList() !== 'undefined') {
 			this.getFileModel()
 			this.getFileList().hideMask()
@@ -79,6 +80,10 @@ export default {
 	},
 
 	close() {
+		if (this.handlers.close && this.handlers.close(this)) {
+			return
+		}
+
 		if (this.getFileList()) {
 			this.getFileList().setViewerMode(false)
 			this.getFileList().reload()
@@ -91,12 +96,28 @@ export default {
 	},
 
 	share() {
+		if (this.handlers.share && this.handlers.share(this)) {
+			return
+		}
+
 		if (isPublic || !this.getFileList()) {
 			console.error('[FilesAppIntegration] Sharing is not supported')
 			return
 		}
 		this.getFileList().showDetailsView(this.fileName, 'shareTabView')
 		OC.Apps.showAppSidebar()
+	},
+
+	rename(newName) {
+		this.fileName = newName
+
+		if (this.handlers.rename && this.handlers.rename(this)) {
+			return
+		}
+		if (this.getFileList()) {
+			this.getFileList().reload()
+			OC.Apps.hideAppSidebar()
+		}
 	},
 
 	insertGraphic(callback) {
@@ -377,6 +398,10 @@ export default {
 	},
 
 	showRevHistory() {
+		if (this.handlers.showRevHistory && this.handlers.showRevHistory(this)) {
+			return
+		}
+
 		if (this.getFileList()) {
 			this.getFileList()
 				.showDetailsView(this.fileName, 'versionsTabView')

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -102,6 +102,17 @@ export default {
 		$('#richdocuments-header').remove()
 	},
 
+	saveAs() {
+		if (this.handlers.saveAs && this.handlers.saveAs(this)) {
+			return
+		}
+
+		if (this.getFileList()) {
+			this.getFileList()
+				.reload()
+		}
+	},
+
 	share() {
 		if (this.handlers.share && this.handlers.share(this)) {
 			return

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -225,7 +225,7 @@ export default {
 	},
 
 	_addHeaderFileActions() {
-		if (!this.getFileList().$el) {
+		if (!this.getFileList() || !this.getFileList().$el) {
 			console.error('[FilesAppIntegration] Failed to register file actions due to missing $el dependency')
 			return
 		}

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -62,8 +62,8 @@ export default {
 
 		if (typeof this.getFileList() !== 'undefined') {
 			this.getFileModel()
-			this.getFileList().hideMask()
-			this.getFileList().setPageTitle(this.fileName)
+			this.getFileList().hideMask && this.getFileList().hideMask()
+			this.getFileList().setPageTitle && this.getFileList().setPageTitle(this.fileName)
 		}
 
 		const headerRight = document.querySelector('#header .header-right')
@@ -224,6 +224,10 @@ export default {
 	},
 
 	_addHeaderFileActions() {
+		if (!this.getFileList().$el) {
+			console.error('[FilesAppIntegration] Failed to register file actions due to missing $el dependency')
+			return
+		}
 		console.debug('[FilesAppIntegration] Adding header file actions')
 		OC.unregisterMenu($('#richdocuments-actions .icon-more'), $('#richdocuments-actions-menu'))
 		$('#richdocuments-actions').remove()

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -138,22 +138,31 @@ export default {
 		}
 	},
 
-	insertGraphic(callback) {
+	insertGraphic(insertFile) {
 		if (isPublic) {
 			console.error('[FilesAppIntegration] insertGraphic is not supported')
 		}
+
+		const insertFileFromPath = (path) => {
+			const filename = path.substring(path.lastIndexOf('/') + 1)
+			$.ajax({
+				type: 'POST',
+				url: OC.generateUrl('apps/richdocuments/assets'),
+				data: {
+					path: path
+				}
+			}).done(function(resp) {
+				insertFile(filename, resp.url)
+			})
+		}
+
+		if (this.handlers.insertGraphic && this.handlers.insertGraphic(this, { insertFileFromPath: insertFileFromPath })) {
+			return
+		}
+
 		OC.dialogs.filepicker(t('richdocuments', 'Insert from {name}', { name: OC.theme.name }), function(path, type) {
 			if (type === OC.dialogs.FILEPICKER_TYPE_CHOOSE) {
-				const filename = path.substring(path.lastIndexOf('/') + 1)
-				$.ajax({
-					type: 'POST',
-					url: OC.generateUrl('apps/richdocuments/assets'),
-					data: {
-						path: path
-					}
-				}).done(function(resp) {
-					callback(filename, resp.url)
-				})
+				insertFileFromPath(path)
 			}
 		}, false, ['image/png', 'image/gif', 'image/jpeg', 'image/svg'], true, OC.dialogs.FILEPICKER_TYPE_CHOOSE)
 	},

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -391,20 +391,24 @@ export default {
 		$(document.querySelector('#content')).on('click.revisions', '#app-sidebar .preview-container', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('click.revisions', '#app-sidebar .downloadVersion', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('mousedown.revisions', '#app-sidebar .revertVersion', this.restoreVersion.bind(this))
+		$(document.querySelector('#content')).on('click.revisionsTab', '#app-sidebar [data-tabid=versionsTabView]', this.addCurrentVersion.bind(this))
 	},
 
 	removeVersionSidebarEvents() {
 		$(document.querySelector('#content')).off('click.revisions')
 		$(document.querySelector('#content')).off('click.revisions')
 		$(document.querySelector('#content')).off('mousedown.revisions')
+		$(document.querySelector('#content')).off('click.revisionsTab')
 	},
 
 	addCurrentVersion() {
+		$('#lastSavedVersion').remove()
+		$('#currentVersion').remove()
 		if (this.getFileModel()) {
 			const preview = OC.MimeType.getIconUrl(this.getFileModel().get('mimetype'))
 			const mtime = this.getFileModel().get('mtime')
 			$('#versionsTabView').prepend('<ul id="lastSavedVersion"><li data-revision="0"><div><div class="preview-container"><img src="' + preview + '" width="44" /></div><div class="version-container">\n'
-				+ '<div><a class="downloadVersion">' + t('richdocuments', 'Last saved version') + '<span class="versiondate has-tooltip live-relative-timestamp" data-timestamp="' + mtime + '"></span></div></div></li></ul>')
+				+ '<div><a class="downloadVersion">' + t('richdocuments', 'Last saved version') + '<br /><span class="versiondate has-tooltip live-relative-timestamp" data-timestamp="' + mtime + '"></span></div></div></li></ul>')
 			$('#versionsTabView').prepend('<ul id="currentVersion"><li data-revision="" class="active"><div><div class="preview-container"><img src="' + preview + '" width="44" /></div><div class="version-container">\n'
 				+ '<div><a class="downloadVersion">' + t('richdocuments', 'Current version') + '</a></div></div></li></ul>')
 			$('.live-relative-timestamp').each(function() {

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -74,15 +74,16 @@ export default {
 		}
 
 		const headerRight = document.querySelector('#header .header-right')
-		const richdocumentsHeader = document.createElement('div')
-		richdocumentsHeader.id = 'richdocuments-header'
-		headerRight.insertBefore(richdocumentsHeader, headerRight.firstChild)
-
-		this._addAvatarList()
-		if (!isPublic) {
-			this._addHeaderShareButton()
-			this._addHeaderFileActions()
-			this.addVersionSidebarEvents()
+		if (!document.getElementById('richdocuments-header')) {
+			const richdocumentsHeader = document.createElement('div')
+			richdocumentsHeader.id = 'richdocuments-header'
+			headerRight.insertBefore(richdocumentsHeader, headerRight.firstChild)
+			this._addAvatarList()
+			if (!isPublic) {
+				this._addHeaderShareButton()
+				this._addHeaderFileActions()
+				this.addVersionSidebarEvents()
+			}
 		}
 	},
 

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -161,7 +161,7 @@ export default {
 	},
 
 	getFileModel() {
-		if (this.fileModel !== null) {
+		if (this.fileModel) {
 			return this.fileModel
 		}
 		if (!this.getFileList()) {

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -39,15 +39,16 @@ export default {
 
 	startLoading() {
 		if (this.getFileList()) {
-			this.getFileList().setViewerMode(true)
-			this.getFileList().showMask()
+			this.getFileList().setViewerMode && this.getFileList().setViewerMode(true)
+			this.getFileList().showMask && this.getFileList().showMask()
 		}
 	},
 
-	init({ fileName, fileId, sendPostMessage, fileList }) {
+	init({ fileName, fileId, sendPostMessage, fileList, fileModel }) {
 		this.fileName = fileName
 		this.fileId = fileId
 		this.fileList = fileList
+		this.fileModel = fileModel
 		this.sendPostMessage = sendPostMessage
 	},
 
@@ -60,7 +61,7 @@ export default {
 			return
 		}
 
-		if (typeof this.getFileList() !== 'undefined') {
+		if (this.getFileList()) {
 			this.getFileModel()
 			this.getFileList().hideMask && this.getFileList().hideMask()
 			this.getFileList().setPageTitle && this.getFileList().setPageTitle(this.fileName)
@@ -85,8 +86,8 @@ export default {
 		}
 
 		if (this.getFileList()) {
-			this.getFileList().setViewerMode(false)
-			this.getFileList().reload()
+			this.getFileList().setViewerMode && this.getFileList().setViewerMode(false)
+			this.getFileList().reload && this.getFileList().reload()
 		}
 		this.fileModel = null
 		if (!isPublic) {
@@ -115,7 +116,7 @@ export default {
 			return
 		}
 		if (this.getFileList()) {
-			this.getFileList().reload()
+			this.getFileList().reload && this.getFileList().reload()
 			OC.Apps.hideAppSidebar()
 		}
 	},
@@ -160,10 +161,10 @@ export default {
 		if (!this.getFileList()) {
 			return null
 		}
-		this.getFileList()._updateDetailsView(this.fileName, false)
+		this.getFileList()._updateDetailsView && this.getFileList()._updateDetailsView(this.fileName, false)
 		this.fileModel = this.getFileList().getModelForFile(this.fileName)
 
-		if (this.fileModel !== null) {
+		if (this.fileModel && this.fileModel.on) {
 			this.fileModel.on('change', () => {
 				this._addHeaderFileActions()
 			})

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -389,7 +389,7 @@ export default {
 				continue
 			}
 			users.push(view.UserId)
-			if (i++ < 3) {
+			if (i++ < 4) {
 				avatardiv.append(this._avatarForView(view))
 			}
 		}

--- a/src/view/NewFileMenu.js
+++ b/src/view/NewFileMenu.js
@@ -1,0 +1,192 @@
+/*
+ * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import Types from '../helpers/types'
+
+/** @type OC.Plugin */
+const NewFileMenu = {
+	attach: function(newFileMenu) {
+		var self = this
+		const document = Types.getFileType('document')
+		const spreadsheet = Types.getFileType('spreadsheet')
+		const presentation = Types.getFileType('presentation')
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + document.extension,
+			displayName: t('richdocuments', 'New Document'),
+			templateName: t('richdocuments', 'New Document') + '.' + document.extension,
+			iconClass: 'icon-filetype-document',
+			fileType: 'x-office-document',
+			actionHandler: function(filename) {
+				if (OC.getCapabilities().richdocuments.templates) {
+					self._openTemplatePicker('document', document.mime, filename)
+				} else {
+					self._createDocument(document.mime, filename)
+				}
+			}
+		})
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + spreadsheet.extension,
+			displayName: t('richdocuments', 'New Spreadsheet'),
+			templateName: t('richdocuments', 'New Spreadsheet') + '.' + spreadsheet.extension,
+			iconClass: 'icon-filetype-spreadsheet',
+			fileType: 'x-office-spreadsheet',
+			actionHandler: function(filename) {
+				if (OC.getCapabilities().richdocuments.templates) {
+					self._openTemplatePicker('spreadsheet', spreadsheet.mime, filename)
+				} else {
+					self._createDocument(spreadsheet.mime, filename)
+				}
+			}
+		})
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + presentation.extension,
+			displayName: t('richdocuments', 'New Presentation'),
+			templateName: t('richdocuments', 'New Presentation') + '.' + presentation.extension,
+			iconClass: 'icon-filetype-presentation',
+			fileType: 'x-office-presentation',
+			actionHandler: function(filename) {
+				if (OC.getCapabilities().richdocuments.templates) {
+					self._openTemplatePicker('presentation', presentation.mime, filename)
+				} else {
+					self._createDocument(presentation.mime, filename)
+				}
+			}
+		})
+	},
+
+	_createDocument: function(mimetype, filename) {
+		OCA.Files.Files.isFileNameValid(filename)
+		filename = FileList.getUniqueName(filename)
+
+		$.post(
+			OC.generateUrl('apps/richdocuments/ajax/documents/create'),
+			{ mimetype: mimetype, filename: filename, dir: document.getElementById('dir').value },
+			function(response) {
+				if (response && response.status === 'success') {
+					FileList.add(response.data, { animate: true, scrollTo: true })
+				} else {
+					OC.dialogs.alert(response.data.message, t('core', 'Could not create file'))
+				}
+			}
+		)
+	},
+
+	_createDocumentFromTemplate: function(templateId, mimetype, filename) {
+		OCA.Files.Files.isFileNameValid(filename)
+		filename = FileList.getUniqueName(filename)
+		$.post(
+			OC.generateUrl('apps/richdocuments/ajax/documents/create'),
+			{ mimetype: mimetype, filename: filename, dir: document.getElementById('dir').value },
+			function(response) {
+				if (response && response.status === 'success') {
+					FileList.add(response.data, { animate: false, scrollTo: false })
+					const path = document.getElementById('dir').value + '/' + filename
+					OCA.RichDocuments.openWithTemplate({
+						fileId: -1,
+						path,
+						templateId: templateId
+					})
+				} else {
+					OC.dialogs.alert(response.data.message, t('core', 'Could not create file'))
+				}
+			}
+		)
+	},
+
+	_openTemplatePicker: function(type, mimetype, filename) {
+		var self = this
+		$.ajax({
+			url: OC.linkToOCS('apps/richdocuments/api/v1/templates', 2) + type,
+			dataType: 'json'
+		}).then(function(response) {
+			if (response.ocs.data.length === 1) {
+				const { id } = response.ocs.data[0]
+				self._createDocumentFromTemplate(id, mimetype, filename)
+				return
+			}
+			self._buildTemplatePicker(response.ocs.data)
+				.then(function() {
+					var buttonlist = [{
+						text: t('core', 'Cancel'),
+						classes: 'cancel',
+						click: function() {
+							$(this).ocdialog('close')
+						}
+					}, {
+						text: t('richdocuments', 'Create'),
+						classes: 'primary',
+						click: function() {
+							var templateId = this.dataset.templateId
+							self._createDocumentFromTemplate(templateId, mimetype, filename)
+							$(this).ocdialog('close')
+						}
+					}]
+
+					$('#template-picker').ocdialog({
+						closeOnEscape: true,
+						modal: true,
+						buttons: buttonlist
+					})
+				})
+		})
+	},
+
+	_buildTemplatePicker: function(data) {
+		var self = this
+		return $.get(OC.filePath('richdocuments', 'templates', 'templatePicker.html'), function(tmpl) {
+			var $tmpl = $(tmpl)
+			// init template picker
+			var $dlg = $tmpl.octemplate({
+				dialog_name: 'template-picker',
+				dialog_title: t('richdocuments', 'Select template')
+			})
+
+			// create templates list
+			var templates = _.values(data)
+			templates.forEach(function(template) {
+				self._appendTemplateFromData($dlg[0], template)
+			})
+
+			$('body').append($dlg)
+		})
+	},
+
+	_appendTemplateFromData: function(dlg, data) {
+		var template = dlg.querySelector('.template-model').cloneNode(true)
+		template.className = ''
+		template.querySelector('img').src = OC.generateUrl('apps/richdocuments/template/preview/' + data.id)
+		template.querySelector('h2').textContent = data.name
+		template.onclick = function() {
+			dlg.dataset.templateId = data.id
+		}
+		if (!dlg.dataset.templateId) {
+			dlg.dataset.templateId = data.id
+		}
+
+		dlg.querySelector('.template-container').appendChild(template)
+	}
+}
+
+export default NewFileMenu

--- a/src/view/NewFileMenu.js
+++ b/src/view/NewFileMenu.js
@@ -102,11 +102,14 @@ const NewFileMenu = {
 			function(response) {
 				if (response && response.status === 'success') {
 					FileList.add(response.data, { animate: false, scrollTo: false })
+					const fileModel = FileList.getModelForFile(filename)
 					const path = document.getElementById('dir').value + '/' + filename
 					OCA.RichDocuments.openWithTemplate({
 						fileId: -1,
 						path,
-						templateId: templateId
+						templateId: templateId,
+						fileList: window.FileList,
+						fileModel
 					})
 				} else {
 					OC.dialogs.alert(response.data.message, t('core', 'Could not create file'))

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -2,8 +2,8 @@
 	var richdocuments_permissions = '<?php p($_['permissions']) ?>';
 	var richdocuments_title = '<?php p($_['title']) ?>';
 	var richdocuments_fileId = '<?php p($_['fileId']) ?>';
-	var richdocuments_token = '<?php p($_['token'] ? $_['token'] : "''") ?>';
-	var richdocuments_urlsrc = '<?php p($_['urlsrc'] ? $_['urlsrc'] : "''") ?>';
+	var richdocuments_token = '<?php p($_['token'] ? $_['token'] : "") ?>';
+	var richdocuments_urlsrc = '<?php p($_['urlsrc'] ? $_['urlsrc'] : "") ?>';
 	var richdocuments_path = '<?php p($_['path']) ?>';
 	var richdocuments_userId = <?php isset($_['userId']) ? print_unescaped('\'' . \OCP\Util::sanitizeHTML($_['userId']) . '\'') : print_unescaped('null') ?>;
 	var richdocuments_instanceId = '<?php p($_['instanceId']) ?>';


### PR DESCRIPTION
This adds a public javascript API to OCA.RichDocuments with the following methods/properties:

- Expose new file configuration `OCA.RichDocuments.config.create`
- Allow to manually trigger the viewer `OCA.RichDocuments.open` and `OCA.RichDocuments.openWithTemplate`
-  Add hooks to files app integration `OCA.RichDocuments.FilesAppIntegration.registerHandler`
	- initAfterReady: will be called once the Collabora frame has been loaded
	- close: will be called after the Collabora view has been closed
	- share: will be called before the default share action is triggered
	- rename: will be called before the default rename action is triggered (the new filename is available as a property of the filesAppIntegration parameter)
	- showRevHistory: will be called before the default show revision history action is triggered

In addition this now saves one additional HTTP call during loading since the configuration exposing has been moved to capabilities.