### PR TITLE
Expose config without extra http call

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -81,6 +81,8 @@ class Capabilities implements ICapability {
 
 	/** @var IL10N */
 	private $l10n;
+	/** @var AppConfig */
+	private $config;
 
 	/**
 	 * Capabilities constructor.
@@ -88,8 +90,9 @@ class Capabilities implements ICapability {
 	 * @param IAppData $appData
 	 * @throws \OCP\Files\NotPermittedException
 	 */
-	public function __construct(IAppData $appData, IL10N $l10n) {
+	public function __construct(IAppData $appData, IL10N $l10n, AppConfig $config) {
 		$this->l10n = $l10n;
+		$this->config = $config;
 		try {
 			$this->appData = $appData->getFolder('richdocuments');
 		} catch (NotFoundException $e) {
@@ -107,6 +110,14 @@ class Capabilities implements ICapability {
 				'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) ? : false,
 				'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ? : false,
 				'productName' => isset($collaboraCapabilities['productName']) ? $collaboraCapabilities['productName'] : $this->l10n->t('Collabora Online'),
+				'config' => [
+					'wopi_url' => $this->config->getAppValue('wopi_url'),
+					'public_wopi_url' => $this->config->getAppValue('public_wopi_url'),
+					'disable_certificate_verification' => $this->config->getAppValue('disable_certificate_verification'),
+					'edit_groups' => $this->config->getAppValue('edit_groups'),
+					'use_groups' => $this->config->getAppValue('use_groups'),
+					'doc_format' => $this->config->getAppValue('doc_format'),
+				]
 			],
 		];
 	}

--- a/src/helpers/types.js
+++ b/src/helpers/types.js
@@ -21,23 +21,11 @@
  *
  */
 
-const getFileType = (document, ooxml) => {
-	let documentTypes = {
-		document: {
-			extension: 'odt',
-			mime: 'application/vnd.oasis.opendocument.text'
-		},
-		spreadsheet: {
-			extension: 'ods',
-			mime: 'application/vnd.oasis.opendocument.spreadsheet'
-		},
-		presentation: {
-			extension: 'odp',
-			mime: 'application/vnd.oasis.opendocument.presentation'
-		}
-	}
+const ooxml = OC.getCapabilities()['richdocuments']['config']['doc_format'] === 'ooxml'
+
+const getFileTypes = () => {
 	if (ooxml) {
-		documentTypes = {
+		return {
 			document: {
 				extension: 'docx',
 				mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
@@ -52,9 +40,27 @@ const getFileType = (document, ooxml) => {
 			}
 		}
 	}
-	return documentTypes[document]
+	return {
+		document: {
+			extension: 'odt',
+			mime: 'application/vnd.oasis.opendocument.text'
+		},
+		spreadsheet: {
+			extension: 'ods',
+			mime: 'application/vnd.oasis.opendocument.spreadsheet'
+		},
+		presentation: {
+			extension: 'odp',
+			mime: 'application/vnd.oasis.opendocument.presentation'
+		}
+	}
+}
+
+const getFileType = (document) => {
+	return getFileTypes()[document]
 }
 
 export default {
+	getFileTypes,
 	getFileType
 }


### PR DESCRIPTION
Extracted from #974 so we can get this in already

Saves one additional HTTP call during loading since the configuration exposing has been moved to capabilities.