### PR TITLE
Set an empty default url

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -17,7 +17,7 @@ use \OCP\IConfig;
 class AppConfig {
 
 	private $defaults = [
-		'wopi_url' => 'https://localhost:9980',
+		'wopi_url' => '',
 		'watermark_text' => '{userId}',
 		'watermark_allGroupsList' => [],
 		'watermark_allTagsList' => [],


### PR DESCRIPTION
This way the auto configuration can actually figure out if an url is already set

Required for https://github.com/nextcloud/richdocuments/pull/993

The default url was not being picked up anyway there

@kendy @mrkara @timar 