### PR TITLE
Do not check for capabilities during load though proxy

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -37,7 +37,9 @@ const odfViewer = {
 
 	open: false,
 	receivedLoading: false,
-	isCollaboraConfigured: typeof OC.getCapabilities().richdocuments.collabora === 'object' && OC.getCapabilities().richdocuments.collabora.length !== 0,
+	isCollaboraConfigured: (
+		(OC.getCapabilities().richdocuments.config.wopi_url.indexOf('proxy.php') !== -1)
+		|| (typeof OC.getCapabilities().richdocuments.collabora === 'object' && OC.getCapabilities().richdocuments.collabora.length !== 0)),
 	supportedMimes: OC.getCapabilities().richdocuments.mimetypes.concat(OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen),
 	excludeMimeFromDefaultOpen: OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen,
 	hideDownloadMimes: ['image/jpeg', 'image/svg+xml', 'image/cgm', 'image/vnd.dxf', 'image/x-emf', 'image/x-wmf', 'image/x-wpg', 'image/x-freehand', 'image/bmp', 'image/png', 'image/gif', 'image/tiff', 'image/jpg', 'image/jpeg', 'text/plain', 'application/pdf'],


### PR DESCRIPTION
This will make sure that even though the capabilities are not yet ready from the built-in server, we still already show the frame and the loading indicator or errors from https://github.com/nextcloud/richdocuments/pull/998