### PR TITLE
Fix CSP violation when collabora server has so-called 'service root'

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -46,6 +46,20 @@ class Application extends App {
 
 	const APPNAME = 'richdocuments';
 
+	/**
+	 * Strips the path and query parameters from the URL.
+	 *
+	 * @param string $url
+	 * @return string
+	 */
+	private function domainOnly($url) {
+		$parsed_url = parse_url($url);
+		$scheme = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';
+		$host	= isset($parsed_url['host']) ? $parsed_url['host'] : '';
+		$port	= isset($parsed_url['port']) ? ':' . $parsed_url['port'] : '';
+		return "$scheme$host$port";
+	}
+
 	public function __construct(array $urlParams = array()) {
 		parent::__construct(self::APPNAME, $urlParams);
 
@@ -105,9 +119,9 @@ class Application extends App {
 		$policy = new ContentSecurityPolicy();
 		if ($publicWopiUrl !== '') {
 			$policy->addAllowedFrameDomain('\'self\'');
-			$policy->addAllowedFrameDomain($publicWopiUrl);
+			$policy->addAllowedFrameDomain($this->domainOnly($publicWopiUrl));
 			if (method_exists($policy, 'addAllowedFormActionDomain')) {
-				$policy->addAllowedFormActionDomain($publicWopiUrl);
+				$policy->addAllowedFormActionDomain($this->domainOnly($publicWopiUrl));
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Andras Timar <andras.timar@collabora.com>

When WOPI URL has a service root part, e.g. it is https://office.test/collabora, there was a CSP violation.

main.js?v=4f4557d9-0:25 Refused to send form data to 'https://office.test/collabora/loleaflet/230f05fb1/loleaflet.html?WOPISrc=https%3A%2F%2Fcloud.test%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%2F21_ocelllpoy1kf&title=Example.odt&lang=en&closebutton=1&revisionhistory=1' because it violates the following Content Security Policy directive: "form-action 'self' https://office.test/collabora".

