### PR TITLE
Check for read permission on the file actions

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -50,7 +50,7 @@ const odfViewer = {
 			OCA.Files.fileActions.register(
 				mime,
 				EDIT_ACTION_NAME,
-				0,
+				OC.PERMISSION_READ,
 				OC.imagePath('core', 'actions/rename'),
 				this.onEdit,
 				t('richdocuments', 'Edit with {productName}', { productName: OC.getCapabilities().richdocuments.productName })


### PR DESCRIPTION
Otherwise it will try to open the file in collabora and show an error there if the access is blocked by files_accesscontrol.
