### PR TITLE
Fix problem where mobile.css did not get used for subsequent document edits

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -145,7 +145,7 @@ const odfViewer = {
 			reloadForFederationCSP(fileName)
 		}
 
-		OC.addStyle('richdocuments', 'mobile')
+		$('head').append($('<link rel="stylesheet" type="text/css" href="' + OC.filePath('richdocuments', 'css', 'mobile.css') + '"/>'))
 
 		var $iframe = $('<iframe id="richdocumentsframe" nonce="' + btoa(OC.requestToken) + '" scrolling="no" allowfullscreen src="' + documentUrl + '" />')
 		odfViewer.loadingTimeout = setTimeout(function() {


### PR DESCRIPTION
The code in the onEdit function wants to take our stylesheet
mobile.css into use, and the code in the onClose function
correspondingly removes it from use.

In onEdit, we used to call the OC.addStyle function to take the
stylesheet into use. That function uses an internal cache of the
pathnames of stylesheets in use. The way we remove the stylesheet from
use in onClose does not affect that cache (the loadedStyles variable
in Nextcloud server's core/src/OC/legacy-loader.js).

Thus, after a Nextcloud document browsing page is loaded, when editing
the first document, everything goes as planned: The stylesheet is
taken into use and it works as expected: In narrow windows (i.e.
mainly on mobile devices) the blue Nextcloud header is not displayed.

When the document is closed, the stylesheet is removed.

But when the next document is edited, the OC.addStyle function thinks
that the stylesheet is in use and does nothing.

This change avoids using OC.addStyle and instead adds the stylesheet
using plain Javascript.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
