### PR TITLE
Bump version to 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 3.7.1
+
+
+### Fixed
+
+* [#1010](https://github.com/nextcloud/richdocuments/pull/1010) Advise installation via 'occ' if it fails from the web interface. @kendy
+* [#1015](https://github.com/nextcloud/richdocuments/pull/1015) String update for built-in CODE option @mrkara
+* [#1017](https://github.com/nextcloud/richdocuments/pull/1017) Handling of a new error state from proxy.php?status. @kendy
+* [#1020](https://github.com/nextcloud/richdocuments/pull/1020) Check for read permission on the file actions @juliushaertl
+* [#1022](https://github.com/nextcloud/richdocuments/pull/1022) Update install.md @juliushaertl
+* [#1024](https://github.com/nextcloud/richdocuments/pull/1024) Update screenshots @timar
+* [#1026](https://github.com/nextcloud/richdocuments/pull/1026) New error state to handle - running on non-glibc based Linux. @kendy
+* [#885](https://github.com/nextcloud/richdocuments/pull/885) Move to @nextcloud packages @juliushaertl
+* [#1038](https://github.com/nextcloud/richdocuments/pull/1038) Fix issues with Nextcloud 15/16 @juliushaertl
+
+
 ## 3.7.0
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>3.7.0</version>
+	<version>3.7.1</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/lib/PermissionManager.php
+++ b/lib/PermissionManager.php
@@ -21,12 +21,13 @@
 
 namespace OCA\Richdocuments;
 
+use OCA\Richdocuments\AppInfo\Application;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
 
 class PermissionManager {
-	const APP_ID = 'richdocuments';
+
 	/** @var IConfig */
 	private $config;
 	/** @var IGroupManager */
@@ -47,7 +48,7 @@ class PermissionManager {
 	}
 
 	public function isEnabledForUser(IUser $user) {
-		$enabledForGroups = $this->config->getAppValue(self::APP_ID, 'use_groups', '');
+		$enabledForGroups = $this->config->getAppValue(Application::APPNAME, 'use_groups', '');
 		if($enabledForGroups === '') {
 			return true;
 		}

--- a/tests/lib/PermissionManagerTest.php
+++ b/tests/lib/PermissionManagerTest.php
@@ -25,17 +25,19 @@ use OCA\Richdocuments\PermissionManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class PermissionManagerTest extends TestCase {
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockBuilder */
+	/** @var IConfig|MockObject */
 	private $config;
-	/** @var IGroupManager|\PHPUnit_Framework_MockObject_MockBuilder */
+	/** @var IGroupManager|MockObject */
 	private $groupManager;
 	/** @var PermissionManager */
 	private $permissionManager;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 		$this->config = $this->createMock(IConfig::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
@@ -43,7 +45,7 @@ class PermissionManagerTest extends TestCase {
 	}
 
 	public function testIsEnabledForUserEnabledNoRestrictions() {
-		/** @var IUser|\PHPUnit_Framework_MockObject_MockBuilder $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 
 		$this->config
@@ -56,7 +58,7 @@ class PermissionManagerTest extends TestCase {
 	}
 
 	public function testIsEnabledForUserEnabledNotInGroup() {
-		/** @var IUser|\PHPUnit_Framework_MockObject_MockBuilder $user */
+		/** @var IUser|MockBuilder $user */
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())
@@ -89,7 +91,7 @@ class PermissionManagerTest extends TestCase {
 	}
 
 	public function testIsEnabledForUserEnabledInGroup() {
-		/** @var IUser|\PHPUnit_Framework_MockObject_MockBuilder $user */
+		/** @var IUser|MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -5,8 +5,8 @@
 		 timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
 		>
-	<testsuite name='ownCloud - Richdocuments App Tests'>
-		<directory suffix='test.php'>.</directory>
+	<testsuite name='Richdocuments App Tests'>
+		<directory suffix='.php'>./lib</directory>
 	</testsuite>
 	<!-- filters for code coverage -->
 	<filter>


### PR DESCRIPTION
## Merged PRs:

* [#1010](https://github.com/nextcloud/richdocuments/pull/1010) Advise installation via 'occ' if it fails from the web interface. @kendy
* [#1015](https://github.com/nextcloud/richdocuments/pull/1015) String update for built-in CODE option @mrkara
* [#1017](https://github.com/nextcloud/richdocuments/pull/1017) Handling of a new error state from proxy.php?status. @kendy
* [#1020](https://github.com/nextcloud/richdocuments/pull/1020) Check for read permission on the file actions @juliushaertl
* [#1022](https://github.com/nextcloud/richdocuments/pull/1022) Update install.md @juliushaertl
* [#1024](https://github.com/nextcloud/richdocuments/pull/1024) Update screenshots @timar
* [#1026](https://github.com/nextcloud/richdocuments/pull/1026) New error state to handle - running on non-glibc based Linux. @kendy
* [#885](https://github.com/nextcloud/richdocuments/pull/885) Move to @nextcloud packages @juliushaertl


## Pending PRs:

* [x] [#1038](https://github.com/nextcloud/richdocuments/pull/1038) Fix issues with Nextcloud 15/16 @juliushaertl
