### PR TITLE
getCurrentUser might be null in contrast to OC.getCurrentUser

### DIFF
--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -48,7 +48,7 @@ const setGuestNameCookie = function(username) {
 
 const shouldAskForGuestName = () => {
 	return !mobile.isDirectEditing()
-		&& getCurrentUser().uid === null
+		&& getCurrentUser()?.uid === null
 		&& Config.get('userId') === null
 		&& getGuestNameCookie() === ''
 		&& (Config.get('permissions') & OC.PERMISSION_UPDATE)


### PR DESCRIPTION
Fixes #1050 

Due to the migration of OC.getCurrentUser to `@nextcloud/auth` the return value changed from `{uid: null}` to `null` so this catches that properly