### PR TITLE
Pick up trusted certificates again

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -114,7 +114,7 @@ class SettingsController extends Controller{
 		return new JSONResponse([
 			'wopi_url' => $this->appConfig->getAppValue('wopi_url'),
 			'public_wopi_url' => $this->appConfig->getAppValue('public_wopi_url'),
-			'disable_certificate_verification' => $this->appConfig->getAppValue('disable_certificate_verification'),
+			'disable_certificate_verification' => $this->appConfig->getAppValue('disable_certificate_verification') === 'yes',
 			'edit_groups' => $this->appConfig->getAppValue('edit_groups'),
 			'use_groups' => $this->appConfig->getAppValue('use_groups'),
 			'doc_format' => $this->appConfig->getAppValue('doc_format'),

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -114,7 +114,7 @@ class SettingsController extends Controller{
 		return new JSONResponse([
 			'wopi_url' => $this->appConfig->getAppValue('wopi_url'),
 			'public_wopi_url' => $this->appConfig->getAppValue('public_wopi_url'),
-			'disable_certificate_verification' => $this->appConfig->getAppValue('disable_certificate_verification', '') !== '',
+			'disable_certificate_verification' => $this->appConfig->getAppValue('disable_certificate_verification'),
 			'edit_groups' => $this->appConfig->getAppValue('edit_groups'),
 			'use_groups' => $this->appConfig->getAppValue('use_groups'),
 			'doc_format' => $this->appConfig->getAppValue('doc_format'),

--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -82,7 +82,9 @@ abstract class Office extends Provider {
 		$client = $this->clientService->newClient();
 		$options = ['timeout' => 10];
 
-		$options['verify'] = $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') === '';
+		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
+		}
 
 		$options['multipart'] = [['name' => $path, 'contents' => $stream]];
 

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -119,7 +119,9 @@ class CapabilitiesService {
 		$client = $this->clientService->newClient();
 		$options = ['timeout' => 45, 'nextcloud' => ['allow_local_address' => true]];
 
-		$options['verify'] = $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') === '';
+		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
+		}
 
 		try {
 			$response = $client->get($capabilitiesEndpoint, $options);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -85,7 +85,7 @@ class Admin implements ISettings {
 					'doc_format'         => $this->config->getAppValue('richdocuments', 'doc_format'),
 					'external_apps'      => $this->config->getAppValue('richdocuments', 'external_apps'),
 					'canonical_webroot'  => $this->config->getAppValue('richdocuments', 'canonical_webroot'),
-					'disable_certificate_verification' => $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') !== '',
+					'disable_certificate_verification' => $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') === 'yes',
 					'templates'          => $this->manager->getSystemFormatted(),
 					'templatesAvailable' => array_key_exists('templates', $this->capabilities) && $this->capabilities['templates'],
 					'settings' => $this->appConfig->getAppSettings(),

--- a/lib/WOPI/DiscoveryManager.php
+++ b/lib/WOPI/DiscoveryManager.php
@@ -98,7 +98,9 @@ class DiscoveryManager {
 		$client = $this->clientService->newClient();
 		$options = ['timeout' => 45, 'nextcloud' => ['allow_local_address' => true]];
 
-		$options['verify'] = $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') === '';
+		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
+		}
 
 		try {
 			return $client->get($wopiDiscovery, $options);


### PR DESCRIPTION
- Revert https://github.com/nextcloud/richdocuments/pull/959 since it replaced the verify parameter which caused custom trusted certificates to not apply on requests
- Unify check for disable_certificate_verification value in settings