### PR TITLE
Check for the proper current user value (again)

### DIFF
--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -48,7 +48,7 @@ const setGuestNameCookie = function(username) {
 
 const shouldAskForGuestName = () => {
 	return !mobile.isDirectEditing()
-		&& getCurrentUser()?.uid === null
+		&& getCurrentUser() === null
 		&& Config.get('userId') === null
 		&& getGuestNameCookie() === ''
 		&& (Config.get('permissions') & OC.PERMISSION_UPDATE)


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/nextcloud/richdocuments/pull/1052 as getCurrentUser()?.uid actually returns undefined and not null, therefore the user was never asked for the guest name and therefore editing didn't work properly on public share links.

This PR now uses the proper null result that is defined by `@nextcloud/auth` for non-logged in users.