### PR TITLE
 Add frontend hooks and expose config/open methods

### DIFF
--- a/lib/Migration/Version030702Date20200626072306.php
+++ b/lib/Migration/Version030702Date20200626072306.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Richdocuments\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version030702Date20200626072306 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('richdocuments_wopi');
+
+		if (!$table->hasColumn('template_id')) {
+			$table->addColumn('template_id', 'integer', [
+				'notnull' => false,
+				'length' => 4,
+			]);
+		}
+
+		if (!$table->hasColumn('hide_download')) {
+			$table->addColumn('hide_download', 'boolean', [
+				'notnull' => true,
+				'default' => false,
+			]);
+		}
+
+		if (!$table->hasColumn('share')) {
+			$table->addColumn('share', 'string', [
+				'notnull' => false,
+				'length' => 64
+			]);
+		}
+
+		if (!$table->hasColumn('direct')) {
+			$table->addColumn('direct', 'boolean', [
+				'notnull' => true,
+				'default' => false,
+			]);
+		}
+		if (!$table->hasColumn('is_remote_token')) {
+			$table->addColumn('is_remote_token', 'boolean', [
+				'notnull' => true,
+				'default' => false,
+			]);
+		}
+
+		if (!$table->hasColumn('remote_server')) {
+			$table->addColumn('remote_server', 'string', [
+				'notnull' => true,
+				'default' => '',
+			]);
+
+		}
+		if (!$table->hasColumn('remote_server_token')) {
+			$table->addColumn('remote_server_token', 'string', [
+				'notnull' => true,
+				'length' => 32,
+				'default' => '',
+			]);
+		}
+
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+}

--- a/lib/Migration/Version2060Date20200302132145.php
+++ b/lib/Migration/Version2060Date20200302132145.php
@@ -9,7 +9,8 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
-class Version2060Date20200302132145 extends SimpleMigrationStep {
+class Version2060Date20200302132145 extends SimpleMigrationStep
+{
 
 	/**
 	 * @param IOutput $output
@@ -17,7 +18,8 @@ class Version2060Date20200302132145 extends SimpleMigrationStep {
 	 * @param array $options
 	 * @return null|ISchemaWrapper
 	 */
-	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+	{
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 

--- a/lib/Migration/Version30704Date20200626072306.php
+++ b/lib/Migration/Version30704Date20200626072306.php
@@ -9,18 +9,7 @@ use OCP\DB\ISchemaWrapper;
 use OCP\Migration\SimpleMigrationStep;
 use OCP\Migration\IOutput;
 
-/**
- * Auto-generated migration step: Please modify to your needs!
- */
-class Version030702Date20200626072306 extends SimpleMigrationStep {
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 */
-	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
-	}
+class Version30704Date20200626072306 extends SimpleMigrationStep {
 
 	/**
 	 * @param IOutput $output
@@ -85,13 +74,5 @@ class Version030702Date20200626072306 extends SimpleMigrationStep {
 
 
 		return $schema;
-	}
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 */
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
 	}
 }


### PR DESCRIPTION
Rebased version of #974 

This adds a public javascript API to OCA.RichDocuments with the following methods/properties:

- Expose new file configuration `OCA.RichDocuments.config.create`
- Allow to manually trigger the viewer `OCA.RichDocuments.open` and `OCA.RichDocuments.openWithTemplate`
-  Add hooks to files app integration `OCA.RichDocuments.FilesAppIntegration.registerHandler`
	- initAfterReady: will be called once the Collabora frame has been loaded
	- close: will be called after the Collabora view has been closed
	- share: will be called before the default share action is triggered
	- rename: will be called before the default rename action is triggered (the new filename is available as a property of the filesAppIntegration parameter)
	- showRevHistory: will be called before the default show revision history action is triggered

In addition this now saves one additional HTTP call during loading since the configuration exposing has been moved to capabilities.