### PR TITLE
Ebardie/activate config

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -36,6 +36,7 @@ You can also edit your documents off-line with the Collabora Office app from the
 	</background-jobs>
 	<commands>
 		<command>OCA\Richdocuments\Command\UpdateEmptyTemplates</command>
+		<command>OCA\Richdocuments\Command\ActivateConfig</command>
 	</commands>
 	<settings>
 		<admin>OCA\Richdocuments\Settings\Admin</admin>

--- a/docs/install.md
+++ b/docs/install.md
@@ -119,11 +119,26 @@ Afterward, configure one VirtualHost properly to proxy the traffic. For security
 			
 After configuring these do restart your apache using /etc/init.d/apache2 restart.
 
-## Configure the app in Nextcloud
+## Configure the app
+
+You can configure the app either from within Nextcloud itself, or from the
+commandline. The latter facilitates automated setup, e.g. via Ansible.
+
+### Configure the app in Nextcloud
 
 Go to the Apps section and choose "Office & text"
 Install the "Collabora Online app"
 Admin -> Collabora Online -> Specify the server you have setup before (e.g. "https://office.nextcloud.com")
+
+Congratulations, your Nextcloud has Collabora Online Office integrated!
+
+### Configure the app from the commandline
+
+From a shell running in the Nextcloud root directory, run the following `occ`
+commands, substituting the server url you've setup (e.g. "https://office.nextcloud.com"):
+
+	./occ config:app:set --value ${SERVER_URL} richdocuments wopi_url
+	./occ richdocuments:activate-config
 
 Congratulations, your Nextcloud has Collabora Online Office integrated!
 

--- a/lib/Command/ActivateConfig.php
+++ b/lib/Command/ActivateConfig.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @copyright Copyright (c) 2019 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCA\RichDocuments\Command;
+
+use OCA\Richdocuments\AppConfig;
+use OCA\Richdocuments\Service\CapabilitiesService;
+use OCA\Richdocuments\TemplateManager;
+use OCA\Richdocuments\WOPI\DiscoveryManager;
+use OCA\Richdocuments\WOPI\Parser;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ActivateConfig extends Command {
+
+	/** @var AppConfig */
+	private $appConfig;
+
+	/** @var CapabilitiesService */
+	private $capabilitiesService;
+
+	/** @var DiscoveryManager  */
+	private $discoveryManager;
+
+	/** @var Parser */
+	private $wopiParser;
+
+	public function __construct(AppConfig $appConfig, CapabilitiesService $capabilitiesService, DiscoveryManager $discoveryManager, Parser $wopiParser) {
+		parent::__construct();
+
+		$this->appConfig = $appConfig;
+		$this->capabilitiesService = $capabilitiesService;
+		$this->discoveryManager = $discoveryManager;
+		$this->wopiParser = $wopiParser;
+	}
+
+	protected function configure() {
+		$this
+			->setName('richdocuments:activate-config')
+			->setDescription('Activate config changes');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		try {
+			$this->discoveryManager->refretch();
+			$this->capabilitiesService->clear();
+			$capaUrlSrc = $this->wopiParser->getUrlSrc('Capabilities');
+			if (is_array($capaUrlSrc) && $capaUrlSrc['action'] === 'getinfo') {
+				$public_wopi_url = str_replace('/hosting/capabilities', '', $capaUrlSrc['urlsrc']);
+				if ($public_wopi_url !== null) {
+					$this->appConfig->setAppValue('public_wopi_url', $public_wopi_url);
+				}
+			}
+			$this->capabilitiesService->clear();
+			$this->capabilitiesService->refretch();
+			$output->writeln('<info>Activated any config changes</info>');
+		} catch (\Exception $e) {
+			$output->writeln('<error>Failed to activate any config changes</error>');
+			$output->writeln($e->getMessage());
+			$output->writeln($e->getTraceAsString());
+		}
+	}
+
+}


### PR DESCRIPTION
* Resolves: #1007 
* Target version: master 

### Summary

A Collabora Online server can be configured on the commandline:

    occ config:app:set --value ${SERVER_URL} richdocuments wopi_url

but the configuration can only be activated by clicking the 'Save' button in the WUI.

I've extracted the relevant parts from the WUI code in *lib/Controller/SettingsController.php* and created a new `occ` command:

    occ  richdocuments:activate-config

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
