### PR TITLE
Use PHP_OS instead of PHP_OS_FAMILY when PHP version < 7.2

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -91,7 +91,7 @@ class Admin implements ISettings {
 					'settings' => $this->appConfig->getAppSettings(),
 					'demo_servers' => $this->demoService->fetchDemoServers(),
 					'web_server' => strtolower($_SERVER['SERVER_SOFTWARE']),
-					'os_family' => PHP_OS_FAMILY,
+					'os_family' => PHP_VERSION_ID >= 70200 ? PHP_OS_FAMILY : PHP_OS,
 					'platform' => php_uname('m')
 				]
 			],


### PR DESCRIPTION
Suggested by Julius Härtl in 41ba1c4b6c25b25abbdb85d0849b4be609827170

Signed-off-by: Muhammet Kara <muhammet.kara@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ X] Code is properly formatted
- [ X] Sign-off message is added to all commits
- [X ] Documentation (manuals or wiki) has been updated or is not required
