### PR TITLE
Do not use isset for checking the class constant

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -236,7 +236,7 @@ class SettingsController extends Controller{
 			if (is_bool($value)) {
 				$parsedValue = $value ? 'yes' : 'no';
 			}
-			$appSettingsType = isset(AppConfig::APP_SETTING_TYPES[$fullKey]) ? AppConfig::APP_SETTING_TYPES[$fullKey] : 'string';
+			$appSettingsType = array_key_exists($fullKey, AppConfig::APP_SETTING_TYPES) ? AppConfig::APP_SETTING_TYPES[$fullKey] : 'string';
 			if ($appSettingsType === 'array') {
 				$parsedValue = implode(',', $value);
 			}


### PR DESCRIPTION
Should fix CI failures on PHP7.0 while `isset(AppConfig::APP_SETTING_TYPES[$fullKey])` should be fully supported by PHP7.0, nikic/PHP-Parser fails on it for some reason, but only on PHP 7.0