### PR TITLE
Template sourced documents support DownloadAsPostMessage

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -259,7 +259,7 @@ class TokenManager {
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
 		if ($this->capabilitiesService->hasTemplateSource()) {
-			$wopi = $this->wopiMapper->generateFileToken($targetFile->getId(), $owneruid, $editoruid, 0, (int)$updatable, $serverHost, null, 0, false, false, false, $templateFile->getId());
+			$wopi = $this->wopiMapper->generateFileToken($targetFile->getId(), $owneruid, $editoruid, 0, (int)$updatable, $serverHost, null, 0, false, $direct, false, $templateFile->getId());
 		} else {
 			// Legacy way of creating new documents from a template
 			$wopi = $this->wopiMapper->generateFileToken($templateFile->getId(), $owneruid, $editoruid, 0, (int)$updatable, $serverHost, null, $targetFile->getId(), $direct);


### PR DESCRIPTION
DownloadAsPostMessage is specific to the client, not the
document. When creating new documents from templates, we
should still respect the DownloadAsPostMessage flag.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [X] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [X] Documentation (manuals or wiki) has been updated or is not required
