### PR TITLE
No need to get the avatar image since we have one for each user

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -217,7 +217,7 @@ class WopiController extends Controller {
 		}
 
 		$user = $this->userManager->get($wopi->getEditorUid());
-		if($user !== null && $user->getAvatarImage(32) !== null) {
+		if($user !== null) {
 			$response['UserExtraInfo']['avatar'] = $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $wopi->getEditorUid(), 'size' => 32]);
 		}
 


### PR DESCRIPTION
Should save some ms on the checkFileInfo calls since we do always have an avatar image available for users these days.

![image](https://user-images.githubusercontent.com/3404133/93853712-a4f42d00-fcb4-11ea-9228-219321611652.png)
