### PR TITLE
Show error if trying to open a file on session credential based external storage

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -72,6 +72,13 @@ const odfViewer = {
 		}
 		odfViewer.open = true
 		if (context) {
+			if (context.$file.attr('data-mounttype') === 'external-session') {
+				OCP.Toast.error(t('richdocuments', 'Opening the file is not supported, since the credentials for the external storage are not available without a session'), {
+					timeout: 0
+				})
+				odfViewer.open = false
+				return
+			}
 			var fileDir = context.dir
 			var fileId = context.fileId || context.$file.attr('data-id')
 			var templateId = context.templateId


### PR DESCRIPTION
This will make sure that a proper error message is shown if a document cannot be opened because the credentials to the external storage are stored in the session, which is not available for Collabora.

Requires https://github.com/nextcloud/server/pull/23261 to work, but is backwards compatible to just do nothing then.

Fixes https://github.com/nextcloud/richdocuments/issues/1048