### PR TITLE
Lint fix

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -191,7 +191,7 @@ const odfViewer = {
 
 	onReceiveLoading() {
 		odfViewer.receivedLoading = true
-		$('#richdocumentsframe').prop('title', 'Collabora Online');
+		$('#richdocumentsframe').prop('title', 'Collabora Online')
 		$('#richdocumentsframe').show()
 		$('html, body').scrollTop(0)
 		$('#content').removeClass('loading')


### PR DESCRIPTION
* Target version: master 

### Summary
When trying to build the current `master` with `npm run dev` i get an error:
```
ERROR in ./src/files.js
Module Error (from ./node_modules/eslint-loader/dist/cjs.js):

/var/www/html/nextcloud/apps/richdocuments/src/files.js
  194:61  error  Extra semicolon  semi

```

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
