### PR TITLE
Use base template for direct editing

### DIFF
--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -161,7 +161,7 @@ class DirectViewController extends Controller {
 				'direct' => true,
 			];
 
-			$response = new TemplateResponse('richdocuments', 'documents', $params, 'empty');
+			$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
 			$policy = new ContentSecurityPolicy();
 			$policy->allowInlineScript(true);
 			$policy->addAllowedFrameDomain($this->appConfig->getAppValue('public_wopi_url'));


### PR DESCRIPTION
Removes the nextcloud header bar which should not show up when editing a document inside of the mobile apps.

Follow-up to https://github.com/nextcloud/richdocuments/pull/1133 which was missing the direct editing controller.