### PR TITLE
The mobile apps need to handle the hyperlinks themselves.

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -362,6 +362,8 @@ const documentsMain = {
 							callMobileMessage('insertGraphic')
 						} else if (msgId === 'UI_Share') {
 							callMobileMessage('share')
+						} else if (msgId === 'UI_Hyperlink') {
+							callMobileMessage('hyperlink', args)
 						}
 						// Fallback to web UI for SaveAs, otherwise ignore other post messages
 						if (msgId !== 'UI_SaveAs') {
@@ -422,6 +424,12 @@ const documentsMain = {
 
 				// Tell the LOOL iframe that we are ready now
 				PostMessages.sendWOPIPostMessage('loolframe', 'Host_PostmessageReady', {})
+
+				// In the mobile apps, don't let Collabora Online handle the
+				// hyperlinks, instead do that in the apps
+				if (isMobileInterfaceAvailable()) {
+					PostMessages.sendWOPIPostMessage('loolframe', 'Disable_Default_UIAction', { action: 'UI_Hyperlink', disable: true })
+				}
 			})
 
 			// submit that


### PR DESCRIPTION
Otherwise the apps hang when the webkit attempts to open a new window.

Signed-off-by: Jan Holesovsky <kendy@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
