### PR TITLE
Fix #1219 - add 'application/vnd.ms-visio.drawing' to support .vsdx

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -42,6 +42,7 @@ class Capabilities implements ICapability {
 		'application/vnd.oasis.opendocument.presentation',
 		'application/vnd.lotus-wordpro',
 		'application/vnd.visio',
+		'application/vnd.ms-visio.drawing',
 		'application/vnd.wordperfect',
 		'application/msonenote',
 		'application/msword',


### PR DESCRIPTION
Add 'application/vnd.ms-visio.drawing' to support .vsdx (Visio) files


* Resolves: #1219 
* Target version: master 

### TODO

- It will work only with next Collabora Online release (6.4.1), because .vsdx and application/vnd.ms-visio.drawing was not in the discovery.xml. See https://github.com/CollaboraOnline/online/commit/2b6b9d897edfc4241e98518368d5de9a6b07753c 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
