### PR TITLE
Adjust ui_defaults

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -268,7 +268,7 @@ const documentsMain = {
 			// form to post the access token for WOPISrc
 			var form = '<form id="loleafletform" name="loleafletform" target="loleafletframe" action="' + urlsrc + '" method="post">'
 				+ '<input name="access_token" value="' + accessToken + '" type="hidden"/>'
-				+ '<input name="ui_defaults" value="TextRuler=true;TextStatusbar=false;TextSidebar=false;PresentationSidebar=false;PresentationStatusbar=false;SpreadsheetSidebar=false" type="hidden"/>'
+				+ '<input name="ui_defaults" value="TextRuler=false;TextStatusbar=true;TextSidebar=false;PresentationSidebar=false;PresentationStatusbar=true;SpreadsheetSidebar=false" type="hidden"/>'
 				+ '<input name="css_variables" value="' + generateCSSVarTokens() + '" type="hidden"/></form>'
 
 			// iframe that contains the Collabora Online


### PR DESCRIPTION
This makes sure that the same ui_defaults are used for new and existing files.

@jancborchardt I'd for now keep the status bar, since it is not yet toggleable with the new notebookbar ui, but if I understood you correctly this is something we should also hide by default then, right?

![image](https://user-images.githubusercontent.com/3404133/98103459-516d2580-1e95-11eb-9029-54835a6dd4cd.png)

