### PR TITLE
add French (Switzerland) and Italian (Switzerland) as special case

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -36,6 +36,12 @@ const languageToBCP47 = () => {
 			'de_CH': 'de-CH',
 			'gsw': 'de-CH',
 			'gsw_CH': 'de-CH'
+		},
+		fr: {
+			'fr_CH': 'fr-CH'
+		},
+		it: {
+			'it_CH': 'it-CH'
 		}
 	}
 	const matchingWhitelist = whitelist[language]


### PR DESCRIPTION
* Target version: master 

### Summary
Received this as a question from a Swiss partner.

To reproduce, in NC:

    set your language to Francais,
    set locale to Francais (Suisse),

    create a new document,
    check language, which should include Suisse / Switzerland.

-> It says Francais (France).

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
