### PR TITLE
Fix issues with federated editing in global scale setups

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -105,17 +105,21 @@ const generateCSSVarTokens = () => {
 		'--border-radius-pill': '--co-border-radius-pill'
 	}
 	var str = ''
-	for (var cssVarKey in cssVarMap) {
-		var cStyle = window.parent.getComputedStyle(document.documentElement).getPropertyValue(cssVarKey)
-		if (!cStyle) {
-			// try suffix -dark instead
-			cStyle = window.parent.getComputedStyle(document.documentElement).getPropertyValue(cssVarKey + '-dark')
+	try {
+		for (var cssVarKey in cssVarMap) {
+			var cStyle = window.parent.getComputedStyle(document.documentElement).getPropertyValue(cssVarKey)
+			if (!cStyle) {
+				// try suffix -dark instead
+				cStyle = window.parent.getComputedStyle(document.documentElement).getPropertyValue(cssVarKey + '-dark')
+			}
+			if (!cStyle) continue // skip if it is not set
+			var varNames = cssVarMap[cssVarKey].split(':')
+			for (var i = 0; i < varNames.length; ++i) {
+				str += varNames[i] + '=' + cStyle + ';'
+			}
 		}
-		if (!cStyle) continue // skip if it is not set
-		var varNames = cssVarMap[cssVarKey].split(':')
-		for (var i = 0; i < varNames.length; ++i) {
-			str += varNames[i] + '=' + cStyle + ';'
-		}
+	} catch (e) {
+		// Skip extracting css vars if we cannot access parent
 	}
 	return str
 }


### PR DESCRIPTION
- Do not fail if computed styles cannot be obtained due to cross origin iframes
- Allow defining an allow list through gs.trustedHosts in config.php:
With this either a domain pattern like *.example.com can be defined or individual domains can be added as trusted sources for federated editing. Having individual domains listed has the benefit that the CSP can be set right away and there is no need to perform an additional reload for opening a document.


```
  // provide a whitelist pattern, this will require the files app to reload 
  // to open a document in order to set the proper csp for the opened document on the remote server
  'gs.enabled' => true,
  'gs.trustedHosts' => [
    '*.local.dev'
  ],
```

or

```
  // immediately add all trusted hosts to csp when loading the files app
  'gs.enabled' => true,
  'gs.trustedHosts' => [
    'nc1.local.dev',
    'nc2.local.dev'
  ],
```

As discussed with @rullzer, ideally we would just obtain the list of hosts from the lookup server once https://github.com/nextcloud/lookup-server/pull/43 is ready.