### PR TITLE
Actually mark wopi entity fields as updated

### DIFF
--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -96,10 +96,10 @@ class Wopi extends Entity {
 	protected $isRemoteToken;
 
 	/** @var string */
-	protected $remoteServer = '';
+	protected $remoteServer;
 
 	/** @var string */
-	protected $remoteServerToken = '';
+	protected $remoteServerToken;
 
 	/** @var string */
 	protected $share;


### PR DESCRIPTION
Just figured out that i missed to push last commit in #1278 to make sure that the empty value from https://github.com/nextcloud/richdocuments/pull/1278/commits/999fc20d3449270e8d4a9512be78f4ec469cc383 is actually taken into account by the mapper. Otherwise the values would be the same and the empty string would not be part of the insert statement.