### PR TITLE
Rename document on save as success

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -467,6 +467,10 @@ const documentsMain = {
 							nameInput.selectionStart = 0
 							nameInput.selectionEnd = documentsMain.fileName.lastIndexOf('.')
 						})
+					} else if (msgId === 'Action_Save_Resp') {
+						if (args.success && args.fileName) {
+							documentsMain.fileName = args.fileName
+						}
 					}
 				})
 


### PR DESCRIPTION
After editor confirmed successful save as operation
rename the document so next time user will open
"Save As" dialog he will see correct "old" file name.

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
