### PR TITLE
Properly trim trailing slashes from the remote url

### DIFF
--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -196,7 +196,7 @@ class FederationService {
 				} else {
 					$wopi = $this->tokenManager->getRemoteTokenFromDirect($item, $direct->getUid());
 				}
-				$url = rtrim($remote, '') . '/index.php/apps/richdocuments/remote?shareToken=' . $item->getStorage()->getToken() .
+				$url = rtrim($remote, '/') . '/index.php/apps/richdocuments/remote?shareToken=' . $item->getStorage()->getToken() .
 					'&remoteServer=' . $wopi->getServerHost() .
 					'&remoteServerToken=' . $wopi->getToken();
 				if ($item->getInternalPath() !== '') {


### PR DESCRIPTION
Otherwise there might be cases where the URL is generated with `//index.php` which might lead to issues with loading the page.