### PR TITLE
Handle errors when fetching remote file info more gracefully

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -444,6 +444,9 @@ class DocumentController extends Controller {
 				list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($node->getId(), $shareToken, $this->uid);
 
 				$remoteWopi = $this->federationService->getRemoteFileDetails($remoteServer, $remoteServerToken);
+				if ($remoteWopi === null) {
+					throw new \Exception('Invalid remote file details for ' . $remoteServerToken);
+				}
 				$this->tokenManager->updateToRemoteToken($wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi);
 
 				$permissions = $share->getPermissions();

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -173,7 +173,7 @@ class FederationService {
 				]
 			]);
 			$responseBody = $response->getBody();
-			$data = \json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+			$data = \json_decode($responseBody, true, 512);
 			$this->logger->debug('Reveived remote file details for ' . $remoteToken . ' from ' . $remote . ': ' . $responseBody);
 			return $data['ocs']['data'];
 		} catch (\Throwable $e) {

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -172,10 +172,12 @@ class FederationService {
 					'token' => $remoteToken
 				]
 			]);
-			$data = \json_decode($response->getBody(), true);
+			$responseBody = $response->getBody();
+			$data = \json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
+			$this->logger->debug('Reveived remote file details for ' . $remoteToken . ' from ' . $remote . ': ' . $responseBody);
 			return $data['ocs']['data'];
 		} catch (\Throwable $e) {
-			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote);
+			$this->logger->error('Unable to fetch remote file details for ' . $remoteToken . ' from ' . $remote, ['exception' => $e]);
 		}
 		return null;
 	}


### PR DESCRIPTION
This will handle errors that may occur when fetching the file info of a remote wopi token fails more gracefully and enhances the logging so that logs will actually help to understand what is going wrong there afterwards.