### PR TITLE
Prefix global scale nodes with the current protocol 

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -149,6 +149,9 @@ class Application extends App {
 			if ($globalScale->isGlobalScaleEnabled()) {
 				$trustedList = \OC::$server->getConfig()->getSystemValue('gs.trustedHosts', []);
 				foreach ($trustedList as $server) {
+					if (strpos($server, 'http://') !== 0 && strpos($server, 'https://') !== 0) {
+						$server = \OC::$server->getRequest()->getServerProtocol() . '://' . $server;
+					}
 					$this->addTrustedRemote($policy, $server);
 				}
 			}


### PR DESCRIPTION
to obtain the remote collabora url properly in https://github.com/nextcloud/richdocuments/blob/a89f9bfc443876be527a0ed2b22bfbf315f54f19/lib/Service/FederationService.php#L81

I couldn't reproduce an actual issue with it in cases where there would be a proper redirect for http -> https but we can save that in such cases and this is less error prone.