### PR TITLE
Properly handle cached failed requests in the Federation service

### DIFF
--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -78,7 +78,8 @@ class FederationService {
 		if (!$this->isTrustedRemote($remote)) {
 			throw new \Exception('Unable to determine collabora URL of remote server ' . $remote . ' - Remote is not a trusted server');
 		}
-		if ($remoteCollabora = $this->cache->get('richdocuments_remote/' . $remote)) {
+		$remoteCollabora = $this->cache->get('richdocuments_remote/' . $remote);
+		if ($remoteCollabora !== null) {
 			return $remoteCollabora;
 		}
 		try {


### PR DESCRIPTION
Else we would never use the result if fetching it failed and just keep
trying every time.