### PR TITLE
Apply new file name after rename

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -438,6 +438,9 @@ const documentsMain = {
 					case 'RD_Version_Restored':
 						$('#loleafletform_viewer').submit()
 						break
+					case 'File_Rename':
+						documentsMain.fileName = args.NewName
+						break
 					default:
 						console.debug('[document] Unhandled post message', parsed)
 					}


### PR DESCRIPTION
If file was renamed inside editor and then
SaveAs dialog was opened the old name was sill
present. This fixes that case.

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>