### PR TITLE
Added IP Address option to the watermark

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -196,12 +196,27 @@ class WopiController extends Controller {
 
 		if ($this->shouldWatermark($isPublic, $wopi->getEditorUid(), $fileId, $wopi)) {
 			$email = $user !== null && !$isPublic ? $user->getEMailAddress() : "";
+			if (!empty($_SERVER['HTTP_CLIENT_IP']))   
+			  {
+			    $ipAddr = $_SERVER['HTTP_CLIENT_IP'];
+			  }
+			//whether ip is from proxy
+			elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR']))  
+			  {
+			    $ipAddr = $_SERVER['HTTP_X_FORWARDED_FOR'];
+			  }
+			//whether ip is from remote address
+			else
+			  {
+			    $ipAddr = $_SERVER['REMOTE_ADDR'];
+			  }			
 			$replacements = [
 				'userId' => $wopi->getEditorUid(),
 				'date' => (new \DateTime())->format('Y-m-d H:i:s'),
 				'themingName' => \OC::$server->getThemingDefaults()->getName(),
 				'userDisplayName' => $userDisplayName,
 				'email' => $email,
+				'ipAddr' => $ipAddr,
 
 			];
 			$watermarkTemplate = $this->appConfig->getAppValue('watermark_text');

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -200,7 +200,7 @@
 			<settings-checkbox v-model="settings.watermark.enabled" :label="t('richdocuments', 'Enable watermarking')" hint=""
 				:disabled="updating" @input="update" />
 			<settings-input-text v-if="settings.watermark.enabled" v-model="settings.watermark.text" label="Watermark text"
-				:hint="t('richdocuments', 'Supported placeholders: {userId}, {userDisplayName}, {email}, {date}, {themingName}')"
+				:hint="t('richdocuments', 'Supported placeholders: {userId}, {userDisplayName}, {email}, {date}, {themingName}, {ipAddr}')"
 				:disabled="updating" @update="update" />
 			<div v-if="settings.watermark.enabled">
 				<settings-checkbox v-model="settings.watermark.allTags" :label="t('richdocuments', 'Show watermark on tagged files')" :disabled="updating"


### PR DESCRIPTION
...{ipAddr}
* Target version: master 

### Summary
I thought it was important to have IP address as an option on the watermark, especially if the file is shared publicly. 

This is working well on my machine, but if there's a better way to implement, let me know. 

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
