### PR TITLE
Improve dark theme experience

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -83,8 +83,6 @@ const hideLoadingIndicator = () => {
 const generateCSSVarTokens = () => {
 	/* NC versus COOL */
 	var cssVarMap = {
-		'--color-main-text': '--co-color-main-text',
-		'--color-main-background': '--co-body-bg',
 		'--color-primary-text': '--co-primary-text',
 		'--color-primary-element': '--co-primary-element:--co-text-accent',
 		'--color-primary-element-light': '--co-primary-element-light',
@@ -93,10 +91,6 @@ const generateCSSVarTokens = () => {
 		'--color-success': '--co-color-success',
 		'--border-radius': '--co-border-radius',
 		'--border-radius-large': '--co-border-radius-large',
-		'--color-background-hover': '--co-background-hover',
-		'--color-background-dark': '--co-background-dark',
-		'--color-text-light': '--co-text-light',
-		'--color-text-lighter': '--co-text-lighter',
 		'--color-loading-light': '--co-loading-light',
 		'--color-loading-dark': '--co-loading-dark',
 		'--color-box-shadow': '--co-box-shadow',


### PR DESCRIPTION
* Resolves: #1334 
* Target version: master 

### Summary
This pull request removes background colours and text colours from the list of variables being passed on to Collabora. Those colour variables aren't used for a lot of elements so they end up not really making a difference with the default theme but gives a bad dark theme experience.

From what I can tell, it isn't currently possible, to provide a proper dark theme experience using only colour variables in Collabora.

This won't affect #229 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required

### Screenshots
before
![dark-before](https://user-images.githubusercontent.com/19759293/109434508-f6e47000-7a15-11eb-944e-a0478ea0b5b4.png)
after
![dark-after](https://user-images.githubusercontent.com/19759293/109434509-f8ae3380-7a15-11eb-9f0d-91f01c8473cc.png)
after with red primary colour
![dark-red](https://user-images.githubusercontent.com/19759293/109434511-f9df6080-7a15-11eb-8216-66850e809c2a.png)