### PR TITLE
Avoid determination of document editor in per-user-encryption setups

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -22,17 +22,20 @@
 namespace OCA\Richdocuments\Controller;
 
 use OC\Files\View;
-use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\AppConfig;
+use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\Db\WopiMapper;
+use OCA\Richdocuments\Helper;
 use OCA\Richdocuments\Service\UserScopeService;
 use OCA\Richdocuments\TemplateManager;
 use OCA\Richdocuments\TokenManager;
-use OCA\Richdocuments\Helper;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\StreamResponse;
+use OCP\AppFramework\QueryException;
+use OCP\Encryption\IManager as IEncryptionManager;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\GenericFileException;
@@ -45,11 +48,10 @@ use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IRequest;
 use OCP\IURLGenerator;
-use OCP\AppFramework\Http\StreamResponse;
 use OCP\IUserManager;
 use OCP\Lock\LockedException;
 use OCP\Share\Exceptions\ShareNotFound;
-use OCP\Share\IManager;
+use OCP\Share\IManager as IShareManager;
 
 class WopiController extends Controller {
 	/** @var IRootFolder */
@@ -70,10 +72,12 @@ class WopiController extends Controller {
 	private $logger;
 	/** @var TemplateManager */
 	private $templateManager;
-	/** @var IManager */
+	/** @var IShareManager */
 	private $shareManager;
 	/** @var UserScopeService */
 	private $userScopeService;
+	/** @var IEncryptionManager */
+	private $encryptionManager;
 
 	// Signifies LOOL that document has been changed externally in this storage
 	const LOOL_STATUS_DOC_CHANGED = 1010;
@@ -84,11 +88,15 @@ class WopiController extends Controller {
 	 * @param IRootFolder $rootFolder
 	 * @param IURLGenerator $urlGenerator
 	 * @param IConfig $config
+	 * @param AppConfig $appConfig
 	 * @param TokenManager $tokenManager
 	 * @param IUserManager $userManager
 	 * @param WopiMapper $wopiMapper
 	 * @param ILogger $logger
 	 * @param TemplateManager $templateManager
+	 * @param IShareManager $shareManager
+	 * @param UserScopeService $userScopeService
+	 * @param IEncryptionManager $encryptionManager
 	 */
 	public function __construct(
 		$appName,
@@ -102,8 +110,9 @@ class WopiController extends Controller {
 		WopiMapper $wopiMapper,
 		ILogger $logger,
 		TemplateManager $templateManager,
-		IManager $shareManager,
-		UserScopeService $userScopeService
+		IShareManager $shareManager,
+		UserScopeService $userScopeService,
+		IEncryptionManager $encryptionManager
 	) {
 		parent::__construct($appName, $request);
 		$this->rootFolder = $rootFolder;
@@ -117,6 +126,7 @@ class WopiController extends Controller {
 		$this->templateManager = $templateManager;
 		$this->shareManager = $shareManager;
 		$this->userScopeService = $userScopeService;
+		$this->encryptionManager = $encryptionManager;
 	}
 
 	/**
@@ -172,7 +182,7 @@ class WopiController extends Controller {
 			'UserExtraInfo' => [
 			],
 			'UserCanWrite' => (bool)$wopi->getCanwrite(),
-			'UserCanNotWriteRelative' => \OC::$server->getEncryptionManager()->isEnabled() || $isPublic,
+			'UserCanNotWriteRelative' => $this->encryptionManager->isEnabled() || $isPublic,
 			'PostMessageOrigin' => $wopi->getServerHost(),
 			'LastModifiedTime' => Helper::toISO8601($file->getMTime()),
 			'SupportsRename' => !$isVersion,
@@ -403,9 +413,15 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		// Set the user to register the change under his name
-		$this->userScopeService->setUserScope($wopi->getUserForFileAccess());
-		$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
+		if (!$this->encryptionManager->isEnabled() || $this->isMasterKeyEnabled()) {
+			// Set the user to register the change under his name
+			$this->userScopeService->setUserScope($wopi->getUserForFileAccess());
+			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
+		} else {
+			// Per-user encryption is enabled so that collabora isn't able to store the file by using the
+			// user's private key. Because of that we have to use the incognito mode for writing the file.
+			\OC_User::setIncognitoMode(true);
+		}
 
 		try {
 			if ($isPutRelative) {
@@ -714,4 +730,19 @@ class WopiController extends Controller {
 		}
 	}
 
+	/**
+	 * Check if the encryption module uses a master key.
+	 *
+	 * @return bool
+	 */
+	private function isMasterKeyEnabled()
+	{
+		try {
+			$util = \OC::$server->query(\OCA\Encryption\Util::class);
+			return $util->isMasterKeyEnabled();
+		} catch (QueryException $e) {
+			// No encryption module enabled
+			return false;
+		}
+	}
 }

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -406,7 +406,6 @@ class WopiController extends Controller {
 							$access_token) {
 		list($fileId, ,) = Helper::parseFileId($fileId);
 		$isPutRelative = ($this->request->getHeader('X-WOPI-Override') === 'PUT_RELATIVE');
-		$isRenameFile = ($this->request->getHeader('X-WOPI-Override') === 'RENAME_FILE');
 
 		$wopi = $this->wopiMapper->getWopiForToken($access_token);
 		if (!$wopi->getCanwrite()) {

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -731,11 +731,8 @@ class WopiController extends Controller {
 
 	/**
 	 * Check if the encryption module uses a master key.
-	 *
-	 * @return bool
 	 */
-	private function isMasterKeyEnabled()
-	{
+	private function isMasterKeyEnabled(): bool {
 		try {
 			$util = \OC::$server->query(\OCA\Encryption\Util::class);
 			return $util->isMasterKeyEnabled();


### PR DESCRIPTION
* Resolves: #1379
* Target version: master 

### Summary
When saving a document with enabled per-user encryption keys, an exception `Private Key missing for user: please try to log-out and log-in again` is thrown.

This is caused by the determination of the user who is editing the document to be able to trace the document's changes (https://github.com/nextcloud/richdocuments/blob/master/lib/Controller/WopiController.php#L407). Setting a specific user causes the usage of the user-specific encryption key instead of using the incognito mode (like it's done in `getFile`: https://github.com/nextcloud/richdocuments/blob/master/lib/Controller/WopiController.php#L349).

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
