### PR TITLE
[stable3.7] Fix version restore

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -417,7 +417,14 @@ export default {
 		avatardiv.append(popover)
 	},
 
+	_originalOnClickRevertVersion: null,
+
 	addVersionSidebarEvents() {
+		const versionTabView = OCA.Files.App.fileList._detailsView._tabViews.find(t => t.el.id === 'versionsTabView')
+		if (versionTabView) {
+			this._originalOnClickRevertVersion = versionTabView._onClickRevertVersion
+			OCA.Files.App.fileList._detailsView._tabViews.find(t => t.el.id === 'versionsTabView')._onClickRevertVersion = () => {}
+		}
 		$(document.querySelector('#content')).on('click.revisions', '#app-sidebar .preview-container', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('click.revisions', '#app-sidebar .downloadVersion', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('mousedown.revisions', '#app-sidebar .revertVersion', this.restoreVersion.bind(this))
@@ -425,6 +432,10 @@ export default {
 	},
 
 	removeVersionSidebarEvents() {
+		const versionTabView = OCA.Files.App.fileList._detailsView._tabViews.find(t => t.el.id === 'versionsTabView')
+		if (versionTabView) {
+			versionTabView._onClickRevertVersion = this._originalOnClickRevertVersion
+		}
 		$(document.querySelector('#content')).off('click.revisions')
 		$(document.querySelector('#content')).off('click.revisions')
 		$(document.querySelector('#content')).off('mousedown.revisions')


### PR DESCRIPTION
When restoring a version during editing we need to wait for Collabora to be ready and therefore richdocuments needs to trigger the restore MOVE action whenever that is done. In order to avoid a too early restore we need to workaround by disabling the default restore action from the files_versions app.

A proper solution is possible once we have some way to hook into the files sidebar restore process with https://github.com/nextcloud/server/pull/26023 though this should at least make things work again for backward compatibility.