### PR TITLE
Fix a regression with GlobalScale IConfig conflicting with IConfig

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -47,6 +47,7 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Template\ITemplateManager;
 use OCP\Files\Template\TemplateFileCreator;
+use OCP\GlobalScale\IConfig as GlobalScaleConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IPreview;
@@ -220,8 +221,8 @@ class Application extends App implements IBootstrap {
 			$federationService = \OC::$server->query(FederationService::class);
 
 			// Always add trusted servers on global scale
-			/** @var IConfig $globalScale */
-			$globalScale = $container->query(IConfig::class);
+			/** @var GlobalScaleConfig $globalScale */
+			$globalScale = $container->query(GlobalScaleConfig::class);
 			if ($globalScale->isGlobalScaleEnabled()) {
 				$trustedList = \OC::$server->getConfig()->getSystemValue('gs.trustedHosts', []);
 				foreach ($trustedList as $server) {


### PR DESCRIPTION
* Resolves: #1442
* Target version: master 

### Summary

`OCP\GlobalScale\IConfig` was used and there was a mixup with `IConfig` in #1422
