### PR TITLE
Reload file name for share feature after Save As

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -342,7 +342,7 @@ $(document).ready(function() {
 			FilesAppIntegration.rename(args.NewName)
 			break
 		case 'Action_Save_Resp':
-			FilesAppIntegration.saveAs()
+			FilesAppIntegration.saveAs(args.fileName)
 			break
 		case 'close':
 			odfViewer.onClose()

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -109,14 +109,19 @@ export default {
 		$('#richdocuments-header').remove()
 	},
 
-	saveAs() {
+	saveAs(newName) {
 		if (this.handlers.saveAs && this.handlers.saveAs(this)) {
 			return
+		}
+
+		if (newName) {
+			this.fileName = newName
 		}
 
 		if (this.getFileList()) {
 			this.getFileList()
 				.reload()
+			OC.Apps.hideAppSidebar()
 		}
 	},
 


### PR DESCRIPTION
There was a bug that after save as the sidebar was showing
the old file when we used share feature.

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>
