### PR TITLE
Do not use libxml_disable_entity_loader on PHP 8 or later

### DIFF
--- a/lib/WOPI/Parser.php
+++ b/lib/WOPI/Parser.php
@@ -39,9 +39,14 @@ class Parser {
 	 */
 	public function getUrlSrc($mimetype) {
 		$discovery = $this->discoveryManager->get();
-		$loadEntities = libxml_disable_entity_loader(true);
-		$discoveryParsed = simplexml_load_string($discovery);
-		libxml_disable_entity_loader($loadEntities);
+		if (\PHP_VERSION_ID < 80000) {
+			$loadEntities = libxml_disable_entity_loader(true);
+			$discoveryParsed = simplexml_load_string($discovery);
+			libxml_disable_entity_loader($loadEntities);
+		} else {
+			$discoveryParsed = simplexml_load_string($discovery);
+		}
+
 
 		$result = $discoveryParsed->xpath(sprintf('/wopi-discovery/net-zone/app[@name=\'%s\']/action', $mimetype));
 		if ($result && count($result) > 0) {


### PR DESCRIPTION
Avoid deprecation logs on PHP 8

https://php.watch/versions/8.0/libxml_disable_entity_loader-deprecation

> In PHP 8.0 and later, PHP uses libxml versions from 2.9.0, which disabled XXE by default. libxml_disable_entity_loader() is now deprecated. 