### PR TITLE
Enhanced federated editing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.0']
         databases: ['sqlite']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation']
@@ -84,7 +84,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.0']
         databases: ['mysql']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation']
@@ -157,7 +157,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.0']
         databases: ['pgsql']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation']
@@ -232,7 +232,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.0']
         databases: ['oci']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation']

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,11 +18,12 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.4']
         databases: ['sqlite']
         server-versions: ['master']
+        scenarios: ['wopi', 'direct', 'federation']
 
-    name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
+    name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
     services:
       collabora:
@@ -53,7 +54,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit:8.5.14
@@ -71,13 +72,10 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose --database=${{ matrix.databases }} --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force ${{ env.APP_NAME }}
-          export OC_PASS=123456
-          ./occ user:add --password-from-env user1
-          ./occ user:add --password-from-env user2
 
-      - name: Run WOPI integration tests
+      - name: Run ${{ matrix.scenarios }} integration tests
         working-directory: apps/${{ env.APP_NAME }}
-        run: cd tests && bash run-integration.sh
+        run: cd tests && bash run-integration.sh features/${{ matrix.scenarios }}.feature
 
   mysql:
     runs-on: ubuntu-latest
@@ -86,11 +84,12 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4']
+        php-versions: ['7.4']
         databases: ['mysql']
         server-versions: ['master']
+        scenarios: ['wopi', 'direct', 'federation']
 
-    name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
+    name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
     services:
       mysql:
@@ -128,7 +127,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit:8.5.14
@@ -146,13 +145,10 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose --database=${{ matrix.databases }} --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force ${{ env.APP_NAME }}
-          export OC_PASS=123456
-          ./occ user:add --password-from-env user1
-          ./occ user:add --password-from-env user2
 
-      - name: Run WOPI integration tests
+      - name: Run ${{ matrix.scenarios }} integration tests
         working-directory: apps/${{ env.APP_NAME }}
-        run: cd tests && bash run-integration.sh
+        run: cd tests && bash run-integration.sh features/${{ matrix.scenarios }}.feature
 
   pgsql:
     runs-on: ubuntu-latest
@@ -164,8 +160,9 @@ jobs:
         php-versions: ['7.4']
         databases: ['pgsql']
         server-versions: ['master']
+        scenarios: ['wopi', 'direct', 'federation']
 
-    name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
+    name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
     services:
       postgres:
@@ -205,7 +202,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit:8.5.14
@@ -223,13 +220,10 @@ jobs:
           mkdir data
           ./occ maintenance:install --verbose --database=${{ matrix.databases }} --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force ${{ env.APP_NAME }}
-          export OC_PASS=123456
-          ./occ user:add --password-from-env user1
-          ./occ user:add --password-from-env user2
 
-      - name: Run WOPI integration tests
+      - name: Run ${{ matrix.scenarios }} integration tests
         working-directory: apps/${{ env.APP_NAME }}
-        run: cd tests && bash run-integration.sh
+        run: cd tests && bash run-integration.sh features/${{ matrix.scenarios }}.feature
 
   oci:
     runs-on: ubuntu-latest
@@ -241,8 +235,9 @@ jobs:
         php-versions: ['7.4']
         databases: ['oci']
         server-versions: ['master']
+        scenarios: ['wopi', 'direct', 'federation']
 
-    name: php${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
+    name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
     services:
       oracle:
@@ -277,7 +272,7 @@ jobs:
           path: apps/${{ env.APP_NAME }}
 
       - name: Set up php ${{ matrix.php-versions }}
-        uses: "shivammathur/setup-php@v2"
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-versions }}"
           extensions: mbstring, iconv, fileinfo, intl, oci8, gd, zip
@@ -294,10 +289,7 @@ jobs:
           ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=1521 --database-user=autotest --database-pass=owncloud --admin-user admin --admin-pass password
           php -f index.php
           ./occ app:enable --force ${{ env.APP_NAME }}
-          export OC_PASS=123456
-          ./occ user:add --password-from-env user1
-          ./occ user:add --password-from-env user2
 
-      - name: Run WOPI integration tests
+      - name: Run ${{ matrix.scenarios }} integration tests
         working-directory: apps/${{ env.APP_NAME }}
-        run: cd tests && bash run-integration.sh
+        run: cd tests && bash run-integration.sh features/${{ matrix.scenarios }}.feature

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -75,5 +75,6 @@ return [
 
 		['name' => 'Federation#index', 'url' => '/api/v1/federation', 'verb' => 'GET'],
 		['name' => 'Federation#remoteWopiToken', 'url' => '/api/v1/federation', 'verb' => 'POST'],
+		['name' => 'Federation#initiatorUser', 'url' => '/api/v1/federation/user', 'verb' => 'POST'],
 	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -30,7 +30,7 @@ return [
 		//documents
 		['name' => 'document#index', 'url' => 'index', 'verb' => 'GET'],
 		['name' => 'document#remote', 'url' => 'remote', 'verb' => 'GET'],
-		['name' => 'document#open', 'url' => 'open', 'verb' => 'GET'],
+		['name' => 'document#openRemoteFile', 'url' => 'open', 'verb' => 'GET'],
 
 		['name' => 'document#createFromTemplate', 'url' => 'indexTemplate', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
@@ -67,13 +67,13 @@ return [
 		['name' => 'templates#delete', 'url' => '/template/{fileId}', 'verb' => 'DELETE'],
 	],
 	'ocs' => [
-		['name' => 'OCS#create', 'url' => '/api/v1/document', 'verb' => 'POST'],
+		['name' => 'OCS#createDirect', 'url' => '/api/v1/document', 'verb' => 'POST'],
+		['name' => 'OCS#createPublic', 'url' => '/api/v1/share', 'verb' => 'POST'],
+		['name' => 'OCS#createPublicFromInitiator', 'url' => '/api/v1/direct/share/initiator', 'verb' => 'POST'],
 		['name' => 'OCS#getTemplates', 'url' => '/api/v1/templates/{type}', 'verb' => 'GET'],
 		['name' => 'OCS#createFromTemplate', 'url' => '/api/v1/templates/new', 'verb' => 'POST'],
 
 		['name' => 'Federation#index', 'url' => '/api/v1/federation', 'verb' => 'GET'],
 		['name' => 'Federation#remoteWopiToken', 'url' => '/api/v1/federation', 'verb' => 'POST'],
-		['name' => 'Federation#remoteDirectToken', 'url' => '/api/v1/federation/direct', 'verb' => 'POST'],
-
 	],
 ];

--- a/docs/federated-editing.md
+++ b/docs/federated-editing.md
@@ -1,0 +1,16 @@
+# Federated file editing
+
+Collabra Online offers support for collaborative editing of files that are shared through federated
+sharing. The file will always be opened on the file owners instance (Source) and other users will
+connect to that through their Nextcloud instance (Initiator).
+
+In a federated scenario both Nextcloud servers need to add each other as trusted servers or in a
+global scale environment a list of nodes can be added through the `gs.trustedHosts` setting in the
+config.php file.
+
+When a Initiator opens a file that is located on an incoming federated share, a check will be
+performed if the share owners instance supports federated editing. If that is the case a Initiator
+token will be created, and the user will be redirected to the Source instance to open the file.
+
+The source instance will then fetch the user and file details, create a WOPI token for the remote
+user with those details and open the document with that.

--- a/docs/mobile_editor.md
+++ b/docs/mobile_editor.md
@@ -1,14 +1,40 @@
 # Mobile Editor OCS API
 
-This API is used to obtain a link for a document to load from mobile apps
+This API is used to obtain a link for a document to load from mobile apps. The link will contain a
+one-time token that can be used once for opening a document in an anonymous browser session or
+webview on mobile devices in the context of the user.
 
-## Creating the link
+## Creating a link for a local file
 
 ```
 <server>/ocs/v2.php/apps/richdocuments/api/v1/document
 ```
 
-A `POST` request to this endpoint with the `fileid` parameter will
-preprare the server to serve this document.
+A `POST` request to this endpoint with the `fileid` parameter will preprare the server to serve this
+document.
 
-The returned xml or json will has an url to open in a webview.
+The returned xml or json will have an url to open in a webview.
+
+## Creating a link for public share links
+
+Opening public share links requires federated editing being properly setup between the two servers.
+
+```
+<server>/ocs/v2.php/apps/richdocuments/api/v1/share
+```
+
+A `POST` request to this endpoint with the following parameters preprare the server to serve this
+document:
+
+| Parameter | Type | Description | Example |
+|---|---|---|---|
+| shareToken | string | Share token of the public share link | Qf5toz6JD7Tn7eD |
+| host | string (optional) | Desc | http://cloud.example.com |
+| path | string (optional) | Path to the file in case the share link is a directory | /path/to/file.odt |
+| password | string (optional) | Optional password to gain access to the share | secret |
+
+The returned xml or json will have an url to open in a webview.
+
+The user will join the session as a guest but with their user details provided by their own
+instance.
+

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -213,7 +213,7 @@ class Application extends App implements IBootstrap {
 		try {
 			$path = $container->getServer()->getRequest()->getPathInfo();
 		} catch (\Exception $e) {}
-		if (strpos($path, '/apps/files/') === 0 && $container->getServer()->getAppManager()->isEnabledForUser('federation')) {
+		if ((strpos($path, '/apps/files/') === 0 || strpos($path, '/s/') === 0) && $container->getServer()->getAppManager()->isEnabledForUser('federation')) {
 			/** @var FederationService $federationService */
 			$federationService = \OC::$server->query(FederationService::class);
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -455,7 +455,7 @@ class DocumentController extends Controller {
 				if ($remoteWopi === null) {
 					throw new \Exception('Invalid remote file details for ' . $remoteServerToken);
 				}
-				$this->tokenManager->updateToRemoteToken($wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi);
+				$this->tokenManager->updateToFederationToken($wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi);
 
 				$permissions = $share->getPermissions();
 				if (!$remoteWopi['canwrite']) {

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -192,56 +192,6 @@ class DocumentController extends Controller {
 	}
 
 	/**
-	 * Redirect to the files app with proper CSP headers set for federated editing
-	 * This is a workaround since we cannot set a nonce for allowing dynamic URLs in the richdocument iframe
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 */
-	public function open($fileId) {
-		try {
-			$folder = $this->rootFolder->getUserFolder($this->uid);
-			$item = $folder->getById($fileId)[0];
-			if (!($item instanceof File)) {
-				throw new \Exception('Node is not a file');
-			}
-
-			if ($item->getStorage()->instanceOfStorage(\OCA\Files_Sharing\External\Storage::class)) {
-				$remote = $item->getStorage()->getRemote();
-				$remoteCollabora = $this->federationService->getRemoteCollaboraURL($remote);
-				if ($remoteCollabora !== '') {
-					$absolute = $item->getParent()->getPath();
-					$relativeFolderPath = $folder->getRelativePath($absolute);
-					$relativeFilePath = $folder->getRelativePath($item->getPath());
-					$url = '/index.php/apps/files/?dir=' . $relativeFolderPath .
-						'&richdocuments_open=' . $relativeFilePath .
-						'&richdocuments_fileId=' . $fileId .
-						'&richdocuments_remote_access=' . $remote;
-
-						$event = new BeforeFederationRedirectEvent(
-							$item, $relativeFolderPath, $remote
-						);
-						$eventDispatcher = \OC::$server->getEventDispatcher();
-						$eventDispatcher->dispatch(BeforeFederationRedirectEvent::class, $event);
-						if ($event->getRedirectUrl()) {
-							$url = $event->getRedirectUrl();
-						}
-					return new RedirectResponse($url);
-				}
-				$this->logger->warning('Failed to connect to remote collabora instance for ' . $fileId);
-			}
-		} catch (\Exception $e) {
-			$this->logger->logException($e, ['app'=>'richdocuments']);
-			$params = [
-				'errors' => [['error' => $e->getMessage()]]
-			];
-			return new TemplateResponse('core', 'error', $params, 'guest');
-		}
-
-		return new TemplateResponse('core', '403', [], 'guest');
-	}
-
-	/**
 	 * @NoAdminRequired
 	 *
 	 * @param string $fileId
@@ -262,7 +212,10 @@ class DocumentController extends Controller {
 				throw new \Exception();
 			}
 
-			/** Open file from remote collabora */
+			/**
+			 * Open file on source instance if it is originating from a federated share
+			 * The generated url will result in {@link remote()}
+			 */
 			$federatedUrl = $this->federationService->getRemoteRedirectURL($item);
 			if ($federatedUrl !== null) {
 				$response = new RedirectResponse($federatedUrl);
@@ -304,8 +257,6 @@ class DocumentController extends Controller {
 			];
 			return new TemplateResponse('core', 'error', $params, 'guest');
 		}
-
-		return new TemplateResponse('core', '403', [], 'guest');
 	}
 
 	/**
@@ -342,7 +293,6 @@ class DocumentController extends Controller {
 		$template = $this->templateManager->get($templateId);
 		list($urlSrc, $wopi) = $this->tokenManager->getTokenForTemplate($template, $this->uid, $file->getId());
 
-		$wopiFileId = $template->getId() . '-' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid');
 		$wopiFileId = $wopi->getFileid() . '_' . $this->settings->getSystemValue('instanceid');
 
 		$params = [
@@ -368,7 +318,7 @@ class DocumentController extends Controller {
 	 *
 	 * @param string $shareToken
 	 * @param string $fileName
-	 * @return TemplateResponse
+	 * @return TemplateResponse|RedirectResponse
 	 * @throws \Exception
 	 */
 	public function publicPage($shareToken, $fileName, $fileId) {
@@ -388,6 +338,12 @@ class DocumentController extends Controller {
 				$item = $node->getById($fileId)[0];
 			} else {
 				$item = $node;
+			}
+			$federatedUrl = $this->federationService->getRemoteRedirectURL($item, null, $share);
+			if ($federatedUrl !== null) {
+				$response = new RedirectResponse($federatedUrl);
+				$response->addHeader('X-Frame-Options', 'ALLOW');
+				return $response;
 			}
 			if ($item instanceof Node) {
 				$params = [
@@ -422,6 +378,58 @@ class DocumentController extends Controller {
 	}
 
 	/**
+	 * Redirect to the files app with proper CSP headers set for federated editing
+	 * This is a workaround since we cannot set a nonce for allowing dynamic URLs in the richdocument iframe
+	 *
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 */
+	public function openRemoteFile($fileId) {
+		try {
+			$folder = $this->rootFolder->getUserFolder($this->uid);
+			$item = $folder->getById($fileId)[0];
+			if (!($item instanceof File)) {
+				throw new \Exception('Node is not a file');
+			}
+
+			if ($item->getStorage()->instanceOfStorage(\OCA\Files_Sharing\External\Storage::class)) {
+				$remote = $item->getStorage()->getRemote();
+				$remoteCollabora = $this->federationService->getRemoteCollaboraURL($remote);
+				if ($remoteCollabora !== '') {
+					$absolute = $item->getParent()->getPath();
+					$relativeFolderPath = $folder->getRelativePath($absolute);
+					$relativeFilePath = $folder->getRelativePath($item->getPath());
+					$url = '/index.php/apps/files/?dir=' . $relativeFolderPath .
+						'&richdocuments_open=' . $relativeFilePath .
+						'&richdocuments_fileId=' . $fileId .
+						'&richdocuments_remote_access=' . $remote;
+
+					$event = new BeforeFederationRedirectEvent(
+						$item, $relativeFolderPath, $remote
+					);
+					$eventDispatcher = \OC::$server->getEventDispatcher();
+					$eventDispatcher->dispatch(BeforeFederationRedirectEvent::class, $event);
+					if ($event->getRedirectUrl()) {
+						$url = $event->getRedirectUrl();
+					}
+					return new RedirectResponse($url);
+				}
+				$this->logger->warning('Failed to connect to remote collabora instance for ' . $fileId);
+			}
+		} catch (\Exception $e) {
+			$this->logger->logException($e, ['app'=>'richdocuments']);
+			$params = [
+				'errors' => [['error' => $e->getMessage()]]
+			];
+			return new TemplateResponse('core', 'error', $params, 'guest');
+		}
+
+		return new TemplateResponse('core', '403', [], 'guest');
+	}
+
+	/**
+	 * Open file on Source instance with token from Initiator instance
+	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 *
@@ -455,10 +463,10 @@ class DocumentController extends Controller {
 				if ($remoteWopi === null) {
 					throw new \Exception('Invalid remote file details for ' . $remoteServerToken);
 				}
-				$this->tokenManager->updateToFederationToken($wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi);
+				$this->tokenManager->upgradeToRemoteToken($wopi, $remoteWopi, $shareToken, $remoteServer, $remoteServerToken);
 
 				$permissions = $share->getPermissions();
-				if (!$remoteWopi['canwrite']) {
+				if (!$remoteWopi->getCanwrite()) {
 					$permissions = $permissions & ~ Constants::PERMISSION_UPDATE;
 				}
 
@@ -471,7 +479,7 @@ class DocumentController extends Controller {
 					'path' => '/',
 					'instanceId' => $this->settings->getSystemValue('instanceid'),
 					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
-					'userId' => $remoteWopi['editorUid'] . '@' . $remoteServer
+					'userId' => $remoteWopi->getEditorUid() ? ($remoteWopi->getEditorUid() . '@' . $remoteServer) : null,
 				];
 
 				$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -128,27 +128,25 @@ class OCSController extends \OCP\AppFramework\OCSController {
 	/**
 	 * Generate a direct editing link for a file in a public share to open with the current user
 	 *
-	 * If
-	 *
 	 * @NoAdminRequired
 	 * @throws OCSForbiddenException
 	 */
 	public function createPublic(
-		string $shareTokenSourceInstance = null,
 		string $shareToken,
+		string $host = null,
 		string $path = '',
 		string $password = null
 	): DataResponse {
-		if ($shareTokenSourceInstance) {
-			$remoteCollabora = $this->federationService->getRemoteCollaboraURL($shareTokenSourceInstance);
+		if ($host) {
+			$remoteCollabora = $this->federationService->getRemoteCollaboraURL($host);
 			if ($remoteCollabora === '') {
 				throw new OCSNotFoundException('Failed to connect to remote collabora instance.');
 			}
 
-			$wopi = $this->tokenManager->newInitiatorToken($shareTokenSourceInstance, null, $shareToken, true, $this->userId);
+			$wopi = $this->tokenManager->newInitiatorToken($host, null, $shareToken, true, $this->userId);
 
 			$client = \OC::$server->getHTTPClientService()->newClient();
-			$response = $client->post(rtrim($shareTokenSourceInstance, '/') . '/ocs/v2.php/apps/richdocuments/api/v1/direct/share/initiator?format=json', [
+			$response = $client->post(rtrim($host, '/') . '/ocs/v2.php/apps/richdocuments/api/v1/direct/share/initiator?format=json', [
 				'body' => [
 					'initiatorServer' => \OC::$server->getURLGenerator()->getAbsoluteURL(''),
 					'initiatorToken' => $wopi->getToken(),

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -156,7 +156,7 @@ class OCSController extends \OCP\AppFramework\OCSController {
 					'path' => $path,
 					'password' => $password
 				],
-				'timeout' => 5
+				'timeout' => 30
 			]);
 			$url = \json_decode($response->getBody(), true)['ocs']['data']['url'];
 

--- a/lib/Db/Direct.php
+++ b/lib/Db/Direct.php
@@ -58,6 +58,15 @@ class Direct extends Entity {
 	/** @var int */
 	protected $templateId;
 
+	/** @var string */
+	protected $share;
+
+	/** @var string */
+	protected $initiatorHost;
+
+	/** @var string */
+	protected $initiatorToken;
+
 	public function __construct() {
 		$this->addType('token', 'string');
 		$this->addType('uid', 'string');
@@ -65,5 +74,8 @@ class Direct extends Entity {
 		$this->addType('timestamp', 'int');
 		$this->addType('template_destination', 'int');
 		$this->addType('template_id', 'int');
+		$this->addType('share', 'string');
+		$this->addType('initiator_host', 'string');
+		$this->addType('initiator_token', 'string');
 	}
 }

--- a/lib/Db/DirectMapper.php
+++ b/lib/Db/DirectMapper.php
@@ -51,18 +51,21 @@ class DirectMapper extends Mapper {
 	}
 
 	/**
-	 * @param string $uid
+	 * @param string|null $uid
 	 * @param int $fileid
 	 * @param int $destination
 	 * @return Direct
 	 */
-	public function newDirect($uid, $fileid, $destination = null) {
+	public function newDirect($uid, $fileid, $destination = null, $share = null, $initiatorHost = null, $initiatorToken = null) {
 		$direct = new Direct();
 		$direct->setUid($uid);
 		$direct->setFileid($fileid);
 		$direct->setToken($this->random->generate(64, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER));
 		$direct->setTimestamp($this->timeFactory->getTime());
 		$direct->setTemplateDestination($destination);
+		$direct->setShare($share);
+		$direct->setInitiatorHost($initiatorHost);
+		$direct->setInitiatorToken($initiatorToken);
 
 		$direct = $this->insert($direct);
 		return $direct;

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -51,8 +51,35 @@ use OCP\AppFramework\Db\Entity;
  * @method int getTemplateDestination()
  * @method void setTemplateId(int $fileId)
  * @method int getTemplateId()
+ * @method void setShare(string $token)
  */
 class Wopi extends Entity {
+
+	/**
+	 * WOPI token to open a file as a user on the current instance
+	 */
+	const TOKEN_TYPE_USER = 0;
+
+	/**
+	 * WOPI token to open a file as a guest on the current instance
+	 */
+	const TOKEN_TYPE_GUEST = 1;
+
+	/**
+	 * WOPI token to open a file as a user from a federated instane
+	 */
+	const TOKEN_TYPE_REMOTE_USER = 2;
+
+	/**
+	 * WOPI token to open a file as a guest from a federated instane
+	 */
+	const TOKEN_TYPE_REMOTE_GUEST = 3;
+
+	/*
+	 * Temporary token that is used to share the opener details to a federated instance
+	 */
+	const TOKEN_TYPE_FEDERATION = 4;
+
 	/** @var string */
 	protected $ownerUid;
 
@@ -92,9 +119,6 @@ class Wopi extends Entity {
 	/** @var bool */
 	protected $direct;
 
-	/** @var bool */
-	protected $isRemoteToken;
-
 	/** @var string */
 	protected $remoteServer;
 
@@ -103,6 +127,9 @@ class Wopi extends Entity {
 
 	/** @var string */
 	protected $share;
+
+	/** @var int */
+	protected $tokenType = 0;
 
 	public function __construct() {
 		$this->addType('owner_uid', 'string');
@@ -118,6 +145,7 @@ class Wopi extends Entity {
 		$this->addType('templateId', 'int');
 		$this->addType('hide_download', 'bool');
 		$this->addType('direct', 'bool');
+		$this->addType('tokenType', 'int');
 	}
 
 	public function isTemplateToken() {
@@ -129,7 +157,7 @@ class Wopi extends Entity {
 	}
 
 	public function isGuest() {
-		return $this->getGuestDisplayname() !== null;
+		return $this->getTokenType() === Wopi::TOKEN_TYPE_GUEST || Wopi::TOKEN_TYPE_REMOTE_GUEST;
 	}
 
 	public function getUserForFileAccess() {

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -64,7 +64,7 @@ class WopiMapper extends Mapper {
 	 * @param int $templateDestination
 	 * @return Wopi
 	 */
-	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false, $isRemoteToken = false, $templateId = 0, $share = null) {
+	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false, $templateId = 0, $share = null, $tokenType = Wopi::TOKEN_TYPE_USER) {
 		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
 
 		$wopi = Wopi::fromParams([
@@ -80,11 +80,11 @@ class WopiMapper extends Mapper {
 			'templateDestination' => $templateDestination,
 			'hideDownload' => $hideDownload,
 			'direct' => $direct,
-			'isRemoteToken' => $isRemoteToken,
 			'templateId' => $templateId,
 			'remoteServer' => '',
 			'remoteServerToken' => '',
-			'share' => $share
+			'share' => $share,
+			'tokenType' => $tokenType
 		]);
 
 		/** @var Wopi $wopi */

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -64,7 +64,7 @@ class WopiMapper extends Mapper {
 	 * @param int $templateDestination
 	 * @return Wopi
 	 */
-	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname, $templateDestination = 0, $hideDownload = false, $direct = false, $templateId = 0, $share = null, $tokenType = Wopi::TOKEN_TYPE_USER) {
+	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname = null, $templateDestination = 0, $hideDownload = false, $direct = false, $templateId = 0, $share = null) {
 		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
 
 		$wopi = Wopi::fromParams([
@@ -84,7 +84,25 @@ class WopiMapper extends Mapper {
 			'remoteServer' => '',
 			'remoteServerToken' => '',
 			'share' => $share,
-			'tokenType' => $tokenType
+			'tokenType' => $guestDisplayname === null ? Wopi::TOKEN_TYPE_USER : Wopi::TOKEN_TYPE_GUEST
+		]);
+
+		/** @var Wopi $wopi */
+		$wopi = $this->insert($wopi);
+
+		return $wopi;
+	}
+
+	public function generateInitiatorToken($uid, $remoteServer) {
+		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
+
+		$wopi = Wopi::fromParams([
+			'fileid' => 0,
+			'editorUid' => $uid,
+			'token' => $token,
+			'expiry' => $this->timeFactory->getTime() + self::TOKEN_LIFETIME_SECONDS,
+			'remoteServer' => $remoteServer,
+			'tokenType' => Wopi::TOKEN_TYPE_INITIATOR
 		]);
 
 		/** @var Wopi $wopi */

--- a/lib/Migration/Version30717Date20210310164901.php
+++ b/lib/Migration/Version30717Date20210310164901.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Richdocuments\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version30717Date20210310164901 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('richdocuments_wopi');
+
+		if (!$table->hasColumn('token_type')) {
+			$table->addColumn('token_type', 'integer', [
+				'notnull' => false,
+				'length' => 4,
+				'default' => 0,
+			]);
+		}
+		if ($table->hasColumn('is_remote_token')) {
+			$table->dropColumn('is_remote_token');
+		}
+
+		return $schema;
+	}
+
+}

--- a/lib/Migration/Version30717Date20210310164901.php
+++ b/lib/Migration/Version30717Date20210310164901.php
@@ -28,6 +28,27 @@ class Version30717Date20210310164901 extends SimpleMigrationStep {
 			$table->dropColumn('is_remote_token');
 		}
 
+		$table = $schema->getTable('richdocuments_direct');
+
+		if (!$table->hasColumn('share')) {
+			$table->addColumn('share', 'string', [
+				'notnull' => false,
+				'length' => 64
+			]);
+		}
+		if (!$table->hasColumn('initiator_host')) {
+			$table->addColumn('initiator_host', 'string', [
+				'notnull' => false,
+				'length' => 255
+			]);
+		}
+		if (!$table->hasColumn('initiator_token')) {
+			$table->addColumn('initiator_token', 'string', [
+				'notnull' => false,
+				'length' => 64
+			]);
+		}
+
 		return $schema;
 	}
 

--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -26,6 +26,8 @@ namespace OCA\Richdocuments\Service;
 
 use OCA\Federation\TrustedServers;
 use OCA\Files_Sharing\External\Storage as SharingExternalStorage;
+use OCA\Richdocuments\Db\Direct;
+use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\TokenManager;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\QueryException;
@@ -38,6 +40,7 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\IRequest;
+use OCP\Share\IShare;
 
 class FederationService {
 
@@ -148,33 +151,21 @@ class FederationService {
 		return $host;
 	}
 
-	public function getRemoteDirectUrl($remote, $shareToken, $filePath) {
-		if ($this->getRemoteCollaboraURL() === '') {
-			return '';
+	/** @return Wopi|null */
+	public function getRemoteFileDetails(string $remote, string $remoteToken) {
+		$cacheKey = md5($remote . $remoteToken);
+		$remoteWopi = $this->cache->get($cacheKey);
+		if ($remoteWopi !== null) {
+			return Wopi::fromParams($remoteWopi);
 		}
-		try {
-			$client = $this->clientService->newClient();
-			$response = $client->post($remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation/direct?format=json', [
-				'timeout' => 5,
-				'body' => [
-					'shareToken' => $shareToken,
-					'filePath' => $filePath
-				]
-			]);
-			$data = \json_decode($response->getBody(), true);
-			return $data['ocs']['data'];
-		} catch (\Throwable $e) {
-			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote, ['exception' => $e]);
-		}
-		return null;
-	}
 
-	public function getRemoteFileDetails($remote, $remoteToken) {
 		if (!$this->isTrustedRemote($remote)) {
-			$this->logger->info('Unable to determine collabora URL of remote server ' . $remote . ' - Remote is not a trusted server');
+			$this->logger->info('COOL-Federation-Source: Unable to determine collabora URL of remote server ' . $remote . ' for token ' . $remoteToken . ' - Remote is not a trusted server');
 			return null;
 		}
+
 		try {
+			$this->logger->debug('COOL-Federation-Source: Fetching remote file details from ' . $remote . ' for token ' . $remoteToken);
 			$client = $this->clientService->newClient();
 			$response = $client->post($remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation?format=json', [
 				'timeout' => 5,
@@ -184,10 +175,11 @@ class FederationService {
 			]);
 			$responseBody = $response->getBody();
 			$data = \json_decode($responseBody, true, 512);
-			$this->logger->debug('Reveived remote file details for ' . $remoteToken . ' from ' . $remote . ': ' . $responseBody);
-			return $data['ocs']['data'];
+			$this->logger->debug('COOL-Federation-Source: Received remote file details for ' . $remoteToken . ' from ' . $remote . ': ' . json_encode($data['ocs']['data']));
+			$this->cache->set($cacheKey, $data['ocs']['data']);
+			return Wopi::fromParams($data['ocs']['data']);
 		} catch (\Throwable $e) {
-			$this->logger->error('Unable to fetch remote file details for ' . $remoteToken . ' from ' . $remote, ['exception' => $e]);
+			$this->logger->error('COOL-Federation-Source: Unable to fetch remote file details for ' . $remoteToken . ' from ' . $remote, ['exception' => $e]);
 		}
 		return null;
 	}
@@ -198,26 +190,37 @@ class FederationService {
 	 * @throws NotFoundException
 	 * @throws InvalidPathException
 	 */
-	public function getRemoteRedirectURL(File $item, $direct = null) {
-		if ($item->getStorage()->instanceOfStorage(SharingExternalStorage::class)) {
-			$remote = $item->getStorage()->getRemote();
-			$remoteCollabora = $this->getRemoteCollaboraURL($remote);
-			if ($remoteCollabora !== '') {
-				if ($direct === null) {
-					$wopi = $this->tokenManager->getRemoteToken($item);
-				} else {
-					$wopi = $this->tokenManager->getRemoteTokenFromDirect($item, $direct->getUid());
-				}
-				$url = rtrim($remote, '/') . '/index.php/apps/richdocuments/remote?shareToken=' . $item->getStorage()->getToken() .
-					'&remoteServer=' . $wopi->getServerHost() .
-					'&remoteServerToken=' . $wopi->getToken();
-				if ($item->getInternalPath() !== '') {
-					$url .= '&filePath=' . $item->getInternalPath();
-				}
-				return $url;
-			}
-			throw new NotFoundException('Failed to connect to remote collabora instance for ' . $item->getId());
+	public function getRemoteRedirectURL(File $item, Direct $direct = null, IShare $share = null) {
+		if (!$item->getStorage()->instanceOfStorage(SharingExternalStorage::class)) {
+			return null;
 		}
-		return null;
+
+		$remote = $item->getStorage()->getRemote();
+		$remoteCollabora = $this->getRemoteCollaboraURL($remote);
+		if ($remoteCollabora !== '') {
+			$shareToken = $share ? $share->getToken() : null;
+
+			$wopi = $this->tokenManager->newInitiatorToken($remote, $item, $shareToken, ($direct !== null), ($direct ? $direct->getUid() : null));
+			$initiatorServer = $wopi->getServerHost();
+			$initiatorToken = $wopi->getToken();
+
+			if ($direct) {
+				//$wopi->setRemoteServer($direct->getInitiatorHost());
+				//$wopi->setRemoteServerToken($direct->getInitiatorToken());
+				// FIXME: the direct token might have a different originator when a share link originating on a federated stoarge is opened
+				// editor uid is null since we don't fetch it from the initiator of direct so @{link remoteWopiToken()} fails
+				// Currently there is no mapping from the initiator user data to the source then
+			}
+
+			$url = rtrim($remote, '/') . '/index.php/apps/richdocuments/remote?shareToken=' . $item->getStorage()->getToken() .
+				'&remoteServer=' . $initiatorServer .
+				'&remoteServerToken=' . $initiatorToken;
+			if ($item->getInternalPath() !== '') {
+				$url .= '&filePath=' . $item->getInternalPath();
+			}
+			return $url;
+		}
+
+		throw new NotFoundException('Failed to connect to remote collabora instance for ' . $item->getId());
 	}
 }

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -21,6 +21,7 @@
 
 namespace OCA\Richdocuments;
 
+use OCA\Richdocuments\Db\Direct;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\Service\CapabilitiesService;
@@ -33,6 +34,7 @@ use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Share\IManager;
 use OCP\IL10N;
+use OCP\Share\IShare;
 use OCP\Util;
 
 class TokenManager {
@@ -61,16 +63,6 @@ class TokenManager {
 	/** @var Helper */
 	private $helper;
 
-	/**
-	 * @param IRootFolder $rootFolder
-	 * @param IManager $shareManager
-	 * @param IURLGenerator $urlGenerator
-	 * @param Parser $wopiParser
-	 * @param AppConfig $appConfig
-	 * @param string $UserId
-	 * @param WopiMapper $wopiMapper
-	 * @param IL10N $trans
-	 */
 	public function __construct(
 		IRootFolder $rootFolder,
 		IManager $shareManager,
@@ -191,25 +183,24 @@ class TokenManager {
 		$fp = $file->fopen('r');
 		fclose($fp);
 
-		$serverHost = $this->urlGenerator->getAbsoluteURL('/');//$this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
-		$guest_name = null;
+		$guestName = null;
 		if ($this->userId === null) {
-			if ($guest_name = $this->helper->getGuestName()) {
-				$guest_name = $this->trans->t('%s (Guest)', Util::sanitizeHTML($guest_name));
+			if ($guestName = $this->helper->getGuestName()) {
+				$guestName = $this->trans->t('%s (Guest)', Util::sanitizeHTML($guestName));
 				$cut = 56;
-				while (mb_strlen($guest_name) >= 64) {
-					$guest_name = $this->trans->t('%s (Guest)', Util::sanitizeHTML(
-						mb_substr($guest_name, 0, $cut)
+				while (mb_strlen($guestName) >= 64) {
+					$guestName = $this->trans->t('%s (Guest)', Util::sanitizeHTML(
+						mb_substr($guestName, 0, $cut)
 					));
 					$cut -= 5;
 				}
 			} else {
-				$guest_name = $this->trans->t('Anonymous guest');
+				$guestName = $this->trans->t('Anonymous guest');
 			}
 		}
-
-		$wopi = $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guest_name, 0, $hideDownload, $direct, 0, $shareToken);
+		$wopi = $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guestName, 0, $hideDownload, $direct, 0, $shareToken);
 
 		try {
 
@@ -224,21 +215,33 @@ class TokenManager {
 	}
 
 	/**
-	 * @param Wopi $wopi
-	 * @param $shareToken
-	 * @param $remoteServer
-	 * @param $remoteServerToken
-	 * @param $remoteWopi
-	 * @return Wopi
+	 * This method is receiving the results from the TOKEN_TYPE_FEDERATION generated on the opener server
+	 * that is created in {@link newInitiatorToken}
 	 */
-	public function updateToFederationToken(Wopi $wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi) {
-		// $wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_*);
-		$uid = $remoteWopi['editorUid'] ? ($remoteWopi['editorUid'] . '@' . $remoteServer) : null;
-		$wopi->setEditorUid($shareToken);
-		$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi['canwrite']);
+	public function upgradeToRemoteToken(Wopi $wopi, Wopi $remoteWopi, string $shareToken, string $remoteServer, string $remoteServerToken): Wopi {
+		if ($remoteWopi->getTokenType() !== Wopi::TOKEN_TYPE_INITIATOR) {
+			return $wopi;
+		}
+
+		$remoteTokenType = $remoteWopi->getEditorUid() !== null ? Wopi::TOKEN_TYPE_REMOTE_USER : Wopi::TOKEN_TYPE_REMOTE_GUEST;
+		$wopi->setTokenType($remoteTokenType);
+		if ($remoteTokenType === Wopi::TOKEN_TYPE_REMOTE_USER) {
+			$wopi->setGuestDisplayname($remoteWopi->getEditorUid() . '@' . $remoteServer);
+		}
+		$wopi->setShare($shareToken);
+		$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi->getCanwrite());
+		$wopi->setHideDownload($wopi->getHideDownload() || $remoteWopi->getHideDownload());
 		$wopi->setRemoteServer($remoteServer);
 		$wopi->setRemoteServerToken($remoteServerToken);
-		$wopi->setGuestDisplayname($uid);
+		$this->wopiMapper->update($wopi);
+		return $wopi;
+	}
+
+	public function upgradeFromDirectInitiator(Direct $direct, Wopi $wopi) {
+		$wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_GUEST);
+		$wopi->setEditorUid(null);
+		$wopi->setRemoteServer($direct->getInitiatorHost());
+		$wopi->setRemoteServerToken($direct->getInitiatorToken());
 		$this->wopiMapper->update($wopi);
 		return $wopi;
 	}
@@ -287,31 +290,16 @@ class TokenManager {
 		];
 	}
 
-	/**
-	 * @param Node $node
-	 * @return Wopi
-	 */
-	public function getRemoteToken(Node $node) {
-		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, null, false);
-		$wopi->setIsRemoteToken(true);
-		$wopi->setRemoteServer($node->getStorage()->getRemote());
-		$wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_USER);
-		$this->wopiMapper->update($wopi);
-		return $wopi;
-	}
+	public function newInitiatorToken($sourceServer, Node $node = null, $shareToken = null, bool $direct = false, $userId = null): Wopi {
+		if ($node !== null) {
+			list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), $shareToken, $userId, $direct);
+			$wopi->setServerHost($sourceServer);
+			$wopi->setTokenType(Wopi::TOKEN_TYPE_INITIATOR);
+			$this->wopiMapper->update($wopi);
+			return $wopi;
+		}
 
-	/**
-	 * @param Node $node
-	 * @return Wopi
-	 */
-	public function getRemoteTokenFromDirect(Node $node, $editorUid) {
-		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, $editorUid, true);
-		$wopi->setIsRemoteToken(true);
-		$wopi->setRemoteServer($node->getStorage()->getRemote());
-		$wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_USER);
-		$this->wopiMapper->update($wopi);
-		return $wopi;
+		return $this->wopiMapper->generateInitiatorToken($this->userId, $sourceServer);
 	}
-
 
 }

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -225,9 +225,11 @@ class TokenManager {
 
 		$remoteTokenType = $remoteWopi->getEditorUid() !== null ? Wopi::TOKEN_TYPE_REMOTE_USER : Wopi::TOKEN_TYPE_REMOTE_GUEST;
 		$wopi->setTokenType($remoteTokenType);
-		if ($remoteTokenType === Wopi::TOKEN_TYPE_REMOTE_USER) {
-			$wopi->setGuestDisplayname($remoteWopi->getEditorUid() . '@' . $remoteServer);
-		}
+		$wopi->setGuestDisplayname(
+			$remoteTokenType === Wopi::TOKEN_TYPE_REMOTE_USER ?
+				$remoteWopi->getEditorUid() . '@' . $remoteServer :
+				$remoteWopi->getGuestDisplayname()
+		);
 		$wopi->setShare($shareToken);
 		$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi->getCanwrite());
 		$wopi->setHideDownload($wopi->getHideDownload() || $remoteWopi->getHideDownload());
@@ -300,6 +302,13 @@ class TokenManager {
 		}
 
 		return $this->wopiMapper->generateInitiatorToken($this->userId, $sourceServer);
+	}
+
+	public function extendWithInitiatorUserToken(Wopi $wopi, string $initiatorUserHost, string $initiatorUserToken): Wopi {
+		$wopi->setRemoteServer($initiatorUserHost);
+		$wopi->setRemoteServerToken($initiatorUserToken);
+		$this->wopiMapper->update($wopi);
+		return $wopi;
 	}
 
 }

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -106,7 +106,7 @@ class TokenManager {
 	 * @return array
 	 * @throws \Exception
 	 */
-	public function getToken($fileId, $shareToken = null, $editoruid = null, $direct = false, $isRemoteToken = false) {
+	public function getToken($fileId, $shareToken = null, $editoruid = null, $direct = false) {
 		list($fileId, , $version) = Helper::parseFileId($fileId);
 		$owneruid = null;
 		$hideDownload = false;
@@ -209,7 +209,7 @@ class TokenManager {
 			}
 		}
 
-		$wopi = $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guest_name, 0, $hideDownload, $direct, $isRemoteToken, 0, $shareToken);
+		$wopi = $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guest_name, 0, $hideDownload, $direct, 0, $shareToken);
 
 		try {
 
@@ -223,8 +223,17 @@ class TokenManager {
 		}
 	}
 
-	public function updateToRemoteToken(Wopi $wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi) {
-		$uid = $remoteWopi['editorUid'] . '@' . $remoteServer;
+	/**
+	 * @param Wopi $wopi
+	 * @param $shareToken
+	 * @param $remoteServer
+	 * @param $remoteServerToken
+	 * @param $remoteWopi
+	 * @return Wopi
+	 */
+	public function updateToFederationToken(Wopi $wopi, $shareToken, $remoteServer, $remoteServerToken, $remoteWopi) {
+		// $wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_*);
+		$uid = $remoteWopi['editorUid'] ? ($remoteWopi['editorUid'] . '@' . $remoteServer) : null;
 		$wopi->setEditorUid($shareToken);
 		$wopi->setCanwrite($wopi->getCanwrite() && $remoteWopi['canwrite']);
 		$wopi->setRemoteServer($remoteServer);
@@ -283,10 +292,10 @@ class TokenManager {
 	 * @return Wopi
 	 */
 	public function getRemoteToken(Node $node) {
-		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, null, false, true);
+		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, null, false);
 		$wopi->setIsRemoteToken(true);
 		$wopi->setRemoteServer($node->getStorage()->getRemote());
-
+		$wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_USER);
 		$this->wopiMapper->update($wopi);
 		return $wopi;
 	}
@@ -296,10 +305,10 @@ class TokenManager {
 	 * @return Wopi
 	 */
 	public function getRemoteTokenFromDirect(Node $node, $editorUid) {
-		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, $editorUid, true, true);
+		list($urlSrc, $token, $wopi) = $this->getToken($node->getId(), null, $editorUid, true);
 		$wopi->setIsRemoteToken(true);
 		$wopi->setRemoteServer($node->getStorage()->getRemote());
-
+		$wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_USER);
 		$this->wopiMapper->update($wopi);
 		return $wopi;
 	}

--- a/src/document.js
+++ b/src/document.js
@@ -250,8 +250,10 @@ const documentsMain = {
 				return
 			}
 
-			OC.Util.History.addOnPopStateHandler(_.bind(documentsMain.onClose))
-			OC.Util.History.pushState()
+			if (!isDirectEditing()) {
+				OC.Util.History.addOnPopStateHandler(_.bind(documentsMain.onClose))
+				OC.Util.History.pushState()
+			}
 
 			PostMessages.sendPostMessage('parent', 'loading')
 			hideLoadingIndicator()

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -5,6 +5,6 @@
 		"guzzlehttp/guzzle": "^7.3",
 		"jarnaiz/behat-junit-formatter": "^1.3",
 		"sabre/dav": "^4.1",
-		"juliushaertl/nextcloud-behat": "^0.2.0"
+		"juliushaertl/nextcloud-behat": "dev-master"
 	}
 }

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -555,12 +555,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/juliushaertl/nextcloud-behat.git",
-                "reference": "7cf3e1105fc1eef5f9b96da394742dd29180143b"
+                "reference": "baafbc7ecb41a8c612fe4d093c5c5ba86e4c4580"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/juliushaertl/nextcloud-behat/zipball/7cf3e1105fc1eef5f9b96da394742dd29180143b",
-                "reference": "7cf3e1105fc1eef5f9b96da394742dd29180143b",
+                "url": "https://api.github.com/repos/juliushaertl/nextcloud-behat/zipball/baafbc7ecb41a8c612fe4d093c5c5ba86e4c4580",
+                "reference": "baafbc7ecb41a8c612fe4d093c5c5ba86e4c4580",
                 "shasum": ""
             },
             "require": {
@@ -599,7 +599,7 @@
                 "issues": "https://github.com/juliushaertl/nextcloud-behat/issues",
                 "source": "https://github.com/juliushaertl/nextcloud-behat/tree/v0.2.0"
             },
-            "time": "2021-04-22T20:47:15+00:00"
+            "time": "2021-04-26T10:24:16+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/tests/composer.lock
+++ b/tests/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b74ac12f4ae07518f9f53568fdcc35d",
+    "content-hash": "760f6509837b9216c491cd0e1fc414f9",
     "packages": [],
     "packages-dev": [
         {
@@ -551,7 +551,7 @@
         },
         {
             "name": "juliushaertl/nextcloud-behat",
-            "version": "v0.2.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/juliushaertl/nextcloud-behat.git",
@@ -573,6 +573,7 @@
                 "nextcloud/coding-standard": "^0.5.0",
                 "vimeo/psalm": "^4.3"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -597,7 +598,7 @@
             "description": "Behat context helpers for Nextcloud integration tests",
             "support": {
                 "issues": "https://github.com/juliushaertl/nextcloud-behat/issues",
-                "source": "https://github.com/juliushaertl/nextcloud-behat/tree/v0.2.0"
+                "source": "https://github.com/juliushaertl/nextcloud-behat/tree/master"
             },
             "time": "2021-04-26T10:24:16+00:00"
         },
@@ -4738,7 +4739,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "juliushaertl/nextcloud-behat": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],

--- a/tests/config/behat.yml
+++ b/tests/config/behat.yml
@@ -3,6 +3,8 @@ default:
     '': '%paths.base%/../features/bootstrap'
   suites:
     default:
+      filters:
+        tags: ~@known-failure-ci
       paths:
         - '%paths.base%/../features'
       contexts:

--- a/tests/features/bootstrap/DirectContext.php
+++ b/tests/features/bootstrap/DirectContext.php
@@ -154,7 +154,7 @@ class DirectContext implements Context {
 
 	private function requestPublicDirectEditingLink($user, $token, $filePath = null, $password = null) {
 		$this->serverContext->sendOCSRequest('POST', 'apps/richdocuments/api/v1/share', [
-			'shareTokenSourceInstance' => $this->serverContext->getBaseUrl(),
+			'host' => $this->serverContext->getBaseUrl(),
 			'shareToken' => $token,
 			'path' => $filePath,
 			'password' => $password

--- a/tests/features/bootstrap/FederationContext.php
+++ b/tests/features/bootstrap/FederationContext.php
@@ -59,4 +59,20 @@ class FederationContext implements Context {
 		);
 	}
 
+	/**
+	 * @Given /^share the file "([^"]*)" with permission ([0-9]+) as a federated share to "([^"]*)" on "([^"]*)"$/
+	 */
+	public function shareTheFileAsAFederatedShareWithPerission($file, $permissions, $user, $remote) {
+		$table = new TableNode([
+			['path', $file],
+			['shareType', 6],
+			['shareWith', $user . '@' . $this->serverContext->getServer($remote) . '/'],
+			['permissions', $permissions]
+		]);
+		$this->sharingContext->asCreatingAShareWith(
+			$this->serverContext->getAuth()[0],
+			$table
+		);
+	}
+
 }

--- a/tests/features/bootstrap/WopiContext.php
+++ b/tests/features/bootstrap/WopiContext.php
@@ -45,6 +45,7 @@ class WopiContext implements Context {
 	private $fileId;
 	private $fileIds = [];
 	private $wopiToken;
+	private $checkFileInfoResult;
 
 	public function __construct()
 	{
@@ -112,11 +113,15 @@ class WopiContext implements Context {
 
 
 	/**
-	 * @Given /^Collabora receives the following in the checkFileInfo response$/
+	 * @Given /^Collabora fetches and receives the following in the checkFileInfo response$/
 	 */
 	public function collaboraReceivesTheFollowingInTheCheckFileInfoResponse(TableNode $table) {
+		$this->collaboraFetchesCheckfileinfo();
 		foreach ($table->getRows() as $row) {
-			Assert::assertEquals((string)$row[1], (string)$this->checkFileInfoResult[$row[0]]);
+			$key = $row[0];
+			$actual = $this->checkFileInfoResult[$key];
+			$expected = $row[1];
+			Assert::assertEquals((string)$expected, (string)$actual, $key . ' does not match the expected value');
 		}
 	}
 

--- a/tests/features/direct.feature
+++ b/tests/features/direct.feature
@@ -207,9 +207,7 @@ Feature: Direct editing
     And Collabora fetches checkFileInfo
     And Collabora fetches and receives the following in the checkFileInfo response
       | BaseFileName     | document-reshare-fed-link.odt |
-      | UserFriendlyName | Anonymous guest               |
-      # FIXME: Known issue as of right now as we do not fetch the initiator user yet
-      # | UserFriendlyName | user3-displayname (Guest)       |
+      | UserFriendlyName | user3-displayname (Guest)       |
     And checkFileInfo "UserId" matches "/Guest-/"
     And checkFileInfo "UserCanWrite" is false
     And both Collabora files used the same file id

--- a/tests/features/direct.feature
+++ b/tests/features/direct.feature
@@ -3,6 +3,7 @@ Feature: Direct editing
   Background:
     Given user "user1" exists
     And user "user2" exists
+    And user "user3" exists
 
   Scenario: Open a file through direct editing
     Given on instance "serverA"
@@ -23,10 +24,10 @@ Feature: Direct editing
     And checkFileInfo "UserCanWrite" is true
     And Collabora can save the file with the content of "./../assets/template.ods"
     And as "user1" create a share with
-      | path | /document-shared.odt |
-      | shareType | 0 |
-      | shareWith | user2 |
-      | permissions | 1 |
+      | path        | /document-shared.odt |
+      | shareType   | 0                    |
+      | shareWith   | user2                |
+      | permissions | 1                    |
 
     And as user "user2"
     Then User "user2" opens "/document-shared.odt" through direct editing
@@ -36,3 +37,182 @@ Feature: Direct editing
     And both Collabora files used the same file id
     And Collabora can not save the file with the content of "./../assets/template.odt"
     Then Collabora downoads the file and it is equal to "./../assets/template.ods"
+
+  Scenario: Open a reshared file through direct editing
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/document-shared-reshare.odt"
+    When User "user1" opens "/document-shared-reshare.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    Then checkFileInfo "BaseFileName" is "document-shared-reshare.odt"
+    And checkFileInfo "UserCanWrite" is true
+    And Collabora can save the file with the content of "./../assets/template.ods"
+    And as "user1" create a share with
+      | path        | /document-shared-reshare.odt |
+      | shareType   | 0                            |
+      | shareWith   | user2                        |
+      | permissions | 31                           |
+
+    And as "user2" create a share with
+      | path        | /document-shared-reshare.odt |
+      | shareType   | 0                            |
+      | shareWith   | user3                        |
+      | permissions | 1                            |
+
+    And as user "user3"
+    Then User "user3" opens "/document-shared-reshare.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And checkFileInfo "BaseFileName" is "document-shared-reshare.odt"
+    And checkFileInfo "UserCanWrite" is false
+    And both Collabora files used the same file id
+    And Collabora can not save the file with the content of "./../assets/template.odt"
+    Then Collabora downoads the file and it is equal to "./../assets/template.ods"
+
+  @federation
+  Scenario: Open a federated shared file through direct editing
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/document-shared-federated.odt"
+    When User "user1" opens "/document-shared-federated.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    Then checkFileInfo "BaseFileName" is "document-shared-federated.odt"
+    And checkFileInfo "UserCanWrite" is true
+    And Collabora can save the file with the content of "./../assets/template.ods"
+    And share the file "/document-shared-federated.odt" with permission 1 as a federated share to "user2" on "serverB"
+    Given on instance "serverB"
+    And as user "user2"
+    And user "user2" accepts last share
+    Then User "user2" opens "/document-shared-federated.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And checkFileInfo "BaseFileName" is "document-shared-federated.odt"
+    And checkFileInfo "UserCanWrite" is false
+    And both Collabora files used the same file id
+    And Collabora can not save the file with the content of "./../assets/template.odt"
+    Then Collabora downoads the file and it is equal to "./../assets/template.ods"
+
+  @federation
+  Scenario: Open a file in a federated shared folder through direct editing
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" creates a folder "FederatedShareFolder"
+    And User "user1" uploads file "./../assets/template.odt" to "/FederatedShareFolder/document-shared-federated.odt"
+    When User "user1" opens "/FederatedShareFolder/document-shared-federated.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    Then checkFileInfo "BaseFileName" is "document-shared-federated.odt"
+    And checkFileInfo "UserCanWrite" is true
+    And Collabora can save the file with the content of "./../assets/template.ods"
+    And share the file "/FederatedShareFolder" with permission 1 as a federated share to "user2" on "serverB"
+    Given on instance "serverB"
+    And as user "user2"
+    And user "user2" accepts last share
+    Then User "user2" opens "/FederatedShareFolder/document-shared-federated.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And checkFileInfo "BaseFileName" is "document-shared-federated.odt"
+    And checkFileInfo "UserCanWrite" is false
+    And both Collabora files used the same file id
+    And Collabora can not save the file with the content of "./../assets/template.odt"
+    Then Collabora downoads the file and it is equal to "./../assets/template.ods"
+
+  Scenario: Open a share link with direct editing
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/document-share-link.odt"
+    When User "user1" opens "/document-share-link.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And as "user1" create a share with
+      | path      | /document-share-link.odt |
+      | shareType | 3                        |
+    And Updating last share with
+      | permissions | 3       |
+    And as user "user2"
+    When User "user2" opens the last share link through direct editing
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | document-share-link.odt   |
+      | OwnerId          | user1                     |
+      | UserFriendlyName | user2-displayname (Guest) |
+    And checkFileInfo "UserCanWrite" is true
+    And both Collabora files used the same file id
+    And Collabora can save the file with the content of "./../assets/template.ods"
+    Then Collabora downoads the file and it is equal to "./../assets/template.ods"
+    And the direct editing link is only valid once
+
+  Scenario: Open a file in a shared folder of a share link with direct editing as read only
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" creates a folder "Folder"
+    And User "user1" uploads file "./../assets/template.odt" to "/Folder/document-share-link.odt"
+    When User "user1" opens "/Folder/document-share-link.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And as "user1" create a share with
+      | path      | /Folder/ |
+      | shareType | 3        |
+    And as user "user2"
+    When User "user2" opens the file "/document-share-link.odt" in the last share link through direct editing
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | document-share-link.odt   |
+      | OwnerId          | user1                     |
+      | UserFriendlyName | user2-displayname (Guest) |
+    And checkFileInfo "UserId" matches "/Guest-/"
+    And both Collabora files used the same file id
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+    Then Collabora downoads the file and it is equal to "./../assets/template.odt"
+
+  Scenario: Open a file in a shared folder of a share link with direct editing as writable
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" creates a folder "Folder"
+    And User "user1" uploads file "./../assets/template.odt" to "/Folder/document-share-link.odt"
+    When User "user1" opens "/Folder/document-share-link.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And as "user1" create a share with
+      | path        | /Folder/ |
+      | shareType   | 3        |
+    And Updating last share with
+      | permissions | 3       |
+    And as user "user2"
+    When User "user2" opens the file "/document-share-link.odt" in the last share link through direct editing
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | document-share-link.odt   |
+      | OwnerId          | user1                     |
+      | UserFriendlyName | user2-displayname (Guest) |
+    And checkFileInfo "UserId" matches "/Guest-/"
+    And checkFileInfo "UserCanWrite" is true
+    And both Collabora files used the same file id
+    And Collabora can save the file with the content of "./../assets/template.ods"
+    Then Collabora downoads the file and it is equal to "./../assets/template.ods"
+
+  @federation @known-failure-ci
+  Scenario: Open a link that originates on a federated share through direct editing
+    Given user "user3" exists
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/document-reshare-fed-link.odt"
+    When User "user1" opens "/document-reshare-fed-link.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And share the file "/document-reshare-fed-link.odt" with permission 31 as a federated share to "user2" on "serverB"
+
+    Given on instance "serverB"
+    And as user "user2"
+    And user "user2" accepts last share
+    Then User "user2" opens "/document-reshare-fed-link.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    And both Collabora files used the same file id
+    And as "user2" create a share with
+      | path      | /document-reshare-fed-link.odt |
+      | shareType | 3                              |
+
+    Given on instance "serverA"
+    And as user "user3"
+    When User "user3" opens the last share link through direct editing
+    And Collabora fetches checkFileInfo
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | document-reshare-fed-link.odt |
+      | UserFriendlyName | Anonymous guest               |
+      # FIXME: Known issue as of right now as we do not fetch the initiator user yet
+      # | UserFriendlyName | user3-displayname (Guest)       |
+    And checkFileInfo "UserId" matches "/Guest-/"
+    And checkFileInfo "UserCanWrite" is false
+    And both Collabora files used the same file id
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+    Then Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And the direct editing link is only valid once

--- a/tests/features/federation.feature
+++ b/tests/features/federation.feature
@@ -116,6 +116,7 @@ Background:
     And Collabora can save the file with the content of "./../assets/template.ods"
     And Collabora downoads the file and it is equal to "./../assets/template.ods"
 
+  @known-failure-ci
   Scenario: Share a file by federation and reshare it as a link
     Given on instance "serverA"
     And as user "user1"
@@ -124,13 +125,11 @@ Background:
     Then User "user1" opens "/file-reshare-link.odt"
     And Collabora fetches checkFileInfo
 
-
     Given on instance "serverB"
     And as user "user2"
     And user "user2" accepts last share
     Then User "user2" opens "/file-reshare-link.odt"
-    And Collabora fetches checkFileInfo
-    And Collabora receives the following in the checkFileInfo response
+    And Collabora fetches and receives the following in the checkFileInfo response
       | BaseFileName | file-reshare-link.odt |
       | UserCanWrite | 1                     |
     And checkFileInfo "BaseFileName" is "file-reshare-link.odt"
@@ -139,20 +138,20 @@ Background:
     Then Collabora downoads the file and it is equal to "./../assets/template.odt"
     And Collabora can save the file with the content of "./../assets/template.ods"
 
-#    # This might fail curently due to using the same instance
-#    And as "user2" create a share with
-#      | path | /file-reshare-link.odt |
-#      | shareType | 3 |
-#
-#    Then Using web as guest
-#    And a guest opens the share link as "Anonymous"
-#    And Collabora fetches checkFileInfo
-#    And checkFileInfo "BaseFileName" is "file-reshare-link.odt"
-#    And checkFileInfo "UserId" matches "/Guest-/"
-#    And checkFileInfo "UserFriendlyName" is "Anonymous (Guest)"
-#    ## FIXME: The owner id seems to be preserved from the orignal instance
-#    ## And checkFileInfo "OwnerId" is "user1"
-#    ## And both Collabora files used the same file id
-#    And checkFileInfo "UserCanWrite" is false
-#    And Collabora downoads the file and it is equal to "./../assets/template.ods"
-#    And Collabora can not save the file with the content of "./../assets/template.odt"
+    # This might fail curently due to using the same instance
+    And as "user2" create a share with
+      | path | /file-reshare-link.odt |
+      | shareType | 3 |
+
+    Then Using web as guest
+    And a guest opens the share link as "Anonymous"
+    And Collabora fetches checkFileInfo
+    And checkFileInfo "BaseFileName" is "file-reshare-link.odt"
+    And checkFileInfo "UserId" matches "/Guest-/"
+    And checkFileInfo "UserFriendlyName" is "Anonymous (Guest)"
+    ## FIXME: The owner id seems to be preserved from the orignal instance
+    ## And checkFileInfo "OwnerId" is "user1"
+    ## And both Collabora files used the same file id
+    And checkFileInfo "UserCanWrite" is false
+    And Collabora downoads the file and it is equal to "./../assets/template.ods"
+    And Collabora can not save the file with the content of "./../assets/template.odt"

--- a/tests/features/wopi.feature
+++ b/tests/features/wopi.feature
@@ -9,17 +9,19 @@ Feature: WOPI
     And User "user1" uploads file "./../assets/template.odt" to "/file.odt"
     Then User "user1" opens "/file.odt"
     And Collabora fetches checkFileInfo
-    And checkFileInfo "BaseFileName" is "file.odt"
-    And checkFileInfo "UserId" is "user1"
-    And checkFileInfo "OwnerId" is "user1"
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | file.odt          |
+      | OwnerId          | user1             |
+      | UserId           | user1             |
+      | UserFriendlyName | user1-displayname |
     And checkFileInfo "UserCanWrite" is true
 
   Scenario: Fetch checkFileInfo for public share link
     Given as user "user1"
     And User "user1" uploads file "./../assets/template.odt" to "/file.odt"
     And as "user1" create a share with
-      | path | /file.odt |
-      | shareType | 3 |
+      | path      | /file.odt |
+      | shareType | 3         |
     Then Using web as guest
     And a guest opens the share link
     And Collabora fetches checkFileInfo
@@ -32,13 +34,118 @@ Feature: WOPI
     And Collabora downloads the file
     Then the file is equal to "./../assets/template.odt"
 
+  Scenario: Open a file in a folder shared by link
+    Given as user "user1"
+    And User "user1" creates a folder "NewFolder"
+    And User "user1" uploads file "./../assets/template.odt" to "/NewFolder/file.odt"
+    And as "user1" create a share with
+      | path      | /NewFolder |
+      | shareType | 3          |
+    Then User "user1" opens "/NewFolder/file.odt"
+    And Collabora fetches checkFileInfo
+    Then Using web as guest
+    And a guest opens the file "file.odt" of the shared link
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName | file.odt |
+      | UserCanWrite |          |
+      | OwnerId      | user1    |
+    And checkFileInfo "UserId" matches "/Guest-/"
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+    Then both Collabora files used the same file id
 
-    Scenario: Fetch checkFileInfo for public share link with write permission
+  Scenario: Open a file in a folder shared by link with a guest name
+    Given as user "user1"
+    And User "user1" creates a folder "NewFolder"
+    And User "user1" uploads file "./../assets/template.odt" to "/NewFolder/file.odt"
+    And as "user1" create a share with
+      | path      | /NewFolder |
+      | shareType | 3          |
+    Then User "user1" opens "/NewFolder/file.odt"
+    And Collabora fetches checkFileInfo
+    Then Using web as guest
+    And a guest opens the file "file.odt" of the shared link as "Anonymous"
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | file.odt          |
+      | UserCanWrite     |                   |
+      | OwnerId          | user1             |
+      | UserFriendlyName | Anonymous (Guest) |
+    And checkFileInfo "UserId" matches "/Guest-/"
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+    Then both Collabora files used the same file id
+
+  Scenario: Open a file in a folder shared by link as the owner
+    Given as user "user1"
+    And User "user1" creates a folder "NewFolder"
+    And User "user1" uploads file "./../assets/template.odt" to "/NewFolder/file.odt"
+    And as "user1" create a share with
+      | path      | /NewFolder |
+      | shareType | 3          |
+    Then User "user1" opens "/NewFolder/file.odt"
+    And Collabora fetches checkFileInfo
+    And User "user1" opens the file "file.odt" of the shared link
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName | file.odt |
+      | UserCanWrite |          |
+      | OwnerId      | user1    |
+      | UserId       | user1    |
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+    Then both Collabora files used the same file id
+
+  Scenario: Fetch checkFileInfo for public share link as the owner
     Given as user "user1"
     And User "user1" uploads file "./../assets/template.odt" to "/file.odt"
     And as "user1" create a share with
-      | path | /file.odt |
-      | shareType | 3 |
+      | path        | /file.odt |
+      | shareType   | 3         |
+    And the user opens the share link
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName | file.odt |
+      | UserCanWrite |          |
+      | OwnerId      | user1    |
+      | UserId       | user1    |
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+
+  Scenario: Fetch checkFileInfo for public share link with download hidden
+    Given as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/file.odt"
+    And as "user1" create a share with
+      | path      | /file.odt |
+      | shareType | 3         |
+    Then Using web as guest
+    And a guest opens the share link
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | file.odt |
+      | UserCanWrite     |          |
+      | OwnerId          | user1    |
+      | DisablePrint     |          |
+      | DisableExport    |          |
+      | DisableCopy      |          |
+      | HidePrintOption  |          |
+      | HideExportOption |          |
+    And Updating last share with
+      | hideDownload | true |
+    Then Using web as guest
+    And a guest opens the share link
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | file.odt |
+      | UserCanWrite     |          |
+      | OwnerId          | user1    |
+      | DisablePrint     | 1        |
+      | DisableExport    | 1        |
+      | DisableCopy      | 1        |
+      | HidePrintOption  | 1        |
+      | HideExportOption | 1        |
+
+  Scenario: Fetch checkFileInfo for public share link with write permission
+    Given as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/file.odt"
+    And as "user1" create a share with
+      | path      | /file.odt |
+      | shareType | 3         |
     And Updating last share with
       | permissions | 3 |
     Then Using web as guest
@@ -71,8 +178,8 @@ Feature: WOPI
     Given as user "user1"
     And User "user1" uploads file "./../assets/template.odt" to "/file.odt"
     And as "user1" create a share with
-      | path | /file.odt |
-      | shareType | 3 |
+      | path      | /file.odt |
+      | shareType | 3         |
     And Updating last share with
       | permissions | 3 |
     And the HTTP status code should be "200"
@@ -98,3 +205,55 @@ Feature: WOPI
     Then User "user1" opens "/file2.odt"
     And Collabora fetches checkFileInfo
     Then both Collabora files used a different file id
+
+  Scenario: Open a shared file
+    Given as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/file-readonly.odt"
+    And as "user1" create a share with
+      | path        | /file-readonly.odt |
+      | shareType   | 0                  |
+      | shareWith   | user2              |
+      | permissions | 1                  |
+    Then User "user2" opens "/file-readonly.odt"
+    And Collabora fetches checkFileInfo
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And checkFileInfo "UserCanWrite" is false
+    And Collabora can not save the file with the content of "./../assets/template.ods"
+
+
+  Scenario: Open a shared file with write permissions
+    Given as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/file-rw.odt"
+    And as "user1" create a share with
+      | path        | /file-rw.odt |
+      | shareType   | 0            |
+      | shareWith   | user2        |
+      | permissions | 31           |
+    Then User "user2" opens "/file-rw.odt"
+    And Collabora fetches checkFileInfo
+    And checkFileInfo "UserCanWrite" is true
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+    And Collabora can save the file with the content of "./../assets/template.ods"
+
+  Scenario: Open a reshared file with read permissions
+    Given user "user3" exists
+    When as user "user1"
+    And User "user1" uploads file "./../assets/template.odt" to "/file-reshare-ro.odt"
+    And as "user1" create a share with
+      | path        | /file-reshare-ro.odt |
+      | shareType   | 0                    |
+      | shareWith   | user2                |
+      | permissions | 31                   |
+    And as user "user2"
+    And as "user2" create a share with
+      | path        | /file-reshare-ro.odt |
+      | shareType   | 0                    |
+      | shareWith   | user3                |
+      | permissions | 1                    |
+    Then User "user3" opens "/file-reshare-ro.odt"
+    And Collabora fetches checkFileInfo
+    And Collabora downloads the file
+    Then the file is equal to "./../assets/template.odt"
+    And checkFileInfo "UserCanWrite" is false
+    And Collabora downoads the file and it is equal to "./../assets/template.odt"
+


### PR DESCRIPTION
### Pending

- [x] Based on https://github.com/nextcloud/richdocuments/pull/1501
- [x] Document new API endpoint


## General concept

This is a rough summary on how the federated editing worked also before this PR:

Collabra Online offers support for collaborative editing of files that are shared through federated
sharing. The file will always be opened on the file owners instance (Source) and other users will
connect to that through their Nextcloud instance (Initiator).

In a federated scenario both Nextcloud servers need to add each other as trusted servers or in a
global scale environment a list of nodes can be added through the `gs.trustedHosts` setting in the
config.php file.

### Additions through this PR

When a Initiator opens a file that is located on an incoming federated share, a check will be
performed if the share owners instance supports federated editing. If that is the case a Initiator
token will be created, and the user will be redirected to the Source instance to open the file.

The source instance will then fetch the user and file details, create a WOPI token for the remote
user with those details and open the document with that.

This allows different new cases in federated editing as now not only the user information is preserved but the additional token types allow:
- Local reshares of incoming federated shares
- Reshares as link of incoming federated shares
- Direct editing for share links to allow users to open a share link on any instance with their user information through a direct editing link

### Wording

The following wordings are used related to federated editing:

- Source: The instance the original file is located at that was initially shared by the file owner
- Initiator (WOPI): The instance that opens the file
- Initiator (User): The instance the file open request was issued by the user
  - Normally this is the same as Initiator(WOPI), except when a public share link is opened by a user on another instance than the Initiator(WOPI)
    - E.g. Instance A requests a direct share link for a public share token on instance B that originates to a federated share from Instance C

### Implementation details

- Files will always be opened with the Collabora server that is provided by the Source instance
- When a initiator attempts to open a file
  - Initiator tokens will be created with the initiator details (user info, wopi token on the initator instance)
  - The user is being redirected to the source instance providing it with the initator token
  - The source instance then will request the information from the initiator tokens on the initiator instances and open the file in the context of the initiator
- Direct editing for share links
  - Allow users to open a share link on any instance with their user information through a direct editing link
  - The OCS API allows the user to request a direct editing link for the share link on Initiator(WOPI)
- Preserve editor information across federation
- Introduce token types
  - TOKEN_TYPE_USER
    - Regular WOPI token for opening a local file as a user on SOURCE 
  - TOKEN_TYPE_GUEST
    - Regular WOPI token for opening a public share link as a guest on SOURCE
  - TOKEN_TYPE_REMOTE_USER
    - Remote WOPI token to open a file initiated by a regular user of INITIATOR on SOURCE
    - remoteServer/remoteServerToken contain the reference to the INITIATOR instance
  - TOKEN_TYPE_REMOTE_GUEST
    - Remote WOPI token to open a file initiated by a guest of INITIATOR(WOPI) on SOURCE
  - TOKEN_TYPE_INITIATOR
    - serverHost contains the source instance host
    - if the Initiator(WOPI) is Initiator(User) the editorUid is used to provide the user info
    - if the Initiator(User) is located on a different instace
      - remoteServer may contain the INITIATOR(USER) host
      - remoteServerToken may contain the INITIATOR(USER) user token
      - Those can be used to obtain the editorUid from the INITIATOR(USER) instance
- Integration tests should cover all the different scenarios that may occur with federated sharing and local sharing in general

