### PR TITLE
Don't cache empty capabilities

### DIFF
--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -113,6 +113,10 @@ class CapabilitiesService {
 		}
 
 		$this->capabilities = $capabilities;
-		$this->cache->set('capabilities', $capabilities, 3600);
+		$ttl = 3600;
+		if (count($capabilities) === 0)
+			$ttl = 60;
+
+		$this->cache->set('capabilities', $capabilities, $ttl);
 	}
 }


### PR DESCRIPTION
Fixes #1441

When caching is configured and request to fetch the
capabilities fails - don't cache the empty result.

This way we will avoid persisting error:
"Collabora Online is not setup yet".

To test bug:
1. use Nextcloud with caching & richdocuments
2. restart apache and stop Collabora Online server
3. open Nextcloud and try to open any document
   you will get "Collabora Online is not setup yet" error
4. start Collabora Online server
5. refresh page and try to open file again

before: error persisted until admin changed richdocuments configuration
after: file is opened with Collabora Online

Signed-off-by: Szymon Kłos <szymon.klos@collabora.com>