### PR TITLE
Work around safari having a inproper 100vh value

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -14,6 +14,16 @@ const PostMessages = new PostMessageService({
 	FRAME_DOCUMENT: () => document.getElementById('richdocumentsframe').contentWindow,
 })
 
+// Workaround for Safari to resize the iframe to the proper height
+// as 100vh is not the proper viewport height there
+const handleResize = () => {
+	document.getElementById('richdocumentsframe').style.maxHeight = (window.innerHeight - 60) + 'px'
+}
+window.addEventListener('resize', handleResize)
+if (window && window.visualViewport) {
+	visualViewport.addEventListener('resize', handleResize)
+}
+
 const isDownloadHidden = document.getElementById('hideDownload') && document.getElementById('hideDownload').value === 'true'
 
 const isPublic = document.getElementById('isPublic') && document.getElementById('isPublic').value === '1'


### PR DESCRIPTION
Fixes an issue with Safari on iOS where 100vh aparently is larger than the actual viewport which causes the Collabora iframe to be cut off on the bottom by default which means that the button to toggle the edit mode is not visible properly.

https://bugs.webkit.org/show_bug.cgi?id=141832

Fixes https://github.com/nextcloud/richdocuments/issues/1487

I found another bug during testing this where the view would still be scrollable even if overflow hidden is set on the body if the keyboard is shown, but that requires some more investigation. (Edit: actually already reported in https://github.com/nextcloud/richdocuments/issues/823)