### PR TITLE
Emit WOPI postmessages through the nextcloud event bus

### DIFF
--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -236,3 +236,13 @@ Example failed event data:
   "wopiFileId": "288_oct9lk1km6wy"
 }
 ```
+
+### WOPI PostMessages
+
+Collabora Online emits various post messages which are catched and handled by the Collabora Online
+Integration app. Postmessages which are sent from the WOPI host (Collabora) to the editor (
+Nextcloud) are also exposed through the Nextcloud event bus under the `richdocuments:wopi-post`
+event name. For details on the post messages see
+the [Collabora Online PostMessage API documentation](WOPI host to editor).
+
+

--- a/src/services/postMessage.tsx
+++ b/src/services/postMessage.tsx
@@ -19,6 +19,9 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+import { emit } from "@nextcloud/event-bus"
+
 type MessageEventSource = Window | MessagePort | ServiceWorker;
 
 export interface WopiPost {
@@ -95,6 +98,14 @@ export default class PostMessageService {
 		if (typeof parsed === 'undefined' || parsed === null) {
 			return
 		}
+
+		try {
+			const wopiPostMessage = JSON.parse(data)
+			if (typeof wopiPostMessage === 'object' && wopiPostMessage !== null) {
+				emit('richdocuments:wopi-post', wopiPostMessage)
+			}
+		} catch (e) {}
+
 		this.postMessageHandlers.forEach((fn: Function): void => {
 			if (parsed.deprecated) {
 				console.debug('PostMessageService.handlePostMessage', 'Ignoring deprecated post message', parsed.msgId)


### PR DESCRIPTION
Emit all post messages we receive from Collabora on the Nextcloud event bus.