### PR TITLE
Retry to check if Collabora is configured

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -92,19 +92,30 @@ const odfViewer = {
 		let templateId
 
 		if (!odfViewer.isCollaboraConfigured) {
-			const setupUrl = OC.generateUrl('/settings/admin/richdocuments')
-			const installHint = OC.isUserAdmin()
-				? `<a href="${setupUrl}">Collabora Online is not setup yet. <br />Click here to configure your own server or connect to a demo server.</a>`
-				: t('richdocuments', 'Collabora Online is not setup yet. Please contact your administrator.')
+			$.get(OC.linkToOCS('cloud') + '/capabilities?format=json').then(
+				e => {
+					if ((OC.getCapabilities().richdocuments.config.wopi_url.indexOf('proxy.php') !== -1)
+						|| (typeof e.ocs.data.capabilities.richdocuments.collabora === 'object'
+						&& e.ocs.data.capabilities.richdocuments.collabora.length !== 0)) {
+						odfViewer.isCollaboraConfigured = true
+						odfViewer.onEdit(fileName, context)
+					} else {
+						const setupUrl = OC.generateUrl('/settings/admin/richdocuments')
+						const installHint = OC.isUserAdmin()
+							? `<a href="${setupUrl}">Collabora Online is not setup yet. <br />Click here to configure your own server or connect to a demo server.</a>`
+							: t('richdocuments', 'Collabora Online is not setup yet. Please contact your administrator.')
 
-			if (OCP.Toast) {
-				OCP.Toast.error(installHint, {
-					isHTML: true,
-					timeout: 0,
-				})
-			} else {
-				OC.Notification.showHtml(installHint)
-			}
+						if (OCP.Toast) {
+							OCP.Toast.error(installHint, {
+								isHTML: true,
+								timeout: 0,
+							})
+						} else {
+							OC.Notification.showHtml(installHint)
+						}
+					}
+				}
+			)
 			return
 		}
 		if (odfViewer.open === true) {


### PR DESCRIPTION
If Collabora wasn't initially configured, retry to check the capabilities just before request to open the file before we will show the error.