### PR TITLE
Fix wrong parameters set when creating a file from a template id

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -280,7 +280,7 @@ class TokenManager {
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
 		if ($this->capabilitiesService->hasTemplateSource()) {
-			$wopi = $this->wopiMapper->generateFileToken($targetFile->getId(), $owneruid, $editoruid, 0, $updatable, $serverHost, null, 0, false, $direct, false, $templateFile->getId());
+			$wopi = $this->wopiMapper->generateFileToken($targetFile->getId(), $owneruid, $editoruid, 0, $updatable, $serverHost, null, 0, false, $direct, $templateFile->getId());
 		} else {
 			// Legacy way of creating new documents from a template
 			$wopi = $this->wopiMapper->generateFileToken($templateFile->getId(), $owneruid, $editoruid, 0, $updatable, $serverHost, null, $targetFile->getId(), $direct);

--- a/tests/features/bootstrap/WopiContext.php
+++ b/tests/features/bootstrap/WopiContext.php
@@ -128,34 +128,42 @@ class WopiContext implements Context {
 	/**
 	 * @Then /^checkFileInfo "([^"]*)" is "([^"]*)"$/
 	 */
-	public function checkfileinfoIs($arg1, $arg2)
+	public function checkfileinfoIs($key, $value)
 	{
-		\PHPUnit\Framework\Assert::assertEquals($arg2, $this->checkFileInfoResult[$arg1]);
+		\PHPUnit\Framework\Assert::assertEquals($value, $this->checkFileInfoResult[$key]);
 	}
 
 
 	/**
 	 * @Then /^checkFileInfo "([^"]*)" matches "([^"]*)"$/
 	 */
-	public function checkfileinfoMatches($arg1, $arg2)
+	public function checkfileinfoMatches($key, $regex)
 	{
-		\PHPUnit\Framework\Assert::assertRegExp($arg2, $this->checkFileInfoResult[$arg1]);
+		\PHPUnit\Framework\Assert::assertRegExp($regex, $this->checkFileInfoResult[$key]);
 	}
 
 	/**
 	 * @Then /^checkFileInfo "([^"]*)" is true$/
 	 */
-	public function checkfileinfoIsTrue($arg1)
+	public function checkfileinfoIsTrue($key)
 	{
-		\PHPUnit\Framework\Assert::assertTrue($this->checkFileInfoResult[$arg1]);
+		\PHPUnit\Framework\Assert::assertTrue($this->checkFileInfoResult[$key]);
 	}
 
 	/**
 	 * @Then /^checkFileInfo "([^"]*)" is false$/
 	 */
-	public function checkfileinfoIsFalse($arg1)
+	public function checkfileinfoIsFalse($key)
 	{
-		\PHPUnit\Framework\Assert::assertFalse($this->checkFileInfoResult[$arg1]);
+		\PHPUnit\Framework\Assert::assertFalse($this->checkFileInfoResult[$key]);
+	}
+
+	/**
+	 * @Then /^checkFileInfo "([^"]*)" is not set/
+	 */
+	public function checkfileinfoIsNotSet($key)
+	{
+		\PHPUnit\Framework\Assert::assertArrayNotHasKey($key, $this->checkFileInfoResult);
 	}
 
 	/**

--- a/tests/features/wopi.feature
+++ b/tests/features/wopi.feature
@@ -257,3 +257,15 @@ Feature: WOPI
     And checkFileInfo "UserCanWrite" is false
     And Collabora downoads the file and it is equal to "./../assets/template.odt"
 
+
+  Scenario: Create a new wopi token from a template for a user and open it
+    Given as user "user1"
+    And user "user1" fetches the document template list
+    And user "user1" creates a new file "/file.odt" from a template
+    And Collabora fetches and receives the following in the checkFileInfo response
+      | BaseFileName     | file.odt          |
+      | OwnerId          | user1             |
+      | UserId           | user1             |
+      | UserFriendlyName | user1-displayname |
+    And checkFileInfo "UserCanWrite" is true
+    And TemplateSource is set


### PR DESCRIPTION
First commit will fail tests, the second fixes the issue with is a regression from https://github.com/nextcloud/richdocuments/commit/ac959b19ec62ae6def4d18690f0f4b96bdad3b75 where dropped `$isRemoteToken` parameter was not removed in the call.