### PR TITLE
Show avatar list if hide download is enabled

### DIFF
--- a/css/viewer.scss
+++ b/css/viewer.scss
@@ -81,6 +81,10 @@
 	position: relative;
 	right: -15px;
 
+	.header-right-richdocuments & {
+		right: 0;
+	}
+
 	& > .richdocuments-avatar {
 		float: right;
 		border-radius: 50%;

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -82,7 +82,15 @@ export default {
 			this.getFileList().setPageTitle && this.getFileList().setPageTitle(this.fileName)
 		}
 
-		const headerRight = document.querySelector('#header .header-right')
+		let headerRight = document.querySelector('#header .header-right')
+		if (!headerRight) {
+			// there might not be a right header for links with hide download enabled
+			const header = document.querySelector('#header')
+			headerRight = document.createElement('div')
+			headerRight.classList.add('header-right')
+			headerRight.classList.add('header-right-richdocuments')
+			header.insertBefore(headerRight, null)
+		}
 		if (!document.getElementById('richdocuments-header')) {
 			const richdocumentsHeader = document.createElement('div')
 			richdocumentsHeader.id = 'richdocuments-header'
@@ -385,7 +393,7 @@ export default {
 	renderAvatars() {
 		const avatardiv = $('#header .header-right #richdocuments-avatars')
 		avatardiv.empty()
-		const popover = $('<div id="editors-menu" class="popovermenu menu-center"><ul></ul></div>')
+		const popover = $('<div id="editors-menu" class="popovermenu"><ul></ul></div>')
 
 		const users = []
 		// Add new avatars


### PR DESCRIPTION
There is no .header-right div when hide download is enabled so we need to add it manually in order to properly show the avatar list in the header then. Before it was not visible at all.

![image](https://user-images.githubusercontent.com/3404133/128997985-68dd0fad-9e38-4387-a95f-3ed93add3cc6.png)
