### PR TITLE
Another attempt to fix height setting for Safari issues on iOS

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -17,7 +17,10 @@ const PostMessages = new PostMessageService({
 // Workaround for Safari to resize the iframe to the proper height
 // as 100vh is not the proper viewport height there
 const handleResize = () => {
-	document.getElementById('richdocumentsframe').style.maxHeight = (window.innerHeight - 60) + 'px'
+	const frame = document.getElementById('richdocumentsframe')
+	if (frame) {
+		frame.style.maxHeight = (document.documentElement.clientHeight - 50) + 'px'
+	}
 }
 window.addEventListener('resize', handleResize)
 if (window && window.visualViewport) {
@@ -245,6 +248,7 @@ const odfViewer = {
 		odfViewer.receivedLoading = true
 		$('#richdocumentsframe').prop('title', 'Collabora Online')
 		$('#richdocumentsframe').show()
+		handleResize()
 		$('html, body').scrollTop(0)
 		$('#content').removeClass('loading')
 		FilesAppIntegration.initAfterReady()


### PR DESCRIPTION
Another attempt to improve frame handling on iOS devices where the height needs to be set manually as 100vh css values do not work as expected.

Also fixes #1608 where the header value was wrongly set to 60px instead of 50px