### PR TITLE
Allow guests to request a direct token for share links

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -73,6 +73,8 @@ return [
 		['name' => 'OCS#getTemplates', 'url' => '/api/v1/templates/{type}', 'verb' => 'GET'],
 		['name' => 'OCS#createFromTemplate', 'url' => '/api/v1/templates/new', 'verb' => 'POST'],
 
+		['name' => 'OCS#updateGuestName', 'url' => '/api/v1/wopi/guestname', 'verb' => 'POST'],
+
 		['name' => 'Federation#index', 'url' => '/api/v1/federation', 'verb' => 'GET'],
 		['name' => 'Federation#remoteWopiToken', 'url' => '/api/v1/federation', 'verb' => 'POST'],
 		['name' => 'Federation#initiatorUser', 'url' => '/api/v1/federation/user', 'verb' => 'POST'],

--- a/docs/mobile_editor.md
+++ b/docs/mobile_editor.md
@@ -35,6 +35,7 @@ document:
 
 The returned xml or json will have an url to open in a webview.
 
-The user will join the session as a guest but with their user details provided by their own
-instance.
-
+The endpoint can be used with or without user credentials for the Nextcloud server. 
+For anonymous requests the webview will ask the user for a guest name on writable 
+files. When requesting a link as an authenticated user, the user will join the
+document as a guest but with their user details provided by their own instance. 

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -222,7 +222,8 @@ class DirectViewController extends Controller {
 					'instanceId' => $this->settings->getSystemValue('instanceid'),
 					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 					'userId' => null,
-					'direct' => true
+					'direct' => true,
+					'directGuest' => empty($direct->getUid()),
 				];
 
 				list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($node->getId(), $direct->getShare(), $direct->getUid(), true);

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -360,11 +360,9 @@ class DocumentController extends Controller {
 					'userId' => $this->uid,
 				];
 
-				if ($this->uid !== null || ($share->getPermissions() & \OCP\Constants::PERMISSION_UPDATE) === 0 || $this->helper->getGuestName() !== null) {
-					list($urlSrc, $token) = $this->tokenManager->getToken($item->getId(), $shareToken, $this->uid);
-					$params['token'] = $token;
-					$params['urlsrc'] = $urlSrc;
-				}
+				list($urlSrc, $token) = $this->tokenManager->getToken($item->getId(), $shareToken, $this->uid);
+				$params['token'] = $token;
+				$params['urlsrc'] = $urlSrc;
 
 				$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
 				$this->setupPolicy($response);

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -271,7 +271,7 @@ class WopiController extends Controller {
 			return $response;
 		}
 
-		$response['UserFriendlyName'] = $initiator->getGuestDisplayname() . ' (Guest)';
+		$response['UserFriendlyName'] = $this->tokenManager->prepareGuestName($initiator->getGuestDisplayname());
 		if ($initiator->hasTemplateId()) {
 			$templateUrl = $wopi->getRemoteServer() . '/index.php/apps/richdocuments/wopi/template/' . $initiator->getTemplateId() . '?access_token=' . $initiator->getToken();
 			$response['TemplateSource'] = $templateUrl;

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -51,7 +51,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getRemoteServerToken()
  * @method void setExpiry(int $expiry)
  * @method int getExpiry()
- * @method void setGuestDisplayname(string $token)
+ * @method void setGuestDisplayname(string $guestDisplayName)
  * @method string getGuestDisplayname()
  * @method void setTemplateDestination(int $fileId)
  * @method int getTemplateDestination()

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -82,7 +82,7 @@ class Helper {
 		return $filename;
 	}
 
-	public function getGuestName() {
+	public function getGuestNameFromCookie() {
 		if ($this->userId !== null || !isset($_COOKIE['guestUser']) || $_COOKIE['guestUser'] === '') {
 			return null;
 		}

--- a/src/document.js
+++ b/src/document.js
@@ -2,7 +2,7 @@ import { emit } from '@nextcloud/event-bus'
 import { getRootUrl } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 import Config from './services/config.tsx'
-import { setGuestNameCookie, shouldAskForGuestName } from './helpers/guestName'
+import { setGuestName, shouldAskForGuestName } from './helpers/guestName'
 
 import PostMessageService from './services/postMessage.tsx'
 import {
@@ -139,8 +139,13 @@ $.widget('oc.guestNamePicker', {
 		$('#documents-content').prepend(text)
 		const setGuestNameSubmit = () => {
 			const username = $('#nickname').val()
-			setGuestNameCookie(username)
-			window.location.reload(true)
+			div.remove()
+			text.innerText = ''
+			text.classList.add('icon-loading')
+			setGuestName(username).then(() => {
+				$('#documents-content').remove()
+				documentsMain.initSession()
+			})
 		}
 
 		$('#nickname').keyup(function(event) {

--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -24,29 +24,35 @@ import Config from './../services/config.tsx'
 import { getCurrentUser } from '@nextcloud/auth'
 import mobile from './mobile'
 
+let guestName = ''
+
 const getGuestNameCookie = function() {
-	const name = 'guestUser='
-	const matchedCookie = document.cookie.split(';')
-		.map((cookie) => {
-			try {
-				return decodeURIComponent(cookie.trim())
-			} catch (e) {
-				return cookie.trim()
-			}
-		}).find((cookie) => {
-			return cookie.indexOf(name) === 0
-		})
-	return matchedCookie ? matchedCookie.substring(name.length) : ''
+	if (guestName === '') {
+		const name = 'guestUser='
+		const matchedCookie = document.cookie.split(';')
+			.map((cookie) => {
+				try {
+					return decodeURIComponent(cookie.trim())
+				} catch (e) {
+					return cookie.trim()
+				}
+			}).find((cookie) => {
+				return cookie.indexOf(name) === 0
+			})
+		guestName = matchedCookie ? matchedCookie.substring(name.length) : ''
+	}
+	return guestName
 }
 
 const setGuestNameCookie = function(username) {
 	if (username !== '') {
 		document.cookie = 'guestUser=' + encodeURIComponent(username) + '; path=/'
+		guestName = username
 	}
 }
 
 const shouldAskForGuestName = () => {
-	return !mobile.isDirectEditing()
+	return (!mobile.isDirectEditing() || Config.get('directGuest'))
 		&& (!getCurrentUser() || getCurrentUser()?.uid === '')
 		&& !Config.get('userId')
 		&& getGuestNameCookie() === ''

--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -22,6 +22,8 @@
 
 import Config from './../services/config.tsx'
 import { getCurrentUser } from '@nextcloud/auth'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
 import mobile from './mobile'
 
 let guestName = ''
@@ -44,11 +46,16 @@ const getGuestNameCookie = function() {
 	return guestName
 }
 
-const setGuestNameCookie = function(username) {
+const setGuestName = function(username) {
 	if (username !== '') {
-		document.cookie = 'guestUser=' + encodeURIComponent(username) + '; path=/'
+		// document.cookie = 'guestUser=' + encodeURIComponent(username) + '; path=/'
 		guestName = username
 	}
+	const accessToken = encodeURIComponent(Config.get('token'))
+	return axios.post(generateOcsUrl('apps/richdocuments/api/v1/wopi', 2) + 'guestname', {
+		access_token: accessToken,
+		guestName,
+	})
 }
 
 const shouldAskForGuestName = () => {
@@ -61,6 +68,6 @@ const shouldAskForGuestName = () => {
 
 export {
 	getGuestNameCookie,
-	setGuestNameCookie,
+	setGuestName,
 	shouldAskForGuestName,
 }

--- a/src/services/config.tsx
+++ b/src/services/config.tsx
@@ -28,9 +28,9 @@ class ConfigService {
         this.loadFromGlobal('userId')
         this.loadFromGlobal('urlsrc')
         this.loadFromGlobal('directEdit')
+        this.loadFromGlobal('directGuest')
         this.loadFromGlobal('permissions')
         this.loadFromGlobal('instanceId')
-
     }
     loadFromGlobal(key: string) {
         // @ts-ignore

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -9,6 +9,7 @@
 	var richdocuments_instanceId = '<?php p($_['instanceId']) ?>';
 	var richdocuments_canonical_webroot = '<?php p($_['canonical_webroot']) ?>';
 	var richdocuments_directEdit = <?php isset($_['direct']) ? p('true') : p('false') ?>;
+	var richdocuments_directGuest = <?php isset($_['directGuest']) ? p('true') : p('false') ?>;
 </script>
 
 <?php

--- a/tests/features/bootstrap/RichDocumentsContext.php
+++ b/tests/features/bootstrap/RichDocumentsContext.php
@@ -215,4 +215,14 @@ class RichDocumentsContext implements Context
 		$this->wopiToken = $result['token'];
 		$this->wopiContext->setWopiParameters($this->currentServer, $this->fileId, $this->wopiToken);
 	}
+
+	/**
+	 * @When /^the guest updates the display name to "([^"]*)"$/
+	 */
+	public function updateTheGuestDisplayName($displayName) {
+		$this->serverContext->sendOCSRequest('POST', 'apps/richdocuments/api/v1/wopi/guestname', [
+			'access_token' => $this->wopiContext->getWopiToken(),
+			'guestName' => $displayName,
+		], [ 'auth' => null ]);
+	}
 }

--- a/tests/features/bootstrap/WopiContext.php
+++ b/tests/features/bootstrap/WopiContext.php
@@ -66,6 +66,10 @@ class WopiContext implements Context {
 		return $this->serverContext->getBaseUrl();
 	}
 
+	public function getWopiToken() {
+		return $this->wopiToken;
+	}
+
 	public function setWopiParameters($server, $fileId, $accessToken) {
 		$this->currentServer = $server;
 		$this->fileId = $fileId;


### PR DESCRIPTION
Allow direct editing for share tokens also for guest users

- [x] Create a direct token without a user
- [x] Handle loading and share token validation
- [x] Figure out a way to set the guest name 
- [x] move guest name setting to a dedicated api endpoint where it can be set given the wopi file id and secret to avoid full page reload which does not work for direct tokens and saves generating an unused wopi token