### PR TITLE
Prevent not-needed early loading of the richdocuments app

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,8 +10,6 @@ You can also edit your documents off-line with the Collabora Office app from the
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>
-		<filesystem/>
-		<dav/>
 		<prevent_group_restriction/>
 	</types>
 	<documentation>


### PR DESCRIPTION
There is no need to register the filesystem/dav types for the app so we can avoid loading it too early