### PR TITLE
Register middleware as a service for ancient versions

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -77,6 +77,14 @@ class Application extends App {
 		} catch (QueryException $e) {
 		}
 
+		$server = $this->getContainer()->getServer();
+		$this->getContainer()->registerService(WOPIMiddleware::class, function () use ($server) {
+			return new WOPIMiddleware(
+				$server->getConfig(),
+				$server->getRequest()
+			);
+		});
+
 		$this->getContainer()->registerCapability(Capabilities::class);
 		$this->getContainer()->registerMiddleWare(WOPIMiddleware::class);
 	}


### PR DESCRIPTION
This ensures that we remain compatibility with older Nextcloud versions where registered middlewares were not resolved through the DI container. Fixes the app loading for times before https://github.com/nextcloud/server/pull/17569 was introduced.