### PR TITLE
make collabora icons inverted

### DIFF
--- a/css/viewer.scss
+++ b/css/viewer.scss
@@ -22,11 +22,10 @@
 }
 
 .icon-collabora {
-  cursor: pointer;
-  opacity: 0.6;
-  &:hover {
-    opacity: 1;
-  }
+	opacity: 0.6;
+	&:hover {
+		opacity: 1;
+	}
 }
 
 .richdocuments-sharing .icon-shared {

--- a/css/viewer.scss
+++ b/css/viewer.scss
@@ -21,6 +21,14 @@
 	background-image: url('../img/x-office-presentation.svg');
 }
 
+.icon-collabora {
+  cursor: pointer;
+  opacity: 0.6;
+  &:hover {
+    opacity: 1;
+  }
+}
+
 .richdocuments-sharing .icon-shared {
 	display: block;
 	width: 16px;

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -261,7 +261,8 @@ export default {
 
 	_addHeaderShareButton() {
 		if ($('header').length) {
-			const $button = $('<div id="richdocuments-sharing"><a class="icon-shared icon-white"></a></div>')
+			const isInverted = window.OCA.Theming.inverted
+			const $button = $('<div id="richdocuments-sharing"><a class="icon-collabora icon-shared ' + (isInverted ? 'icon-black' : 'icon-white') + '"></a></div>')
 			$('#richdocuments-header').append($button)
 			$button.on('click', () => {
 				if (!$('#app-sidebar').is(':visible')) {
@@ -277,7 +278,8 @@ export default {
 		console.debug('[FilesAppIntegration] Adding header file actions')
 		OC.unregisterMenu($('#richdocuments-actions .icon-more'), $('#richdocuments-actions-menu'))
 		$('#richdocuments-actions').remove()
-		const actionsContainer = $('<div id="richdocuments-actions"><div class="icon-more icon-white"></div><ul id="richdocuments-actions-menu" class="popovermenu"></ul></div>')
+		const isInverted = window.OCA.Theming.inverted
+		const actionsContainer = $('<div id="richdocuments-actions"><div class="icon-collabora icon-more ' + (isInverted ? 'icon-black' : 'icon-white') + '"></div><ul id="richdocuments-actions-menu" class="popovermenu"></ul></div>')
 		const actions = actionsContainer.find('#richdocuments-actions-menu').empty()
 
 		const getContext = () => ({

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -261,7 +261,7 @@ export default {
 
 	_addHeaderShareButton() {
 		if ($('header').length) {
-			const isInverted = window.OCA.Theming.inverted
+			const isInverted = Boolean(window?.OCA?.Theming?.inverted)
 			const $button = $('<div id="richdocuments-sharing"><a class="icon-collabora icon-shared ' + (isInverted ? 'icon-black' : 'icon-white') + '"></a></div>')
 			$('#richdocuments-header').append($button)
 			$button.on('click', () => {
@@ -278,7 +278,7 @@ export default {
 		console.debug('[FilesAppIntegration] Adding header file actions')
 		OC.unregisterMenu($('#richdocuments-actions .icon-more'), $('#richdocuments-actions-menu'))
 		$('#richdocuments-actions').remove()
-		const isInverted = window.OCA.Theming.inverted
+		const isInverted = Boolean(window?.OCA?.Theming?.inverted)
 		const actionsContainer = $('<div id="richdocuments-actions"><div class="icon-collabora icon-more ' + (isInverted ? 'icon-black' : 'icon-white') + '"></div><ul id="richdocuments-actions-menu" class="popovermenu"></ul></div>')
 		const actions = actionsContainer.find('#richdocuments-actions-menu').empty()
 


### PR DESCRIPTION
Signed-off-by: Luka Trovic <luka@nextcloud.com>


* Resolves: #680
* Target version: master 

### Summary
The color of the `share` and `more` buttons that appear on the header for office documents is now inverted according to the change of the theme color.

http://prntscr.com/1sld74l