### PR TITLE
richdocumentsframe use 100% of mobile screen height

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -19,7 +19,7 @@ const PostMessages = new PostMessageService({
 const handleResize = () => {
 	const frame = document.getElementById('richdocumentsframe')
 	if (frame) {
-		frame.style.maxHeight = (document.documentElement.clientHeight - 50) + 'px'
+		frame.style.maxHeight = (document.documentElement.clientHeight) + 'px'
 	}
 }
 window.addEventListener('resize', handleResize)


### PR DESCRIPTION
Signed-off-by: Andreas-Kainz <kainz.a@gmail.com>


* Resolves: #1608
* Target version: master 

### Summary
richdocumentframe use 50px less than screen height, which cause ain issue on mobile.

### Before
![before](https://user-images.githubusercontent.com/8517736/134824128-95611778-53c1-47a5-b7e0-c189001d9c50.png)

### After
![after](https://user-images.githubusercontent.com/8517736/134824134-58a3c235-262f-4a25-b01c-3114e7e00b4a.png)
