### PR TITLE
Do not load template directories twice

### DIFF
--- a/lib/Template/CollaboraTemplateProvider.php
+++ b/lib/Template/CollaboraTemplateProvider.php
@@ -29,7 +29,9 @@ namespace OCA\Richdocuments\Template;
 
 use OCA\Richdocuments\TemplateManager;
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
 use OCP\Files\Template\ICustomTemplateProvider;
+use OCP\Files\Template\ITemplateManager;
 use OCP\Files\Template\Template;
 use OCP\Files\Template\TemplateFileCreator;
 use OCP\IURLGenerator;
@@ -40,10 +42,13 @@ class CollaboraTemplateProvider implements ICustomTemplateProvider {
 	private $templateManager;
 	/** @var IURLGenerator */
 	private $urlGenerator;
+	/** @var ITemplateManager */
+	private $coreTemplateManager;
 
-	public function __construct(TemplateManager $templateManager, IURLGenerator $urlGenerator) {
+	public function __construct(TemplateManager $templateManager, IURLGenerator $urlGenerator, ITemplateManager $coreTemplateManager) {
 		$this->templateManager = $templateManager;
 		$this->urlGenerator = $urlGenerator;
+		$this->coreTemplateManager = $coreTemplateManager;
 	}
 
 	public function getTemplateType(): string {
@@ -63,11 +68,24 @@ class CollaboraTemplateProvider implements ICustomTemplateProvider {
 			return [];
 		}
 
+		$collaboraTemplates = $this->isSameUserTemplateFolder() ? $this->templateManager->getSystem($type) : $this->templateManager->getAll($type);
+
 		return array_map(function(File $file) {
 			$template = new Template(CollaboraTemplateProvider::class, (string)$file->getId(), $file);
 			$template->setCustomPreviewUrl($this->urlGenerator->linkToRouteAbsolute('richdocuments.templates.getPreview', ['fileId' => $file->getId()]));
 			return $template;
-		}, $this->templateManager->getAll($type));
+		}, $collaboraTemplates);
+	}
+
+	private function isSameUserTemplateFolder(): bool {
+		try {
+			$userTemplatesFolder = $this->templateManager->getUserTemplateDir();
+			$internalPath = $userTemplatesFolder->getInternalPath();
+			$userTemplatePath = mb_strpos($internalPath, 'files/') === 0 ? mb_substr($internalPath, 5): $internalPath;
+			return $this->coreTemplateManager->getTemplatePath() === $userTemplatePath;
+		} catch (NotFoundException $e) {
+		}
+		return false;
 	}
 
 	public function getCustomTemplate(string $template): File {

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -387,7 +387,7 @@ class TemplateManager {
 	 * @return Folder
 	 * @throws NotFoundException
 	 */
-	private function getUserTemplateDir() {
+	public function getUserTemplateDir() {
 		if ($this->userId === null) {
 			throw new NotFoundException('userId not set');
 		}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/richdocuments/issues/1505

Otherwise in cases where the new nextcloud template directory was set to the same location as the collabora user setting the templates were rendered twice.

We should also get rid of the user setting but that is something tracked in https://github.com/nextcloud/richdocuments/issues/1793