### PR TITLE
url-encode filename when constructing the iframe url for the viewer

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -116,7 +116,7 @@ export default {
 	},
 	methods: {
 		async load() {
-			const documentUrl = getDocumentUrlForFile(this.filename, this.fileid) + '&path=' + this.filename
+			const documentUrl = getDocumentUrlForFile(this.filename, this.fileid) + '&path=' + encodeURIComponent(this.filename)
 			this.$emit('update:loaded', true)
 			this.src = documentUrl
 			this.loading = true


### PR DESCRIPTION
This fixes the problem mentioned
[here](https://github.com/nextcloud/server/issues/24618): when trying to
open a document from the dashboard in a Folder with special characters
like `&` or `+`, the viewer shows an error.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
