### PR TITLE
Ensure that the guest name picker is shown on editable links

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -508,6 +508,8 @@ const documentsMain = {
 	},
 
 	initSession() {
+		PostMessages.sendPostMessage('parent', 'loading')
+
 		documentsMain.urlsrc = Config.get('urlsrc')
 		documentsMain.fullPath = Config.get('path')
 		documentsMain.token = Config.get('token')
@@ -609,7 +611,7 @@ $(document).ready(function() {
 	OCA.RichDocuments.documentsMain = documentsMain
 
 	if (shouldAskForGuestName()) {
-		PostMessages.sendPostMessage('parent', 'loading')
+		PostMessages.sendPostMessage('parent', 'NC_ShowNamePicker')
 		$('#documents-content').guestNamePicker()
 	} else {
 		documentsMain.initSession()

--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -48,7 +48,7 @@ const getGuestNameCookie = function() {
 
 const setGuestName = function(username) {
 	if (username !== '') {
-		// document.cookie = 'guestUser=' + encodeURIComponent(username) + '; path=/'
+		document.cookie = 'guestUser=' + encodeURIComponent(username) + '; path=/'
 		guestName = username
 	}
 	const accessToken = encodeURIComponent(Config.get('token'))

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -210,7 +210,14 @@ export default {
 		close() {
 			this.$parent.close()
 		},
-		postMessageHandler({ parsed }) {
+		postMessageHandler({ parsed, data }) {
+			if (data === 'NC_ShowNamePicker') {
+				this.documentReady()
+				return
+			} else if (data === 'loading') {
+				this.loading = LOADING_STATE.LOADING
+				return
+			}
 			console.debug('[viewer] Received post message', parsed)
 			const { msgId, args, deprecated } = parsed
 			if (deprecated) { return }


### PR DESCRIPTION
Fixes #1914 

Steps to reproduce:
- Create a share link for a folder with edit permissions
- Open an existing office document

Before:
- Endless loading

After:
- See the guest name input

In addition the guest name is also added as a browser cookie so that it can be reused on the next attempt to open a file