### PR TITLE
Don't wait DOMContentLoaded to register the viewer handler

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -28,14 +28,12 @@ import { getCapabilities } from '@nextcloud/capabilities'
 
 const supportedMimes = getCapabilities().richdocuments.mimetypes
 
-document.addEventListener('DOMContentLoaded', function(event) {
-	if (OCA.Viewer) {
-		OCA.Viewer.registerHandler({
-			id: 'richdocuments',
-			group: null,
-			mimes: supportedMimes,
-			component: Office,
-			theme: 'light',
-		})
-	}
-})
+if (OCA.Viewer) {
+	OCA.Viewer.registerHandler({
+		id: 'richdocuments',
+		group: null,
+		mimes: supportedMimes,
+		component: Office,
+		theme: 'light',
+	})
+}


### PR DESCRIPTION
fixes #1958

We can now rely on script loading dependencies. In fact, waiting for DOMContentLoaded was even too late and the registration was not effective.