### PR TITLE
Switch from iconv to mb_convert_encoding

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -455,7 +455,7 @@ class WopiController extends Controller {
 				}
 				$file = $file[0];
 				$suggested = $this->request->getHeader('X-WOPI-SuggestedTarget');
-				$suggested = iconv('utf-7', 'utf-8', $suggested);
+				$suggested = mb_convert_encoding($suggested, 'utf-8', 'utf-7');
 
 				if ($suggested[0] === '.') {
 					$path = dirname($file->getPath()) . '/New File' . $suggested;
@@ -575,7 +575,7 @@ class WopiController extends Controller {
 
 				$suggested = $this->request->getHeader('X-WOPI-RequestedName');
 
-				$suggested = iconv('utf-7', 'utf-8', $suggested) . '.' . $file->getExtension();
+				$suggested = mb_convert_encoding($suggested, 'utf-8', 'utf-7') . '.' . $file->getExtension();
 
 				if (strpos($suggested, '.') === 0) {
 					$path = dirname($file->getPath()) . '/New File' . $suggested;
@@ -610,7 +610,7 @@ class WopiController extends Controller {
 				$file = $file[0];
 
 				$suggested = $this->request->getHeader('X-WOPI-SuggestedTarget');
-				$suggested = iconv('utf-7', 'utf-8', $suggested);
+				$suggested = mb_convert_encoding($suggested, 'utf-8', 'utf-7');
 
 				if ($suggested[0] === '.') {
 					$path = dirname($file->getPath()) . '/New File' . $suggested;


### PR DESCRIPTION
Switches all (three) uses of `iconv` to using `mb_convert_encoding` to resolve #1966.