### PR TITLE
Always add gs.trustedHosts to the CSP

### DIFF
--- a/docs/federated-editing.md
+++ b/docs/federated-editing.md
@@ -6,7 +6,23 @@ connect to that through their Nextcloud instance (Initiator).
 
 In a federated scenario both Nextcloud servers need to add each other as trusted servers or in a
 global scale environment a list of nodes can be added through the `gs.trustedHosts` setting in the
-config.php file.
+config.php file:
+
+```php
+'gs.trustedHosts' => [
+	'gs1.example.com',
+	'gs2.example.com',
+	'collabora.example.com'
+]
+```
+
+Using wildcards is also possible:
+
+```php
+'gs.trustedHosts' => [
+	'*.example.com'
+]
+```
 
 When a Initiator opens a file that is located on an incoming federated share, a check will be
 performed if the share owners instance supports federated editing. If that is the case a Initiator
@@ -14,3 +30,10 @@ token will be created, and the user will be redirected to the Source instance to
 
 The source instance will then fetch the user and file details, create a WOPI token for the remote
 user with those details and open the document with that.
+
+## Allow remote access on Collabora
+Collabora by default only allows embedding from the same remote that the initial frame is loaded. In order to enable embedding also in trusted remotes like a different GS node, the following setting will allow that:
+
+Assuming gs1.example.com and gs2.example.com are Nextcloud servers:
+
+	coolconfig set net.frame_ancestors "*.example.com"

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -198,6 +198,12 @@ class Application extends App implements IBootstrap {
 	public function updateCSP() {
 		$container = $this->getContainer();
 
+		// Do not apply CSP rules on WebDAV/OCS
+		// Ideally this could be a middleware running after the controller execution before rendering the result to only do it on page response
+		if ($container->getServer()->getRequest()->getScriptName() !== '/index.php') {
+			return;
+		}
+
 		$publicWopiUrl = $container->getServer()->getConfig()->getAppValue('richdocuments', 'public_wopi_url', '');
 		$publicWopiUrl = $publicWopiUrl === '' ? \OC::$server->getConfig()->getAppValue('richdocuments', 'wopi_url') : $publicWopiUrl;
 		$cspManager = $container->getServer()->getContentSecurityPolicyManager();
@@ -213,11 +219,7 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Dynamically add CSP for federated editing
 		 */
-		$path = '';
-		try {
-			$path = $container->getServer()->getRequest()->getPathInfo();
-		} catch (\Exception $e) {}
-		if ((strpos($path, '/apps/files/') === 0 || strpos($path, '/s/') === 0) && $container->getServer()->getAppManager()->isEnabledForUser('federation')) {
+		if ($container->getServer()->getAppManager()->isEnabledForUser('federation')) {
 			/** @var FederationService $federationService */
 			$federationService = \OC::$server->query(FederationService::class);
 
@@ -227,6 +229,7 @@ class Application extends App implements IBootstrap {
 			if ($globalScale->isGlobalScaleEnabled()) {
 				$trustedList = \OC::$server->getConfig()->getSystemValue('gs.trustedHosts', []);
 				foreach ($trustedList as $server) {
+					$policy->addAllowedFrameDomain($server);
 					$this->addTrustedRemote($policy, $server);
 				}
 			}
@@ -241,8 +244,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	private function addTrustedRemote($policy, $url) {
-		/** @var FederationService $federationService */
-		$federationService = \OC::$server->query(FederationService::class);
+		$federationService = \OC::$server->get(FederationService::class);
 		try {
 			$remoteCollabora = $federationService->getRemoteCollaboraURL($url);
 			$policy->addAllowedFrameDomain($url);


### PR DESCRIPTION
Improve handling of registering trusted global scale hosts for the CSP allow list and add some config examples.