### PR TITLE
Blank timestamp is equivalent to null

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -487,7 +487,7 @@ class WopiController extends Controller {
 				$file = $this->getFileForWopiToken($wopi);
 				$wopiHeaderTime = $this->request->getHeader('X-LOOL-WOPI-Timestamp');
 
-				if ($wopiHeaderTime !== null && $wopiHeaderTime !== Helper::toISO8601($file->getMTime() ?? 0)) {
+				if (!empty($wopiHeaderTime) && $wopiHeaderTime !== Helper::toISO8601($file->getMTime() ?? 0)) {
 					$this->logger->debug('Document timestamp mismatch ! WOPI client says mtime {headerTime} but storage says {storageTime}', [
 						'headerTime' => $wopiHeaderTime,
 						'storageTime' => Helper::toISO8601($file->getMTime() ?? 0)


### PR DESCRIPTION
The request->getHeader() function returns an empty string
even when the header in question doesn't exist. Here we
treat blank timestamps as if they weren't set, which translates
to skipping the timestamp mismatch and forcing the PUT operation.

Resolves the "overwrite" option in the conflict resolution dialog not working.
