### PR TITLE
Keep mime-type indices consecutive.

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -96,10 +96,10 @@ class Capabilities implements ICapability {
 			$filteredMimetypes = self::MIMETYPES;
 			// If version is too old, draw is not supported
 			if (!$this->capabilitiesService->hasDrawSupport()) {
-				$filteredMimetypes = array_diff($filteredMimetypes, [
+				$filteredMimetypes = array_values(array_diff($filteredMimetypes, [
 					'application/vnd.oasis.opendocument.graphics',
 					'application/vnd.oasis.opendocument.graphics-flat-xml',
-				]);
+				]));
 			}
 			$this->capabilities = [
 				'richdocuments' => [


### PR DESCRIPTION
Some JS parts of the code need the mime-type list as array. However,
when using array_filter() indices may become non-consecutive and
non-zero based. In this case json_encode/decode will not generate a JS
array but a JS object. This commit fixes this problem by wrapping the
potentially sparse array with a call to array_values().

Signed-off-by: Claus-Justus Heine <himself@claus-justus-heine.de>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary



### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
