### PR TITLE
🐛 Fix CSP violation when Nextcloud server has so-called 'service root'

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -211,9 +211,7 @@ class Application extends App implements IBootstrap {
 		if ($publicWopiUrl !== '') {
 			$policy->addAllowedFrameDomain('\'self\'');
 			$policy->addAllowedFrameDomain($this->domainOnly($publicWopiUrl));
-			if (method_exists($policy, 'addAllowedFormActionDomain')) {
-				$policy->addAllowedFormActionDomain($this->domainOnly($publicWopiUrl));
-			}
+			$policy->addAllowedFormActionDomain($this->domainOnly($publicWopiUrl));
 		}
 
 		/**

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -159,6 +159,7 @@ class DocumentController extends Controller {
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedFrameDomain($wopiDomain);
 		$policy->allowInlineScript(true);
+		$policy->addAllowedFormActionDomain($wopiDomain);
 		$response->setContentSecurityPolicy($policy);
 
 		$featurePolicy = new FeaturePolicy();


### PR DESCRIPTION
* Target version: master 

### Summary

When Nextcloud has a service root part, e.g. it is https://example.org/nextcloud, there was a CSP violation.

```
Refused to send form data to 'https://coolwsd.example.org/browser/739da71/cool.html?WOPISrc=https%3A%2F…gl&title=Foobar.ods&lang=fr&closebutton=1&revisionhistory=1' because it violates the following Content Security Policy directive: "form-action 'self'".
```

Similar to PR #1000

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Documentation (manuals or wiki) has been updated or is not required
