### PR TITLE
Map es-419 to es-MX

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -30,6 +30,12 @@ const languageToBCP47 = () => {
 	if (language === 'de-DE') {
 		language = 'de'
 	}
+
+	// es-419 should be mapped as this is not considered a valid locale string in COOL
+	if (language === 'es-419') {
+		language = 'es-MX'
+	}
+
 	// special case where setting the bc47 region depending on the locale setting makes sense
 	const whitelist = {
 		de: {


### PR DESCRIPTION
Steps to reproduce:

- Set your users language to "Español (Latin America)" (Nextcloud language code es_419)
- Try to open a document

A follow up fix to handle language codes with numbers more gracefully will follow on COOL but this will make sure documents can be properly loaded already in the meantime.
