### PR TITLE
Hotfix #2094 and maybe #2017 for pullrequest to master.

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -190,7 +190,7 @@ export default {
 		if (this.fileModel) {
 			return this.fileModel
 		}
-		if (!this.getFileList() || !this.getFileList()?.getModelForFile() || !this.getFileList()._updateDetailsView) {
+		if (!this.getFileList() || !this.getFileList()?.getModelForFile(this.fileName) || !this.getFileList()._updateDetailsView) {
 			return null
 		}
 		this.getFileList()._updateDetailsView && this.getFileList()._updateDetailsView(this.fileName, false)


### PR DESCRIPTION
* Resolves: #2094 
* Target version: master

### Summary

Adds omitted argument to `getModelForFile` call to prevent `TypeError: fileName is undefined`in firefox.


### TODO

- [ ] Backport this to 5.0.3 (I cannot create a pullrequest to a tag) to resolve #2017

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
