### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -24,7 +24,7 @@ let checkingProxyStatus = false
 
 const checkProxyStatus = () => {
 	checkingProxyStatus = true
-	const url = Config.get('urlsrc').substr(0, Config.get('urlsrc').indexOf('proxy.php') + 'proxy.php'.length)
+	const url = Config.get('urlsrc').slice(0, Config.get('urlsrc').indexOf('proxy.php') + 'proxy.php'.length)
 	$.get(url + '?status').done(function(val) {
 		if (val && val.status && val.status !== 'OK') {
 			if (val.status === 'starting' || val.status === 'stopped') {

--- a/src/files.js
+++ b/src/files.js
@@ -183,8 +183,8 @@ const odfViewer = {
 			if (typeof shareOwnerId !== 'undefined') {
 				const lastIndex = shareOwnerId.lastIndexOf('@')
 				// only redirect if remote file, not opened though reload and csp blocks the request
-				if (shareOwnerId.substr(lastIndex).indexOf('/') !== -1 && fileId !== preloadId) {
-					canAccessCSP('https://' + shareOwnerId.substr(lastIndex) + '/ocs/v2.php/apps/richdocuments/api/v1/federation', () => {
+				if (shareOwnerId.slice(lastIndex).indexOf('/') !== -1 && fileId !== preloadId) {
+					canAccessCSP('https://' + shareOwnerId.slice(lastIndex) + '/ocs/v2.php/apps/richdocuments/api/v1/federation', () => {
 						console.debug('Cannot load federated instance though CSP, navigating to ', generateUrl('/apps/richdocuments/open?fileId=' + fileId))
 						window.location = generateUrl('/apps/richdocuments/open?fileId=' + fileId)
 					})
@@ -296,7 +296,7 @@ const odfViewer = {
 
 	checkProxyStatus() {
 		const wopiUrl = OC.getCapabilities().richdocuments.config.wopi_url
-		const url = wopiUrl.substr(0, wopiUrl.indexOf('proxy.php') + 'proxy.php'.length)
+		const url = wopiUrl.slice(0, wopiUrl.indexOf('proxy.php') + 'proxy.php'.length)
 		$.get(url + '?status').done(function(result) {
 			if (result && result.status) {
 				if (result.status === 'OK' || result.status === 'error') {

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -67,7 +67,7 @@ const getNextcloudVersion = () => {
 
 const splitPath = (path) => {
 	const fileName = path.split('\\').pop().split('/').pop()
-	const directory = path.substr(0, (path.length - fileName.length - 1))
+	const directory = path.slice(0, -fileName.length - 1)
 	return [directory, fileName]
 }
 

--- a/src/services/collabora.js
+++ b/src/services/collabora.js
@@ -51,7 +51,7 @@ export const checkProxyStatus = async(_resolve, _reject) => {
 		return true
 	}
 
-	const url = wopiUrl.substr(0, wopiUrl.indexOf('proxy.php') + 'proxy.php'.length)
+	const url = wopiUrl.slice(0, wopiUrl.indexOf('proxy.php') + 'proxy.php'.length)
 	const proxyStatusUrl = url + '?status'
 
 	const checkProxyStatusCallback = async(resolve, reject) => {

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -360,7 +360,7 @@ export default {
 		const avatar = avatarContainer.find('.avatar')
 
 		avatar.css({
-			borderColor: '#' + ('000000' + Number(view.Color).toString(16)).substr(-6),
+			borderColor: '#' + ('000000' + Number(view.Color).toString(16)).slice(-6),
 			borderWidth: '2px',
 			borderStyle: 'solid',
 		})

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -134,7 +134,7 @@ export default {
 		},
 		viewColor() {
 			return view => ({
-				'border-color': '#' + ('000000' + Number(view.Color).toString(16)).substr(-6),
+				'border-color': '#' + ('000000' + Number(view.Color).toString(16)).slice(-6),
 				'border-width': '2px',
 				'border-style': 'solid',
 			})


### PR DESCRIPTION
### Summary

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
