### PR TITLE
Allow MS Office template file extensions for TemplateSource usage

### DIFF
--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -524,7 +524,11 @@ class TemplateManager {
 	}
 
 	public function isSupportedTemplateSource(string $extension): bool {
-		$supportedExtensions = ['ott', 'otg', 'otp', 'ots'];
+		$supportedExtensions = [
+			'ott', 'otg', 'otp', 'ots',
+			'dotx', 'xltx', 'potx',
+			'dot', 'xlt', 'pot',
+		];
 		return in_array($extension, $supportedExtensions, true);
 	}
 


### PR DESCRIPTION
Fixes #2108

Otherwise the file content will be copied and taken as the source of the document instead of creating the file properly from the template.