### PR TITLE
Fixes CSP on Nextcloud installations not on root directory

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -200,7 +200,7 @@ class Application extends App implements IBootstrap {
 
 		// Do not apply CSP rules on WebDAV/OCS
 		// Ideally this could be a middleware running after the controller execution before rendering the result to only do it on page response
-		if ($container->getServer()->getRequest()->getScriptName() !== '/index.php') {
+		if (!str_ends_with($container->getServer()->getRequest()->getScriptName(), '/index.php')) {
 			return;
 		}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -200,7 +200,9 @@ class Application extends App implements IBootstrap {
 
 		// Do not apply CSP rules on WebDAV/OCS
 		// Ideally this could be a middleware running after the controller execution before rendering the result to only do it on page response
-		if (!str_ends_with($container->getServer()->getRequest()->getScriptName(), '/index.php')) {
+		$script_name_parts = explode('/', $container->getServer()->getRequest()->getScriptName());
+		$script_file = end($script_name_parts);
+		if ($script_file !== 'index.php') {
 			return;
 		}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -200,9 +200,9 @@ class Application extends App implements IBootstrap {
 
 		// Do not apply CSP rules on WebDAV/OCS
 		// Ideally this could be a middleware running after the controller execution before rendering the result to only do it on page response
-		$script_name_parts = explode('/', $container->getServer()->getRequest()->getScriptName());
-		$script_file = end($script_name_parts);
-		if ($script_file !== 'index.php') {
+		$scriptNameParts = explode('/', $container->getServer()->getRequest()->getScriptName());
+		$scriptFile = end($scriptNameParts);
+		if ($scriptFile !== 'index.php') {
 			return;
 		}
 


### PR DESCRIPTION
### Summary
Fixes an issue affecting installations where Nextcloud is not installed on the root directory of the server. When accessing links to richdocuments files these would fail to open due to CSP violation issues when trying to resolve the collabora server scripts.

These requests were incorrectly applying the CSP for OCS/WebDav request and not allowing Collabora scripts to run. 

Fixes https://github.com/nextcloud/richdocuments/issues/2089

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
