### PR TITLE
Let integration tests pass again

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
         image: collabora/code
         env:
           extra_params: '--o:ssl.enable=false'
-          domain: nextcloud
+          aliasgroup1: 'http://nextcloud'
         ports:
           - "9980:9980"
 
@@ -103,7 +103,7 @@ jobs:
         image: collabora/code
         env:
           extra_params: '--o:ssl.enable=false'
-          domain: nextcloud
+          aliasgroup1: 'http://nextcloud'
         ports:
           - "9980:9980"
 
@@ -178,7 +178,7 @@ jobs:
         image: collabora/code
         env:
           extra_params: '--o:ssl.enable=false'
-          domain: nextcloud
+          aliasgroup1: 'http://nextcloud'
         ports:
           - "9980:9980"
 
@@ -248,7 +248,7 @@ jobs:
         image: collabora/code
         env:
           extra_params: '--o:ssl.enable=false'
-          domain: nextcloud
+          aliasgroup1: 'http://nextcloud'
         ports:
           - "9980:9980"
 

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 OC_PATH=../../../
 OCC=${OC_PATH}occ
 SCENARIO_TO_RUN=$1
@@ -34,6 +36,7 @@ else
 	COOL_CONTAINER=$(docker run -t -d -p 9980:9980 -e "domain=localhost" -e "extra_params=--o:ssl.enable=false" collabora/code)
 fi;
 
+curl --fail http://localhost:$PORT_COOL/hosting/capabilities
 
 
 


### PR DESCRIPTION
Adapt to changed wopi allow list configuration using alias groups: https://sdk.collaboraonline.com/docs/installation/CODE_Docker_image.html#setting-the-application-configuration-dynamically-via-environment-variables

Makes them pass (except for the federation ones which are being looked into by @Raudius separately)