### PR TITLE
Add gs.trustedHosts to form-action csp

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -229,6 +229,7 @@ class Application extends App implements IBootstrap {
 				foreach ($trustedList as $server) {
 					$policy->addAllowedFrameDomain($server);
 					$this->addTrustedRemote($policy, $server);
+					$policy->addAllowedFormActionDomain($server);
 				}
 			}
 			$remoteAccess = $container->getServer()->getRequest()->getParam('richdocuments_remote_access');


### PR DESCRIPTION
This will allow loadbalanced collabora servers to serve frames. 

* Target version: master 

### Summary
Without a way to add individual servers to form-action csp header it is not possible to load balance collabora servers

