### PR TITLE
Pass TTL token to Collabora

### DIFF
--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -171,6 +171,7 @@ class DirectViewController extends Controller {
 				'title' => $item->getName(),
 				'fileId' => $wopi->getFileid() . '_' . $this->config->getSystemValue('instanceid'),
 				'token' => $wopi->getToken(),
+				'token_ttl' => $wopi->getExpiry(),
 				'urlsrc' => $urlSrc,
 				'path' => $relativePath,
 				'instanceId' => $this->config->getSystemValue('instanceid'),
@@ -232,6 +233,7 @@ class DirectViewController extends Controller {
 					$this->tokenManager->upgradeFromDirectInitiator($direct, $wopi);
 				}
 				$params['token'] = $token;
+				$params['token_ttl'] = $wopi->getExpiry();
 				$params['urlsrc'] = $urlSrc;
 
 				$this->initialState->provideDocument($wopi);

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -212,6 +212,7 @@ class DocumentController extends Controller {
 				'title' => $item->getName(),
 				'fileId' => $item->getId() . '_' . $this->config->getSystemValue('instanceid'),
 				'token' => $token,
+				'token_ttl' => $wopi->getExpiry(),
 				'urlsrc' => $urlSrc,
 				'path' => $folder->getRelativePath($item->getPath()),
 				'instanceId' => $this->config->getSystemValue('instanceid'),
@@ -281,6 +282,7 @@ class DocumentController extends Controller {
 			'title' => $fileName,
 			'fileId' => $wopiFileId,
 			'token' => $wopi->getToken(),
+			'token_ttl' => $wopi->getExpiry(),
 			'urlsrc' => $urlSrc,
 			'path' => $userFolder->getRelativePath($file->getPath()),
 			'instanceId' => $this->config->getSystemValue('instanceid'),
@@ -344,6 +346,7 @@ class DocumentController extends Controller {
 
 				list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($item->getId(), $shareToken, $this->uid);
 				$params['token'] = $token;
+				$params['token_ttl'] = $wopi->getExpiry();
 				$params['urlsrc'] = $urlSrc;
 
 				$this->initialState->provideDocument($wopi);
@@ -458,6 +461,7 @@ class DocumentController extends Controller {
 					'title' => $node->getName(),
 					'fileId' => $node->getId() . '_' . $this->config->getSystemValue('instanceid'),
 					'token' => $token,
+					'token_ttl' => $wopi->getExpiry(),
 					'urlsrc' => $urlSrc,
 					'path' => '/',
 					'instanceId' => $this->config->getSystemValue('instanceid'),

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -30,8 +30,10 @@ use OCP\ILogger;
 use OCP\Security\ISecureRandom;
 
 class WopiMapper extends Mapper {
-	// Tokens expire after this many seconds (not defined by WOPI specs).
-	const TOKEN_LIFETIME_SECONDS = 1800;
+	// Tokens expire after this many seconds.
+	// 10 hours is the recommended value on the spec doc:
+	// https://docs.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/concepts#access_token_ttl
+	const TOKEN_LIFETIME_SECONDS = 36000;
 
 	/** @var ISecureRandom */
 	private $random;

--- a/src/document.js
+++ b/src/document.js
@@ -178,12 +178,14 @@ const documentsMain = {
 
 			const urlsrc = getWopiUrl({ fileId, title, readOnly: true })
 
-			// access_token - must be passed via a form post
+			// access_token & access_token_ttl - must be passed via a form post
 			const accessToken = encodeURIComponent(documentsMain.token)
+			const accessTokenTtl = encodeURIComponent(documentsMain.tokenTtl)
 
 			// form to post the access token for WOPISrc
 			const form = '<form id="loleafletform_viewer" name="loleafletform_viewer" target="loleafletframe_viewer" action="' + urlsrc + '" method="post">'
 				+ '<input name="access_token" value="' + accessToken + '" type="hidden"/>'
+				+ '<input name="access_token_ttl" value="' + accessTokenTtl + '" type="hidden"/>'
 				+ '<input name="ui_defaults" value="' + getUIDefaults() + '" type="hidden"/>'
 				+ '<input name="css_variables" value="' + generateCSSVarTokens() + '" type="hidden"/>'
 				+ '<input name="theme" value="' + getCollaboraTheme() + '" type="hidden"/>'
@@ -235,10 +237,12 @@ const documentsMain = {
 
 			// access_token - must be passed via a form post
 			const accessToken = encodeURIComponent(documentsMain.token)
+			const accessTokenTtl = encodeURIComponent(documentsMain.tokenTtl)
 
 			// form to post the access token for WOPISrc
 			const form = '<form id="loleafletform" name="loleafletform" target="loleafletframe" action="' + urlsrc + '" method="post">'
 				+ '<input name="access_token" value="' + accessToken + '" type="hidden"/>'
+				+ '<input name="access_token_ttl" value="' + accessTokenTtl + '" type="hidden"/>'
 				+ '<input name="ui_defaults" value="' + getUIDefaults() + '" type="hidden"/>'
 				+ '<input name="css_variables" value="' + generateCSSVarTokens() + '" type="hidden"/>'
 				+ '<input name="theme" value="' + getCollaboraTheme() + '" type="hidden"/>'
@@ -513,6 +517,7 @@ const documentsMain = {
 		documentsMain.urlsrc = Config.get('urlsrc')
 		documentsMain.fullPath = Config.get('path')
 		documentsMain.token = Config.get('token')
+		documentsMain.tokenTtl = Config.get('token_ttl') * 1000
 		documentsMain.fileId = Config.get('fileId')
 		documentsMain.fileName = Config.get('title')
 		documentsMain.canEdit = Boolean(Config.get('permissions') & OC.PERMISSION_UPDATE)

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -3,6 +3,7 @@
 	var richdocuments_title = '<?php p($_['title']) ?>';
 	var richdocuments_fileId = '<?php p($_['fileId']) ?>';
 	var richdocuments_token = '<?php p($_['token'] ? $_['token'] : "") ?>';
+	var richdocuments_token_ttl = <?php p($_['token_ttl'] ?: 0) ?>;
 	var richdocuments_urlsrc = '<?php p($_['urlsrc'] ? $_['urlsrc'] : "") ?>';
 	var richdocuments_path = '<?php p($_['path']) ?>';
 	var richdocuments_userId = <?php isset($_['userId']) ? print_unescaped('\'' . \OCP\Util::sanitizeHTML($_['userId']) . '\'') : print_unescaped('null') ?>;
@@ -21,3 +22,5 @@ script('richdocuments', 'richdocuments-document');
 	<div id="proxyLoadingMessage"></div>
 </div>
 <div id="documents-content"></div>
+
+


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/2123
* Target version: master 

### Summary
Adds light-enforcement of the TTL token by passing the token to the Collabora server. This will provide users a warning when their token is about to expire (15 minutes prior to expiry).

Note: this PR does not enforce expiration on our back-end yet, so a user will be able to continue editing documents beyond the expiry of their token. This will come on #2150 .

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
