### PR TITLE
Adjust template preview ratio

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -136,7 +136,7 @@ class Application extends App implements IBootstrap {
 				$odpType->addMimetype('application/vnd.oasis.opendocument.graphics');
 				$odpType->addMimetype('application/vnd.oasis.opendocument.graphics-template');
 				$odpType->setIconClass('icon-filetype-draw');
-				$odpType->setRatio(16/9);
+				$odpType->setRatio(1);
 				return $odpType;
 			});
 		});


### PR DESCRIPTION
Contributes to https://github.com/nextcloud/example-files/issues/21#issuecomment-1102426385 to make the template picker previews square ratio for draw files:
![Screenshot 2022-04-19 at 14 43 34](https://user-images.githubusercontent.com/3404133/164007116-59c06f66-f723-46a8-8876-c10f0a03e0ab.png)

