### PR TITLE
Add app config to enable trusted domain list usage

### DIFF
--- a/docs/federated-editing.md
+++ b/docs/federated-editing.md
@@ -37,3 +37,9 @@ Collabora by default only allows embedding from the same remote that the initial
 Assuming gs1.example.com and gs2.example.com are Nextcloud servers:
 
 	coolconfig set net.frame_ancestors "*.example.com"
+
+## Trusted hosts
+
+By default, trusted hosts of Nextcloud will not be allowed for federated editing. This can be enabled through the following app config value:
+
+	occ config:app:set richdocuments federation_use_trusted_domains --value="yes"

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -16,6 +16,10 @@ use \OCP\IConfig;
 
 class AppConfig {
 
+	public const FEDERATION_USE_TRUSTED_DOMAINS = 'federation_use_trusted_domains';
+
+	public const SYSTEM_GS_TRUSTED_HOSTS = 'gs.trustedHosts';
+
 	private $defaults = [
 		'wopi_url' => '',
 		'timeout' => 15,
@@ -105,6 +109,20 @@ class AppConfig {
 			}
 		}
 		return $result;
+	}
+
+	/**
+	 * Returns a list of trusted domains from the gs.trustedHosts config
+	 */
+	public function getTrustedDomains(): array {
+		return $this->config->getSystemValue(self::SYSTEM_GS_TRUSTED_HOSTS, []);
+	}
+
+	/**
+	 * Returns if federation trusted domains should be always allowed for federated editing
+	 */
+	public function isTrustedDomainAllowedForFederation(): bool {
+		return $this->config->getAppValue(Application::APPNAME, self::FEDERATION_USE_TRUSTED_DOMAINS, 'no') === 'yes';
 	}
 
  }


### PR DESCRIPTION
Trusted domains do not are not necessarily allowed for federated editing so this PR adds a config switch for that and disables it by default. 