### PR TITLE
Clean up expired tokens

### DIFF
--- a/lib/Backgroundjobs/Cleanup.php
+++ b/lib/Backgroundjobs/Cleanup.php
@@ -32,7 +32,7 @@ class Cleanup extends TimedJob {
 
 	/** @var IDBConnection */
 	private $db;
-	/** @var $wopiMapper */
+	/** @var WopiMapper $wopiMapper */
 	private $wopiMapper;
 
 	public function __construct(IDBConnection $db, WopiMapper $wopiMapper) {

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -24,9 +24,9 @@ namespace OCA\Richdocuments\Db;
 
 use OCA\Richdocuments\Exceptions\ExpiredTokenException;
 use OCA\Richdocuments\Exceptions\UnknownTokenException;
-use OCP\AppFramework\Db\TokenExpiredException;
 use OCP\AppFramework\Db\Mapper;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\ILogger;
 use OCP\Security\ISecureRandom;
@@ -165,5 +165,23 @@ class WopiMapper extends Mapper {
 		}
 
 		return $wopi;
+	}
+
+	/**
+	 * @param int|null $limit
+	 * @param int|null $offset
+	 * @return int[]
+	 * @throws \OCP\DB\Exception
+	 */
+	public function getExpiredTokenIds(?int $limit = null, ?int $offset = null)
+	{
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id')
+			->from('richdocuments_wopi')
+			->where($qb->expr()->lt('expiry', $qb->createNamedParameter(time() - 60, IQueryBuilder::PARAM_INT)))
+			->setFirstResult($offset)
+			->setMaxResults($limit);
+
+		return array_column($qb->executeQuery()->fetchAll(), 'id');
 	}
 }


### PR DESCRIPTION
* Resolves: [# <!-- related github issue -->](https://github.com/nextcloud/richdocuments/issues/2123)
* Target version: master 

### Summary

Cleans up expired tokens in the cron. 1000 expired tokens are deleted each time the background job runs.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
