### PR TITLE
File history fix behaviour in group folders

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -34,7 +34,6 @@ use OCA\Richdocuments\TemplateManager;
 use OCA\Richdocuments\TokenManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\TokenExpiredException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\StreamResponse;

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -84,6 +84,10 @@ export default {
 			this.getFileList().hideMask && this.getFileList().hideMask()
 			this.getFileList().setPageTitle && this.getFileList().setPageTitle(this.fileName)
 		}
+
+		if (!isPublic) {
+			this.addVersionSidebarEvents()
+		}
 	},
 
 	close() {
@@ -417,6 +421,8 @@ export default {
 	},
 
 	addVersionSidebarEvents() {
+		// eslint-disable-next-line
+		console.log('addVersionSidebarEvents')
 		$(document.querySelector('#content')).on('click.revisions', '.app-sidebar .preview-container', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('click.revisions', '.app-sidebar .downloadVersion', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('mousedown.revisions', '.app-sidebar .revertVersion', this.restoreVersion.bind(this))

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -421,8 +421,6 @@ export default {
 	},
 
 	addVersionSidebarEvents() {
-		// eslint-disable-next-line
-		console.log('addVersionSidebarEvents')
 		$(document.querySelector('#content')).on('click.revisions', '.app-sidebar .preview-container', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('click.revisions', '.app-sidebar .downloadVersion', this.showVersionPreview.bind(this))
 		$(document.querySelector('#content')).on('mousedown.revisions', '.app-sidebar .revertVersion', this.restoreVersion.bind(this))


### PR DESCRIPTION
* Resolves: #387
* Target version: master 

### Summary
Fixes retrieval of history revisions from files in group folders. 
Additionally this PR also allows seeing past revisions from within the viewer (in read only). This behaviour was already implemented but broken in a previous change.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
