### PR TITLE
Disable remote image insertion on public links

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -204,7 +204,7 @@ class WopiController extends Controller {
 			'LastModifiedTime' => Helper::toISO8601($file->getMTime()),
 			'SupportsRename' => !$isVersion,
 			'UserCanRename' => !$isPublic && !$isVersion,
-			'EnableInsertRemoteImage' => true,
+			'EnableInsertRemoteImage' => !$isPublic,
 			'EnableShare' => $file->isShareable() && !$isVersion,
 			'HideUserList' => '',
 			'DisablePrint' => $wopi->getHideDownload(),


### PR DESCRIPTION
* Replaces: #2035
* Target version: master

### Summary

Ensure that the insert image from Nextcloud UI parts are properly disabled on public share links through the checkFileInfo EnableInsertRemoteImage flag.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
