### PR TITLE
Use visibility instead of display to have the iframe already allocate the size

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -58,7 +58,7 @@
 					<ActionButton icon="icon-menu-sidebar" @click="share" />
 				</Actions>
 			</div>
-			<iframe v-show="showIframe"
+			<iframe :style="{visibility: showIframe ? 'visible' : 'hidden' }"
 				id="collaboraframe"
 				ref="documentFrame"
 				:src="src" />


### PR DESCRIPTION
This should address the various reportings where firefox failed loading a document when multiple users joined it due to the Collabora iframe requiring the size of the iframe before the Frame_Ready post message is emitted. We currently hide the iframe until that message is received to avoid having multiple loading indicators of different types. By moving the hiding to use visibility this should already allocate the size properly.

Huge thanks to @alangecker for the in depth debugging and insights provided in  https://github.com/nextcloud/richdocuments/issues/2125#issuecomment-1126820265

Needs a bit more long term testing on my side to verify that it always works reliably. A hot fix to apply manually is available in https://github.com/nextcloud/richdocuments/issues/2125#issuecomment-1127547720 for anyone who would want to help testing this.

Fixes https://github.com/nextcloud/richdocuments/issues/2125
Fixes https://github.com/nextcloud/richdocuments/issues/2094