### PR TITLE
Fix viewer styling to adjust to upstream viewer changes

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -337,6 +337,11 @@ export default {
 		flex-direction: column;
 		background-color: var(--color-main-background);
 		transition: opacity .25s;
+
+		.viewer & {
+			height: 100vh;
+			top: -50px;
+		}
 	}
 
 	iframe {


### PR DESCRIPTION
Fixes #2190 

While not nice, since the viewer added a `position: relative;` on the parent, this is currently the only way that we can overlay the viewer header and make the richdocuments frame full screen.