### PR TITLE
Backport translations to stable branches

### DIFF
--- a/.tx/backport
+++ b/.tx/backport
@@ -1,1 +1,3 @@
-stable3.8
+stable4
+stable23
+stable24


### PR DESCRIPTION
Should fix #2231 

Based on https://github.com/nextcloud/docker-ci/blob/master/translations-app/handleAppTranslations.sh#L17-L19

- [ ] Drop this file once stable4 branch is no longer supported as we can use the default stable* then
- [ ] Document the backport behaviour for app developers