### PR TITLE
Move document params to initial state

### DIFF
--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -175,15 +175,10 @@ class DirectViewController extends Controller {
 				'token_ttl' => $wopi->getExpiry(),
 				'urlsrc' => $urlSrc,
 				'path' => $relativePath,
-				'instanceId' => $this->config->getSystemValue('instanceid'),
-				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 				'direct' => true,
 			];
 
-			$this->initialState->provideDocument($wopi);
-			$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
-			$this->applyPolicies($response);
-			return $response;
+			return $this->documentTemplateResponse($wopi, $params);
 		} catch (\Exception $e) {
 			$this->logger->logException($e);
 			return  $this->renderErrorPage('Failed to open the requested file.');
@@ -218,8 +213,6 @@ class DirectViewController extends Controller {
 					'title' => $node->getName(),
 					'fileId' => $node->getId() . '_' . $this->settings->getSystemValue('instanceid'),
 					'path' => '/',
-					'instanceId' => $this->settings->getSystemValue('instanceid'),
-					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 					'userId' => null,
 					'direct' => true,
 					'directGuest' => empty($direct->getUid()),
@@ -233,10 +226,7 @@ class DirectViewController extends Controller {
 				$params['token_ttl'] = $wopi->getExpiry();
 				$params['urlsrc'] = $urlSrc;
 
-				$this->initialState->provideDocument($wopi);
-				$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
-				$this->applyPolicies($response);
-				return $response;
+				return $this->documentTemplateResponse($wopi, $params);
 			}
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' => 'richdocuments']);

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -180,9 +180,6 @@ class DocumentController extends Controller {
 				'token_ttl' => $wopi->getExpiry(),
 				'urlsrc' => $urlSrc,
 				'path' => $folder->getRelativePath($item->getPath()),
-				'instanceId' => $this->config->getSystemValue('instanceid'),
-				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
-				'userId' => $this->uid
 			];
 
 			$encryptionManager = \OC::$server->getEncryptionManager();
@@ -195,10 +192,7 @@ class DocumentController extends Controller {
 				$encryptionManager->getEncryptionModule()->update($absPath, $owner, $accessList);
 			}
 
-			$this->initialState->provideDocument($wopi);
-			$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
-			$this->applyPolicies($response);
-			return $response;
+			return $this->documentTemplateResponse($wopi, $params);
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' => 'richdocuments']);
 			return $this->renderErrorPage('Failed to open the requested file.');
@@ -249,15 +243,9 @@ class DocumentController extends Controller {
 			'token_ttl' => $wopi->getExpiry(),
 			'urlsrc' => $urlSrc,
 			'path' => $userFolder->getRelativePath($file->getPath()),
-			'instanceId' => $this->config->getSystemValue('instanceid'),
-			'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
-			'userId' => $this->uid
 		];
 
-		$this->initialState->provideDocument($wopi);
-		$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
-		$this->applyPolicies($response);
-		return $response;
+		return $this->documentTemplateResponse($wopi, $params);
 	}
 
 	/**
@@ -303,9 +291,6 @@ class DocumentController extends Controller {
 					'title' => $item->getName(),
 					'fileId' => $item->getId() . '_' . $this->config->getSystemValue('instanceid'),
 					'path' => '/',
-					'instanceId' => $this->config->getSystemValue('instanceid'),
-					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
-					'userId' => $this->uid,
 					'isPublicShare' => true,
 				];
 
@@ -314,10 +299,7 @@ class DocumentController extends Controller {
 				$params['token_ttl'] = $wopi->getExpiry();
 				$params['urlsrc'] = $urlSrc;
 
-				$this->initialState->provideDocument($wopi);
-				$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
-				$this->applyPolicies($response);
-				return $response;
+				return $this->documentTemplateResponse($wopi, $params);
 			}
 		} catch (\Exception $e) {
 			$this->logger->logException($e, ['app' => 'richdocuments']);
@@ -382,15 +364,10 @@ class DocumentController extends Controller {
 					'token_ttl' => $wopi->getExpiry(),
 					'urlsrc' => $urlSrc,
 					'path' => '/',
-					'instanceId' => $this->config->getSystemValue('instanceid'),
-					'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 					'userId' => $remoteWopi->getEditorUid() ? ($remoteWopi->getEditorUid() . '@' . $remoteServer) : null,
 				];
 
-				$this->initialState->provideDocument($wopi);
-				$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
-				$this->applyPolicies($response);
-				return $response;
+				return $this->documentTemplateResponse($wopi, $params);
 			}
 		} catch (ShareNotFound $e) {
 			return new TemplateResponse('core', '404', [], 'guest');

--- a/lib/Controller/DocumentTrait.php
+++ b/lib/Controller/DocumentTrait.php
@@ -2,11 +2,20 @@
 
 namespace OCA\Richdocuments\Controller;
 
+use OCA\Richdocuments\Db\Wopi;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\FeaturePolicy;
+use OCP\AppFramework\Http\TemplateResponse;
 
 trait DocumentTrait {
 	private $appConfig;
+
+	private function documentTemplateResponse(Wopi $wopi, array $params): TemplateResponse {
+		$this->initialState->provideDocument($wopi, $params);
+		$response = new TemplateResponse('richdocuments', 'documents', $params, 'base');
+		$this->applyPolicies($response);
+		return $response;
+	}
 
 	/**
 	 * Setup policy headers for the response

--- a/src/services/config.tsx
+++ b/src/services/config.tsx
@@ -20,31 +20,21 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
+import { loadState } from '@nextcloud/initial-state'
 
 class ConfigService {
-    private values: {[name: string]: string}
+
+    private values: {[name: string]: any}
+
     constructor () {
-        this.values = {}
-        this.loadFromGlobal('userId')
-        this.loadFromGlobal('urlsrc')
-        this.loadFromGlobal('directEdit')
-        this.loadFromGlobal('directGuest')
-        this.loadFromGlobal('permissions')
-        this.loadFromGlobal('instanceId')
-        this.loadFromGlobal('isPublicShare')
-    }
-    loadFromGlobal(key: string) {
-        // @ts-ignore
-        this.values[key] = window['richdocuments_' + key]
-    }
-    update(key: string, value: string) {
-        // @ts-ignore
+		this.values = loadState('richdocuments', 'document', {})
+	}
+
+    update(key: string, value: any) {
         this.values[key] = value
     }
-    get(key: string) {
-        if (typeof this.values[key] === 'undefined') {
-            this.loadFromGlobal(key)
-        }
+
+    get(key: string): any {
         return this.values[key]
     }
 }

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -1,19 +1,3 @@
-<script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>">
-	var richdocuments_permissions = '<?php p($_['permissions']) ?>';
-	var richdocuments_title = '<?php print_unescaped(addslashes($_['title'])) ?>';
-	var richdocuments_fileId = '<?php p($_['fileId']) ?>';
-	var richdocuments_token = '<?php p($_['token'] ? $_['token'] : "") ?>';
-	var richdocuments_token_ttl = <?php p($_['token_ttl'] ?: 0) ?>;
-	var richdocuments_urlsrc = '<?php p($_['urlsrc'] ? $_['urlsrc'] : "") ?>';
-	var richdocuments_path = '<?php p($_['path']) ?>';
-	var richdocuments_userId = <?php isset($_['userId']) ? print_unescaped('\'' . \OCP\Util::sanitizeHTML($_['userId']) . '\'') : print_unescaped('null') ?>;
-	var richdocuments_instanceId = '<?php p($_['instanceId']) ?>';
-	var richdocuments_canonical_webroot = '<?php p($_['canonical_webroot']) ?>';
-	var richdocuments_directEdit = <?php isset($_['direct']) ? p('true') : p('false') ?>;
-	var richdocuments_directGuest = <?php isset($_['directGuest']) ? p('true') : p('false') ?>;
-	var richdocuments_isPublicShare = <?php isset($_['isPublicShare']) && $_['isPublicShare'] ? p('true') : p('false') ?>;
-</script>
-
 <?php
 script('richdocuments', 'richdocuments-document');
 ?>

--- a/tests/features/bootstrap/DirectContext.php
+++ b/tests/features/bootstrap/DirectContext.php
@@ -136,19 +136,20 @@ class DirectContext implements Context {
 			). '/';
 		}
 		$contents = $response->getBody()->getContents();
-		$re = '/var richdocuments_([A-z]+) = (.*);/m';
+
+		$re = '/id="initial-state-richdocuments-([A-z]+)" value="(.*)"/m';
 		preg_match_all($re, $contents, $matches, PREG_SET_ORDER, 0);
-		$params = [];
+		$initialState = [];
 		foreach ($matches as $match) {
-			$params[$match[1]] = str_replace("'", "", $match[2]);
+			$initialState[$match[1]] = json_decode(base64_decode($match[2], true), true);
 		}
 
-		Assert::assertNotEmpty($params['fileId']);
-		Assert::assertNotEmpty($params['token']);
+		Assert::assertNotEmpty($initialState['fileId']);
+		Assert::assertNotEmpty($initialState['token']);
 
 		$currentServer = $currentServer ?? $this->serverContext->getBaseUrl();
 
-		$this->wopiContext->setWopiParameters($currentServer, $params['fileId'], $params['token']);
+		$this->wopiContext->setWopiParameters($currentServer, $initialState['fileId'], $initialState['token']);
 		Assert::assertEquals(200, $response->getStatusCode());
 	}
 

--- a/tests/features/bootstrap/RichDocumentsContext.php
+++ b/tests/features/bootstrap/RichDocumentsContext.php
@@ -198,16 +198,17 @@ class RichDocumentsContext implements Context {
 
 	private function extractRichdocumentsFrontendContext($response) {
 		$contents = $response->getBody()->getContents();
-		$re = '/var richdocuments_([A-z]+) = (.*);/m';
+		$re = '/id="initial-state-richdocuments-([A-z]+)" value="(.*)"/m';
 		preg_match_all($re, $contents, $matches, PREG_SET_ORDER, 0);
 		$result = [];
 		foreach ($matches as $match) {
-			$result[$match[1]] = str_replace("'", "", $match[2]);
+			$result[$match[1]] = json_decode(base64_decode($match[2], true), true);
 		}
 
-		$this->fileIds[] = $result['fileId'];
-		$this->fileId = $result['fileId'];
-		$this->wopiToken = $result['token'];
+		$document = $result['document'];
+		$this->fileIds[] = $document['fileId'];
+		$this->fileId = $document['fileId'];
+		$this->wopiToken = $document['token'];
 		$this->wopiContext->setWopiParameters($this->currentServer, $this->fileId, $this->wopiToken);
 	}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"outDir": "./dist/",
 		"sourceMap": false,
 		"noImplicitAny": true,
+		"moduleResolution": "node",
 		"module": "es6",
 		"target": "es5",
 		"jsx": "react",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,6 @@
 		"module": "es6",
 		"target": "es5",
 		"jsx": "react",
-		"paths": {
-			"@nextcloud/event-bus": [
-				"./node_modules/@nextcloud/event-bus/dist/index.js",
-				"./node_modules/@nextcloud/event-bus/dist/lib/*"
-			]
-		},
 		"allowJs": true
 	},
 	"include": ["src/**/*.tsx"],


### PR DESCRIPTION
Avoid building inline javascript in the template to pass over the required metadata for the document opening.

This also fixes an issue where special characters in a filename like `It's.odt` caused the save as dialog to show double escaped html.

- [x] Integration tests currently parse the inline js https://github.com/nextcloud/richdocuments/blob/9bb9661795e69d2a035522affe0913626ae3f02c/tests/features/bootstrap/RichDocumentsContext.php#L200-L213
