### PR TITLE
Fix encoding in filename

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -27,7 +27,7 @@
 				id="cool-loading-overlay"
 				:class="{ debug: debug }">
 				<EmptyContent v-if="!error" icon="icon-loading">
-					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }) }}
+					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }, undefined, { escape: false }) }}
 					<template #desc>
 						<button @click="close">
 							{{ t('richdocuments', 'Cancel') }}


### PR DESCRIPTION
Avoid double encoding in the loading screen as vue already handles that, so we can skip it on the translations.
