### PR TITLE
bugfix/noid/non visible create file

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -75,6 +75,10 @@ const odfViewer = {
 						return
 					}
 
+					if (context.fileInfoModel) {
+						context.fileId = context.fileInfoModel.get('id')
+					}
+
 					const fileModel = context.fileList.findFile(fileName)
 					const shareOwnerId = fileModel?.shareOwnerId
 					return this.onEdit(fileName, {


### PR DESCRIPTION
Steps to reproduce:
- Create a directory
- `touch a{1..100}.txt` and upload them to the directory
- reload the directory
- Try to create a new document named `z1.odt` so that it is added at the end of the file list where it is not visible

Before:
- Loading fails

After:
- Loading works