### PR TITLE
Prevent download on user shares

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -22,6 +22,7 @@
 namespace OCA\Richdocuments;
 
 use OC\Files\Filesystem;
+use OCA\Files_Sharing\SharedStorage;
 use OCA\Richdocuments\Db\Direct;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Db\Wopi;
@@ -143,6 +144,25 @@ class TokenManager {
 						$editorGroup = $this->groupManager->get($editGroup);
 						if ($editorGroup !== null && $editorGroup->inGroup($editorUser)) {
 							$updatable = true;
+							break;
+						}
+					}
+				}
+
+				// disable download if at least one shared access has it disabled
+
+				foreach ($files as $file) {
+					$storage = $file->getStorage();
+					// using string as we have no guarantee that "files_sharing" app is loaded
+					if ($storage->instanceOfStorage(SharedStorage::class)) {
+						if (!method_exists(SharedStorage::class, 'getAttributes')) {
+							break;
+						}
+						/** @var SharedStorage $storage */
+						$share = $storage->getShare();
+						$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
+						if ($canDownload !== null && !$canDownload) {
+							$hideDownload = true;
 							break;
 						}
 					}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -17,6 +17,12 @@ namespace Doctrine\DBAL\Platforms {
 	class SqlitePlatform {}
 }
 
+namespace OCA\Files_Sharing {
+	use \OCP\Share\IShare;
+	class SharedStorage {
+		public function getShare(): IShare {}
+	}
+}
 
 namespace OCA\Files_Sharing\Event {
 	use \OCP\Share\IShare;


### PR DESCRIPTION
Depends on https://github.com/nextcloud/server/pull/32482
Implements #2267 

Set the `hideDownload` attribute of the Wopi token when it's created. Get this from the share permissions. If multiple shares give access to the file, only one with download disabled will lead to hiding it in Collabora.

- [ ] https://github.com/nextcloud/server/pull/33448