### PR TITLE
Fix: allow opening PDF with Collabora

### DIFF
--- a/css/filetypes.scss
+++ b/css/filetypes.scss
@@ -13,3 +13,11 @@
 .icon-filetype-draw {
 	background-image: url('../img/x-office-drawing.svg');
 }
+
+.icon-richdocuments {
+	background-image: url(../img/app-dark.svg);
+}
+
+body.dark .icon-richdocuments {
+	background-image: url(../img/app.svg);
+}

--- a/css/filetypes.scss
+++ b/css/filetypes.scss
@@ -16,8 +16,5 @@
 
 .icon-richdocuments {
 	background-image: url(../img/app-dark.svg);
-}
-
-body.dark .icon-richdocuments {
-	background-image: url(../img/app.svg);
+	filter: var(--background-invert-if-dark);
 }

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -37,3 +37,28 @@ if (OCA.Viewer) {
 		theme: 'light',
 	})
 }
+
+// TODO: Viewer.openWith introduced with https://github.com/nextcloud/viewer/pull/1273
+//       This check can be replaced with `if(OCA.Viewer)` once NC 24 is EOL.
+if (OCA.Viewer.openWith) {
+	const supportedMimes = OC.getCapabilities().richdocuments.mimetypes.concat(OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen)
+	const actionName = 'Edit with ' + OC.getCapabilities().richdocuments.productName
+	const actionDisplayName = t('richdocuments', 'Edit with {productName}', { productName: OC.getCapabilities().richdocuments.productName }, undefined, { escape: false })
+
+	for (const mime of supportedMimes) {
+		const action = {
+			name: actionName,
+			mime,
+			permissions: OC.PERMISSION_READ,
+			iconClass: 'icon-richdocuments',
+			displayName: actionDisplayName,
+			actionHandler: (fileName, context) => {
+				OCA.Viewer.openWith('richdocuments', {
+					path: context.fileInfoModel.getFullPath()
+				})
+			}
+		}
+
+		OCA.Files.fileActions.registerAction(action)
+	}
+}

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -41,9 +41,9 @@ if (OCA.Viewer) {
 // TODO: Viewer.openWith introduced with https://github.com/nextcloud/viewer/pull/1273
 //       This check can be replaced with `if(OCA.Viewer)` once NC 24 is EOL.
 if (OCA.Viewer.openWith) {
-	const supportedMimes = OC.getCapabilities().richdocuments.mimetypes.concat(OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen)
-	const actionName = 'Edit with ' + OC.getCapabilities().richdocuments.productName
-	const actionDisplayName = t('richdocuments', 'Edit with {productName}', { productName: OC.getCapabilities().richdocuments.productName }, undefined, { escape: false })
+	const supportedMimes = getCapabilities().richdocuments.mimetypesNoDefaultOpen
+	const actionName = 'Edit with ' + getCapabilities().richdocuments.productName
+	const actionDisplayName = t('richdocuments', 'Edit with {productName}', { productName: getCapabilities().richdocuments.productName }, undefined, { escape: false })
 
 	for (const mime of supportedMimes) {
 		const action = {


### PR DESCRIPTION
* Resolves: #1894 
* Target version: master 

### Summary
Fixes regression where PDFs could not be opened with collabora since we moved to using the Viewer app (https://github.com/nextcloud/richdocuments/pull/1820).

Adds the context menu option to edit PDFs, and registers the actions with the files app. For the action handler we call the new viewer method `openWith` (https://github.com/nextcloud/viewer/pull/1273).

### TODO
- [x] Depends on: https://github.com/nextcloud/viewer/pull/1273

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
