### PR TITLE
Exclude MSOffice mime types association if OnlyOffice app is installed

### DIFF
--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -112,6 +112,18 @@ class CapabilitiesService {
 		return $this->l10n->t('Nextcloud Office');
 	}
 
+	public function hasOtherOOXMLApps(): bool {
+		if ($this->appManager->isEnabledForUser('officeonline')) {
+			return true;
+		}
+
+		if ($this->appManager->isEnabledForUser('onlyoffice')) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public function clear(): void {
 		$this->cache->remove('capabilities');
 	}


### PR DESCRIPTION
Signed-off-by: Grégory Marigot <gmarigot@teicee.com>


* Resolves: #2281 
* Target version: master 

### Summary

The Nextcloud Office app configure the association with all possible office documents mime types.
But if we also have the OnlyOffice app, it's not possible to open any document with it...

Collabora and OnlyOffice are both great and it's a common case to want to install both: Collabora for OpenOffice documents and OnlyOffice for MSOffice documents.

This patch is a workaround specific for this case (and because it's not possible to wait for nextcloud/server#8105) : the Nextcloud Office app check if the OnlyOffice app is not installed before adding all the MSOffice mime types.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
