### PR TITLE
Do not show two header bars on public link

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -136,6 +136,7 @@ const documentsMain = {
 	isEditorMode: false,
 	isViewerMode: false,
 	isFrameReady: false,
+	isPublic: false,
 	ready: false,
 	fileName: null,
 	baseName: null,
@@ -176,7 +177,7 @@ const documentsMain = {
 				$('#revViewerContainer').prepend($('<div id="revViewer">'))
 			}
 
-			const urlsrc = getWopiUrl({ fileId, title, readOnly: true })
+			const urlsrc = getWopiUrl({ fileId, title, readOnly: true, closeButton: !documentsMain.isPublic || documentsMain.originalFileId })
 
 			// access_token & access_token_ttl - must be passed via a form post
 			const accessToken = encodeURIComponent(documentsMain.token)
@@ -233,7 +234,7 @@ const documentsMain = {
 			$(document.body).addClass('claro')
 			$(document.body).prepend(documentsMain.UI.container)
 
-			const urlsrc = getWopiUrl({ fileId, title, readOnly: false, closeButton: true, revisionHistory: !!Config.get('userId') })
+			const urlsrc = getWopiUrl({ fileId, title, readOnly: false, closeButton: !documentsMain.isPublic || documentsMain.originalFileId, revisionHistory: !documentsMain.isPublic })
 
 			// access_token - must be passed via a form post
 			const accessToken = encodeURIComponent(documentsMain.token)
@@ -522,6 +523,7 @@ const documentsMain = {
 		documentsMain.fileName = Config.get('title')
 		documentsMain.canEdit = Boolean(Config.get('permissions') & OC.PERMISSION_UPDATE)
 		documentsMain.canShare = typeof OC.Share !== 'undefined' && Config.get('permissions') & OC.PERMISSION_SHARE
+		documentsMain.isPublic = !Config.get('userId')
 
 		$('footer,nav').hide()
 		// fade out file list and show the document

--- a/src/files.js
+++ b/src/files.js
@@ -166,14 +166,11 @@ const odfViewer = {
 		const viewport = document.querySelector('meta[name=viewport]')
 		viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no')
 		if (isPublic) {
-			// force the preview to adjust its height
-			$('#preview').append($iframe).css({ height: '100%' })
-			$('body').css({ height: '100%' })
+			$('body').append($iframe)
+			$iframe.addClass('full')
 			$('#content').addClass('full-height')
 			$('footer').addClass('hidden')
 			$('#imgframe').addClass('hidden')
-			$('.directLink').addClass('hidden')
-			$('.directDownload').addClass('hidden')
 			$('#controls').addClass('hidden')
 			$('#content').addClass('loading')
 		} else {


### PR DESCRIPTION
* Resolves: #1884
* Target version: master 

### Summary


### TODO

- [x] Remove duplicate header bar
- [x] Remove Close button
- [x] Expose Download functionality
- [x] Expose Add to your nextcloud functionality
- [x] close button would still be required if a file is opened in a shared folder

### Checklist

- [x] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
