### PR TITLE
Fix incorrect HTML encoding of filename

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -27,7 +27,7 @@
 				id="cool-loading-overlay"
 				:class="{ debug: debug }">
 				<EmptyContent v-if="!error" icon="icon-loading">
-					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }, undefined, { escape: false }) }}
+					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }, 1, {escape: false}) }}
 					<template #desc>
 						<button @click="close">
 							{{ t('richdocuments', 'Cancel') }}

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -1,6 +1,6 @@
 <script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>">
 	var richdocuments_permissions = '<?php p($_['permissions']) ?>';
-	var richdocuments_title = '<?php p($_['title']) ?>';
+	var richdocuments_title = '<?php print_unescaped(addslashes($_['title'])) ?>';
 	var richdocuments_fileId = '<?php p($_['fileId']) ?>';
 	var richdocuments_token = '<?php p($_['token'] ? $_['token'] : "") ?>';
 	var richdocuments_token_ttl = <?php p($_['token_ttl'] ?: 0) ?>;


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/2230
* Target version: master 

### Summary
Fixes some issues where the filename appears with encoded HTML entities.
 * When opening the document
 * In the "Save as..." dialog

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
