### PR TITLE
Limit capabilities to users that are enabled

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -75,7 +75,7 @@ class Application extends App implements IBootstrap {
 		if ($currentUser !== null) {
 			/** @var PermissionManager $permissionManager */
 			$permissionManager = \OC::$server->query(PermissionManager::class);
-			if (!$permissionManager->isEnabledForUser($currentUser)) {
+			if (!$permissionManager->isEnabledForUser($currentUser->getUID())) {
 				return;
 			}
 		}

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -80,16 +80,23 @@ class Capabilities implements ICapability {
 	private $config;
 	/** @var CapabilitiesService */
 	private $capabilitiesService;
+	/** @var PermissionManager */
+	private $permissionManager;
 
 	private $capabilities = null;
 
-	public function __construct(IL10N $l10n, AppConfig $config, CapabilitiesService $capabilitiesService) {
+	public function __construct(IL10N $l10n, AppConfig $config, CapabilitiesService $capabilitiesService, PermissionManager $permissionManager) {
 		$this->l10n = $l10n;
 		$this->config = $config;
 		$this->capabilitiesService = $capabilitiesService;
+		$this->permissionManager = $permissionManager;
 	}
 
 	public function getCapabilities() {
+		if (!$this->permissionManager->isEnabledForUser()) {
+			return [];
+		}
+
 		if (!$this->capabilities) {
 			$collaboraCapabilities = $this->capabilitiesService->getCapabilities();
 			$filteredMimetypes = self::MIMETYPES;
@@ -100,6 +107,7 @@ class Capabilities implements ICapability {
 					'application/vnd.oasis.opendocument.graphics-flat-xml',
 				]);
 			}
+
 			$this->capabilities = [
 				'richdocuments' => [
 					'version' => \OC::$server->getAppManager()->getAppVersion('richdocuments'),

--- a/lib/Listener/LoadViewerListener.php
+++ b/lib/Listener/LoadViewerListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+
+namespace OCA\Richdocuments\Listener;
+
+use OCA\Richdocuments\PermissionManager;
+use OCA\Richdocuments\Service\InitialStateService;
+use OCA\Viewer\Event\LoadViewer;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
+
+class LoadViewerListener implements IEventListener {
+	/** @var PermissionManager */
+	private $permissionManager;
+	/** @var InitialStateService */
+	private $initialStateService;
+
+	public function __construct(PermissionManager $permissionManager, InitialStateService $initialStateService) {
+		$this->permissionManager = $permissionManager;
+		$this->initialStateService = $initialStateService;
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof LoadViewer) {
+			return;
+		}
+		if ($this->permissionManager->isEnabledForUser()) {
+			$this->initialStateService->provideCapabilities();
+			Util::addScript('richdocuments', 'richdocuments-viewer', 'viewer');
+		}
+	}
+}

--- a/lib/Listener/ShareLinkListener.php
+++ b/lib/Listener/ShareLinkListener.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+
+namespace OCA\Richdocuments\Listener;
+
+use OCA\Files_Sharing\Event\ShareLinkAccessedEvent;
+use OCA\Richdocuments\PermissionManager;
+use OCA\Richdocuments\Service\InitialStateService;
+use OCP\EventDispatcher\Event;
+use OCP\Share\IShare;
+use OCP\Util;
+
+class ShareLinkListener implements \OCP\EventDispatcher\IEventListener {
+	/** @var PermissionManager */
+	private $permissionManager;
+	/** @var InitialStateService */
+	private $initialStateService;
+
+	public function __construct(PermissionManager $permissionManager, InitialStateService $initialStateService) {
+		$this->permissionManager = $permissionManager;
+		$this->initialStateService = $initialStateService;
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof ShareLinkAccessedEvent) {
+			return;
+		}
+
+		/** @var IShare $share */
+		$share = $event->getShare();
+		$owner = $share->getShareOwner();
+
+		if ($this->permissionManager->isEnabledForUser($owner)) {
+			$this->initialStateService->provideCapabilities();
+			Util::addScript('richdocuments', 'richdocuments-files');
+		}
+	}
+}

--- a/lib/PermissionManager.php
+++ b/lib/PermissionManager.php
@@ -24,7 +24,7 @@ namespace OCA\Richdocuments;
 use OCA\Richdocuments\AppInfo\Application;
 use OCP\IConfig;
 use OCP\IGroupManager;
-use OCP\IUser;
+use OCP\IUserSession;
 
 class PermissionManager {
 
@@ -32,11 +32,17 @@ class PermissionManager {
 	private $config;
 	/** @var IGroupManager */
 	private $groupManager;
+	/** @var IUserSession */
+	private $userSession;
 
-	public function __construct(IConfig $config,
-		IGroupManager $groupManager) {
+	public function __construct(
+		IConfig $config,
+		IGroupManager $groupManager,
+		IUserSession $userSession
+	) {
 		$this->config = $config;
 		$this->groupManager = $groupManager;
+		$this->userSession = $userSession;
 	}
 
 	/**
@@ -47,16 +53,24 @@ class PermissionManager {
 		return explode('|', $groupString);
 	}
 
-	public function isEnabledForUser(IUser $user) {
+	public function isEnabledForUser(string $userId = null) {
+		if ($userId === null) {
+			$user = $this->userSession->getUser();
+			$userId = $user ? $user->getUID() : null;
+		}
+
+		if ($userId === null) {
+			return true;
+		}
+
 		$enabledForGroups = $this->config->getAppValue(Application::APPNAME, 'use_groups', '');
 		if ($enabledForGroups === '') {
 			return true;
 		}
 
 		$groups = $this->splitGroups($enabledForGroups);
-		$uid = $user->getUID();
 		foreach ($groups as $group) {
-			if ($this->groupManager->isInGroup($uid, $group)) {
+			if ($this->groupManager->isInGroup($userId, $group)) {
 				return true;
 			}
 		}

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -9,6 +9,34 @@ namespace OCA\Federation {
     }
 }
 
+namespace OCA\Viewer\Event {
+	class LoadViewer extends \OCP\EventDispatcher\Event {}
+}
+
 namespace Doctrine\DBAL\Platforms {
 	class SqlitePlatform {}
+}
+
+
+namespace OCA\Files_Sharing\Event {
+	use \OCP\Share\IShare;
+	class ShareLinkAccessedEvent extends \OCP\EventDispatcher\Event {
+		public function __construct(IShare $share, string $step = '', int $errorCode = 200, string $errorMessage = '') {}
+
+		public function getShare(): IShare {
+		}
+
+		public function getStep(): string {
+		}
+
+		public function getErrorCode(): int {
+		}
+
+		public function getErrorMessage(): string {
+		}
+	}
+}
+
+class OC_Helper {
+	public static function getFileTemplateManager() {}
 }


### PR DESCRIPTION
Resolves https://github.com/nextcloud/richdocuments/issues/1859

This PR addresses some issues that happen if usage of Collabora is limited to certain groups:
- First commit makes sure that direct editing capabilities are not exposed to clients where the user doesn't belong to an allowed group
- Second commit makes sure that the scripts for public pages are only loaded if the share owner is member of such a group
- Move to use the LoadViewer and ShareLinkAccessedEvent events (skip when back porting below 23)