### PR TITLE
Fix translation string for "Loading {filename} ..."

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -27,7 +27,7 @@
 				id="cool-loading-overlay"
 				:class="{ debug: debug }">
 				<EmptyContent v-if="!error" icon="icon-loading">
-					{{ t('richdocuments', 'Loading {filename}…', { filename: basename }) }}
+					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }) }}
 					<template #desc>
 						<button @click="close">
 							{{ t('richdocuments', 'Cancel') }}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/2231
* Target version: master 

### Summary
Fixes discrepancy between front-end string and translatable string from transifex.
