### PR TITLE
[stable23] Fix incorrect HTML encoding of filename

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -27,7 +27,7 @@
 				id="cool-loading-overlay"
 				:class="{ debug: debug }">
 				<EmptyContent v-if="!error" icon="icon-loading">
-					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }) }}
+					{{ t('richdocuments', 'Loading {filename} …', { filename: basename }, 1, {escape: false}) }}
 					<template #desc>
 						<button @click="close">
 							{{ t('richdocuments', 'Cancel') }}

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -1,6 +1,6 @@
 <script nonce="<?php p(\OC::$server->getContentSecurityPolicyNonceManager()->getNonce()) ?>">
 	var richdocuments_permissions = '<?php p($_['permissions']) ?>';
-	var richdocuments_title = '<?php p($_['title']) ?>';
+	var richdocuments_title = '<?php print_unescaped(addslashes($_['title'])) ?>';
 	var richdocuments_fileId = '<?php p($_['fileId']) ?>';
 	var richdocuments_token = '<?php p($_['token'] ? $_['token'] : "") ?>';
 	var richdocuments_urlsrc = '<?php p($_['urlsrc'] ? $_['urlsrc'] : "") ?>';


### PR DESCRIPTION
Manual backport for: https://github.com/nextcloud/richdocuments/pull/2318