### PR TITLE
Log error when fetching the capabilities fails

### DIFF
--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -30,6 +30,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
+use Psr\Log\LoggerInterface;
 
 class CapabilitiesService {
 
@@ -43,17 +44,20 @@ class CapabilitiesService {
 	private $appManager;
 	/** @var IL10N */
 	private $l10n;
+	/** @var LoggerInterface */
+	private $logger;
 
 	/** @var array */
 	private $capabilities;
 
 
-	public function __construct(IConfig $config, IClientService $clientService, ICacheFactory $cacheFactory, IAppManager $appManager, IL10N $l10n) {
+	public function __construct(IConfig $config, IClientService $clientService, ICacheFactory $cacheFactory, IAppManager $appManager, IL10N $l10n, LoggerInterface $logger) {
 		$this->config = $config;
 		$this->clientService = $clientService;
 		$this->cache = $cacheFactory->createDistributed('richdocuments');
 		$this->appManager = $appManager;
 		$this->l10n = $l10n;
+		$this->logger = $logger;
 	}
 
 	public function getCapabilities() {
@@ -132,6 +136,7 @@ class CapabilitiesService {
 				$capabilities = [];
 			}
 		} catch (\Exception $e) {
+			$this->logger->error('Failed to fetch the Collabora capabilities endpoint: ' . $e->getMessage(), [ 'exception' => $e ]);
 			$capabilities = [];
 		}
 

--- a/lib/WOPI/DiscoveryManager.php
+++ b/lib/WOPI/DiscoveryManager.php
@@ -81,11 +81,7 @@ class DiscoveryManager {
 			$options['timeout'] = 180;
 		}
 
-		try {
-			return $client->get($wopiDiscovery, $options);
-		} catch (\Exception $e) {
-			throw $e;
-		}
+		return $client->get($wopiDiscovery, $options);
 	}
 
 	public function refetch() {


### PR DESCRIPTION
It can be quite annoying to debug a failing setup if the request to capabilities fails (e.g. because the certificate is not in the Nextcloud certificate store) and there is no trace about it in the logs. 🙈 