### PR TITLE
Defer viewer registration

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -28,37 +28,39 @@ import { getCapabilities } from '@nextcloud/capabilities'
 
 const supportedMimes = getCapabilities().richdocuments.mimetypes
 
-if (OCA.Viewer) {
-	OCA.Viewer.registerHandler({
-		id: 'richdocuments',
-		group: null,
-		mimes: supportedMimes,
-		component: Office,
-		theme: 'light',
-	})
-}
-
-// TODO: Viewer.openWith introduced with https://github.com/nextcloud/viewer/pull/1273
-//       This check can be replaced with `if(OCA.Viewer)` once NC 24 is EOL.
-if (OCA.Viewer.openWith) {
-	const supportedMimes = OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen
-	const actionName = 'Edit with ' + OC.getCapabilities().richdocuments.productName
-	const actionDisplayName = t('richdocuments', 'Edit with {productName}', { productName: OC.getCapabilities().richdocuments.productName }, undefined, { escape: false })
-
-	for (const mime of supportedMimes) {
-		const action = {
-			name: actionName,
-			mime,
-			permissions: OC.PERMISSION_READ,
-			iconClass: 'icon-richdocuments',
-			displayName: actionDisplayName,
-			actionHandler: (fileName, context) => {
-				OCA.Viewer.openWith('richdocuments', {
-					path: context.fileInfoModel.getFullPath()
-				})
-			}
-		}
-
-		OCA.Files.fileActions.registerAction(action)
+window.addEventListener('DOMContentLoaded', function() {
+	if (OCA.Viewer) {
+		OCA.Viewer.registerHandler({
+			id: 'richdocuments',
+			group: null,
+			mimes: supportedMimes,
+			component: Office,
+			theme: 'light',
+		})
 	}
-}
+
+	// TODO: Viewer.openWith introduced with https://github.com/nextcloud/viewer/pull/1273
+	//       This check can be replaced with `if(OCA.Viewer)` once NC 24 is EOL.
+	if (OCA.Viewer.openWith) {
+		const supportedMimes = OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen
+		const actionName = 'Edit with ' + OC.getCapabilities().richdocuments.productName
+		const actionDisplayName = t('richdocuments', 'Edit with {productName}', { productName: OC.getCapabilities().richdocuments.productName }, undefined, { escape: false })
+
+		for (const mime of supportedMimes) {
+			const action = {
+				name: actionName,
+				mime,
+				permissions: OC.PERMISSION_READ,
+				iconClass: 'icon-richdocuments',
+				displayName: actionDisplayName,
+				actionHandler: (fileName, context) => {
+					OCA.Viewer.openWith('richdocuments', {
+						path: context.fileInfoModel.getFullPath(),
+					})
+				},
+			}
+
+			OCA.Files.fileActions.registerAction(action)
+		}
+	}
+})


### PR DESCRIPTION
Turned out @Raudius was right and the [change of registering the LoadVIewer event listener](https://github.com/nextcloud/richdocuments/pull/2354/files#diff-4eb824426a8cffb8b33b62b57744c69f32ea30ea755249a7a6170d9402885debR71) changed the loading order of scripts. Therefore we need to defer the registration in javascript for stable23 in order to properly open files.

