### PR TITLE
[stable24] No need to json/base64 decode the title 

### DIFF
--- a/src/services/config.tsx
+++ b/src/services/config.tsx
@@ -35,7 +35,7 @@ class ConfigService {
     loadFromGlobal(key: string) {
         // @ts-ignore
         this.values[key] = window['richdocuments_' + key]
-		if (['path', 'title'].indexOf(key) !== -1) {
+		if (['path'].indexOf(key) !== -1) {
 			this.values[key] = JSON.parse(atob(this.values[key]));
 		}
     }


### PR DESCRIPTION
As the backend only uses addslashes there is no need for further decoding.