### PR TITLE
Limit avatar request size to 64 pixel

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -104,7 +104,7 @@ class WopiController extends Controller {
 	// Signifies LOOL that document has been changed externally in this storage
 	public const LOOL_STATUS_DOC_CHANGED = 1010;
 
-	public const WOPI_AVATAR_SIZE = 32;
+	public const WOPI_AVATAR_SIZE = 64;
 
 	public function __construct(
 		$appName,


### PR DESCRIPTION
Related server PR https://github.com/nextcloud/server/pull/31010

This makes sure that browsers can use an already cached avatar variant and do not need to load a different file for Collabora.