### PR TITLE
fix safari does not focus to document frame on startup

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -197,6 +197,7 @@ const documentsMain = {
 
 			$('#revViewer').append(form)
 			$('#revViewer').append(frame)
+			$('#loleafletframe_viewer').focus()
 
 			// submit that
 			$('#loleafletform_viewer').submit()
@@ -254,6 +255,7 @@ const documentsMain = {
 
 			$('#mainContainer').append(form)
 			$('#mainContainer').append(frame)
+			$('#loleafletframe').focus()
 
 			emit('richdocuments:wopi-load:started', {
 				wopiFileId: fileId,


### PR DESCRIPTION
To reproduce the issue on safari or a webkit browser:
Open a document and just start typing
and the typing does appear even though cursor is blinking
on the document.

Signed-off-by: Mert Tumer <mert.tumer@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
