### PR TITLE
Fix: hide download option inside Collabora for "hide download" shares

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -38,6 +38,7 @@ use OCP\IUserManager;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\IL10N;
+use OCP\Share\IShare;
 use OCP\Util;
 
 class TokenManager {
@@ -155,13 +156,13 @@ class TokenManager {
 					$storage = $file->getStorage();
 					// using string as we have no guarantee that "files_sharing" app is loaded
 					if ($storage->instanceOfStorage(SharedStorage::class)) {
-						if (!method_exists(SharedStorage::class, 'getAttributes')) {
+						if (!method_exists(IShare::class, 'getAttributes')) {
 							break;
 						}
 						/** @var SharedStorage $storage */
 						$share = $storage->getShare();
-						$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
-						if ($canDownload !== null && !$canDownload) {
+						$attributes = $share->getAttributes();
+						if ($attributes !== null && !$attributes->getAttribute('permissions', 'download')) {
 							$hideDownload = true;
 							break;
 						}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/2386
* Target version: master 

### Summary
Corrects logic for "hideDownload" property.