### PR TITLE
Implement endpoint to open files in the browser

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,6 +34,8 @@ return [
 		['name' => 'document#createFromTemplate', 'url' => 'indexTemplate', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
 
+		['name' => 'document#editOnline', 'url' => 'editonline', 'verb' => 'GET'],
+
 		// external api access
 		['name' => 'document#extAppGetData', 'url' => '/ajax/extapp/data/{fileId}', 'verb' => 'POST'],
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -26,6 +26,7 @@ namespace OCA\Richdocuments;
 use OCA\Richdocuments\Service\CapabilitiesService;
 use OCP\Capabilities\ICapability;
 use OCP\IL10N;
+use OCP\IURLGenerator;
 
 class Capabilities implements ICapability {
 	public const MIMETYPES = [
@@ -74,22 +75,20 @@ class Capabilities implements ICapability {
 		'text/spreadsheet'
 	];
 
-	/** @var IL10N */
-	private $l10n;
-	/** @var AppConfig */
-	private $config;
-	/** @var CapabilitiesService */
-	private $capabilitiesService;
-	/** @var PermissionManager */
-	private $permissionManager;
+	private IL10N $l10n;
+	private AppConfig $config;
+	private CapabilitiesService $capabilitiesService;
+	private PermissionManager $permissionManager;
+	private IURLGenerator $urlGenerator;
 
 	private $capabilities = null;
 
-	public function __construct(IL10N $l10n, AppConfig $config, CapabilitiesService $capabilitiesService, PermissionManager $permissionManager) {
+	public function __construct(IL10N $l10n, AppConfig $config, CapabilitiesService $capabilitiesService, PermissionManager $permissionManager, IURLGenerator $urlGenerator) {
 		$this->l10n = $l10n;
 		$this->config = $config;
 		$this->capabilitiesService = $capabilitiesService;
 		$this->permissionManager = $permissionManager;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	public function getCapabilities() {
@@ -117,6 +116,7 @@ class Capabilities implements ICapability {
 					'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) ?: false,
 					'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ?: false,
 					'productName' => isset($collaboraCapabilities['productName']) ? $collaboraCapabilities['productName'] : $this->l10n->t('Nextcloud Office'),
+					'editonline_endpoint' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.document.editOnline'),
 					'config' => [
 						'wopi_url' => $this->config->getAppValue('wopi_url'),
 						'public_wopi_url' => $this->config->getAppValue('public_wopi_url'),

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -11,11 +11,13 @@
 
 namespace OCA\Richdocuments\Controller;
 
+use OC\User\NoUserException;
 use OCA\Richdocuments\Service\FederationService;
 use OCA\Richdocuments\Service\InitialStateService;
 use OCA\Richdocuments\TemplateManager;
 use OCA\Richdocuments\TokenManager;
 use \OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\Constants;
 use OCP\Files\File;
@@ -30,13 +32,14 @@ use \OCP\ILogger;
 use \OCP\AppFramework\Http\TemplateResponse;
 use \OCA\Richdocuments\AppConfig;
 use OCP\ISession;
+use OCP\IURLGenerator;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 
 class DocumentController extends Controller {
 	use DocumentTrait;
 
-	/** @var string */
+	/** @var ?string */
 	private $uid;
 	/** @var IConfig */
 	private $config;
@@ -58,6 +61,7 @@ class DocumentController extends Controller {
 	private $federationService;
 	/** @var InitialStateService */
 	private $initialState;
+	private IURLGenerator $urlGenerator;
 
 	public function __construct(
 		$appName,
@@ -72,7 +76,8 @@ class DocumentController extends Controller {
 		ILogger $logger,
 		TemplateManager $templateManager,
 		FederationService $federationService,
-		InitialStateService $initialState
+		InitialStateService $initialState,
+		IURLGenerator $urlGenerator
 	) {
 		parent::__construct($appName, $request);
 		$this->uid = $UserId;
@@ -86,6 +91,7 @@ class DocumentController extends Controller {
 		$this->templateManager = $templateManager;
 		$this->federationService = $federationService;
 		$this->initialState = $initialState;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -402,10 +408,50 @@ class DocumentController extends Controller {
 		return new TemplateResponse('core', '403', [], 'guest');
 	}
 
-	private function renderErrorPage($message) {
+	private function renderErrorPage(string $message, $status = Http::STATUS_INTERNAL_SERVER_ERROR) {
 		$params = [
 			'errors' => [['error' => $message]]
 		];
-		return new TemplateResponse('core', 'error', $params, 'guest');
+		$response = new TemplateResponse('core', 'error', $params, 'guest');
+		$response->setStatus($status);
+		return $response;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 * @NoAdminRequired
+	 */
+	public function editOnline(string $path = null, string $userId = null) {
+		if ($path === null) {
+			return $this->renderErrorPage('No path provided');
+		}
+
+		if ($userId === null) {
+			$userId = $this->uid;
+		}
+
+		if ($userId !== null && $userId !== $this->uid) {
+			return $this->renderErrorPage('You are trying to open a file from another user account than the one you are currently logged in with.');
+		}
+
+		if ($userId === null) {
+			$params = [];
+			$params['redirect_url'] = $this->request->getRequestUri();
+			$params['user'] = $userId;
+			$url = $this->urlGenerator->linkToRoute('core.login.showLoginForm', $params);
+			return new RedirectResponse($url);
+		}
+
+		try {
+			$userFolder = $this->rootFolder->getUserFolder($userId);
+			$file = $userFolder->get($path);
+			$redirectUrl = $this->urlGenerator->getAbsoluteURL('/index.php/f/' . $file->getId());
+			return new RedirectResponse($redirectUrl);
+		} catch (NotFoundException $e) {
+		} catch (NotPermittedException $e) {
+		} catch (NoUserException $e) {
+		}
+
+		return $this->renderErrorPage('File not found', Http::STATUS_NOT_FOUND);
 	}
 }


### PR DESCRIPTION
Implements #2418 

Adds the following entry to the richdocuments capabilities:
```
<editonline_endpoint>http://nextcloud.dev.local/index.php/apps/richdocuments/editonline</editonline_endpoint>
```

A file can be opened through:
http://nextcloud.dev.local/index.php/apps/richdocuments/editonline?path=/Test.odt&userId=admin

- If the user is not logged in they will be redirected to the login page
- If the user is logged in they will see an error
- If the passed user id is different from the currently logged in user, they will see a hint about that