### PR TITLE
[stable24] Viewer top margin is not needed

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -340,7 +340,6 @@ export default {
 
 		.viewer & {
 			height: 100vh;
-			top: -50px;
 		}
 	}
 


### PR DESCRIPTION
On NC 24, adding a `-50px` margin hides the collabora menu and the viewer buttons.
