### PR TITLE
Local editing

### DIFF
--- a/img/launch.svg
+++ b/img/launch.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
+</svg>

--- a/lib/Listener/CSPListener.php
+++ b/lib/Listener/CSPListener.php
@@ -68,6 +68,7 @@ class CSPListener implements IEventListener {
 
 		$policy = new EmptyContentSecurityPolicy();
 		$policy->addAllowedFrameDomain("'self'");
+		$policy->addAllowedFrameDomain("nc:");
 
 		foreach ($urls as $url) {
 			$policy->addAllowedFrameDomain($url);

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -86,6 +86,10 @@ const getDocumentUrlForFile = (fileDir, fileId) => {
 		})
 }
 
+const getNextcloudUrl = () => {
+	return window.location.host + (window.location.port ? `:${window.location.port}` : '')
+}
+
 export {
 	getSearchParam,
 	getWopiUrl,
@@ -93,4 +97,5 @@ export {
 	getDocumentUrlFromTemplate,
 	getDocumentUrlForPublicFile,
 	getDocumentUrlForFile,
+	getNextcloudUrl,
 }

--- a/tests/lib/Listener/CSPListenerTest.php
+++ b/tests/lib/Listener/CSPListenerTest.php
@@ -96,7 +96,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $this->getMergedPolicy();
 
-		self::assertEquals(["'self'", "http://public"], $policy->getAllowedFrameDomains());
+		self::assertEquals(["'self'", "nc:" , "http://public"], $policy->getAllowedFrameDomains());
 		self::assertEquals(["'self'", "http://public"], $policy->getAllowedFormActionDomains());
 	}
 
@@ -123,7 +123,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $this->getMergedPolicy();
 
-		self::assertEquals(["'self'"], $policy->getAllowedFrameDomains());
+		self::assertEquals(["'self'", "nc:"], $policy->getAllowedFrameDomains());
 		self::assertEquals(["'self'"], $policy->getAllowedFormActionDomains());
 	}
 
@@ -135,7 +135,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $this->getMergedPolicy();
 
-		self::assertEquals(["'self'", "http://public"], $policy->getAllowedFrameDomains());
+		self::assertEquals(["'self'", "nc:", "http://public"], $policy->getAllowedFrameDomains());
 		self::assertEquals(["'self'", "http://public"], $policy->getAllowedFormActionDomains());
 	}
 
@@ -147,7 +147,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $this->getMergedPolicy();
 
-		self::assertEquals(["'self'", "https://public"], $policy->getAllowedFrameDomains());
+		self::assertEquals(["'self'", "nc:", "https://public"], $policy->getAllowedFrameDomains());
 		self::assertEquals(["'self'", "https://public"], $policy->getAllowedFormActionDomains());
 	}
 
@@ -165,7 +165,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $this->getMergedPolicy();
 
-		self::assertEquals(["'self'", "https://public", "*.example.com"], $policy->getAllowedFrameDomains());
+		self::assertEquals(["'self'", "nc:", "https://public", "*.example.com"], $policy->getAllowedFrameDomains());
 		self::assertEquals(["'self'", "https://public", "*.example.com"], $policy->getAllowedFormActionDomains());
 	}
 
@@ -180,7 +180,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $this->getMergedPolicy();
 
-		self::assertEquals(["'self'", "http://internal"], $policy->getAllowedFrameDomains());
+		self::assertEquals(["'self'", "nc:", "http://internal"], $policy->getAllowedFrameDomains());
 		self::assertEquals(["'self'", "http://internal"], $policy->getAllowedFormActionDomains());
 	}
 
@@ -205,7 +205,7 @@ class CSPListenerTest extends TestCase {
 
 		$policy = $manager->getDefaultPolicy();
 
-		self::assertArrayUnordered(["'self'", "external.example.com", "http://public"], $policy->getAllowedFrameDomains(), "Domains are equal", 0.0, 10, true);
+		self::assertArrayUnordered(["'self'", "external.example.com", "http://public", "nc:"], $policy->getAllowedFrameDomains(), "Domains are equal", 0.0, 10, true);
 		self::assertArrayUnordered(["'self'", "external.example.com", "http://public"], $policy->getAllowedFormActionDomains());
 	}
 


### PR DESCRIPTION
* Target version: master 

### Summary
Adds a button to the Collabora editor which enables the file to be opened locally.

Clicking the button will:
  * Trigger a warning that the file will close for all users currently viewing the file with Collabora
  * Save the file
  * Close all currently open collabora sessions of the file
  * Unlock the file (if locked)
  * Open an `nc://` url to be handled by the desktop client

### TODO

- [ ] Remove the button when viewing read-only files (csv, pdf)?