### PR TITLE
Always show the close button

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -177,7 +177,7 @@ const documentsMain = {
 				$('#revViewerContainer').prepend($('<div id="revViewer">'))
 			}
 
-			const urlsrc = getWopiUrl({ fileId, title, readOnly: true, closeButton: !documentsMain.isPublic || documentsMain.originalFileId })
+			const urlsrc = getWopiUrl({ fileId, title, readOnly: true, closeButton: true })
 
 			// access_token & access_token_ttl - must be passed via a form post
 			const accessToken = encodeURIComponent(documentsMain.token)
@@ -235,7 +235,7 @@ const documentsMain = {
 			$(document.body).addClass('claro')
 			$(document.body).prepend(documentsMain.UI.container)
 
-			const urlsrc = getWopiUrl({ fileId, title, readOnly: false, closeButton: !documentsMain.isPublic || documentsMain.originalFileId, revisionHistory: !documentsMain.isPublic })
+			const urlsrc = getWopiUrl({ fileId, title, readOnly: false, closeButton: true, revisionHistory: !documentsMain.isPublic })
 
 			// access_token - must be passed via a form post
 			const accessToken = encodeURIComponent(documentsMain.token)


### PR DESCRIPTION
Avoid being locked in with direct editing on iOS.