### PR TITLE
Fix `public_wopi_url` variable configuration name

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -16,7 +16,7 @@ use \OCP\IConfig;
 
 class AppConfig {
 	public const WOPI_URL = 'wopi_url';
-	public const WOPI_URL_PUBLIC = 'wopi_url_public';
+	public const PUBLIC_WOPI_URL = 'public_wopi_url';
 
 	public const FEDERATION_USE_TRUSTED_DOMAINS = 'federation_use_trusted_domains';
 
@@ -128,7 +128,7 @@ class AppConfig {
 	}
 
 	public function getCollaboraUrlPublic(): string {
-		return $this->config->getAppValue(Application::APPNAME, self::WOPI_URL_PUBLIC, $this->getCollaboraUrlInternal());
+		return $this->config->getAppValue(Application::APPNAME, self::PUBLIC_WOPI_URL, $this->getCollaboraUrlInternal());
 	}
 
 	public function getCollaboraUrlInternal(): string {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Hi,

We faced an issue in our private Nextcloud instance, the collabora editor was blocked due to a CSP error. The allowed URL was the internal one instead of the public. And so we realized that the variable name was incorrect,  the variable is named `public_wopi_url` in the Nextcloud app configuration. We already tried this fix and if works on our instance.

Thanks a lot for this amazing open source project :)

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
