### PR TITLE
Add config option to turn on Collabora feature lock for read only users

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -22,6 +22,8 @@ class AppConfig {
 
 	public const SYSTEM_GS_TRUSTED_HOSTS = 'gs.trustedHosts';
 
+	public const READ_ONLY_FEATURE_LOCK = 'read_only_feature_lock';
+
 	private $defaults = [
 		'wopi_url' => '',
 		'timeout' => 15,
@@ -133,5 +135,31 @@ class AppConfig {
 
 	public function getCollaboraUrlInternal(): string {
 		return $this->config->getAppValue(Application::APPNAME, self::WOPI_URL, '');
+	}
+
+	public function getUseGroups(): ?array {
+		$groups = $this->config->getAppValue(Application::APPNAME, 'use_groups', '');
+		if ($groups === '') {
+			return null;
+		}
+
+		return $this->splitGroups($groups);
+	}
+
+	public function getEditGroups(): ?array {
+		$groups = $this->config->getAppValue(Application::APPNAME, 'edit_groups', '');
+		if ($groups === '') {
+			return null;
+		}
+
+		return $this->splitGroups($groups);
+	}
+
+	public function isReadOnlyFeatureLocked(): bool {
+		return $this->config->getAppValue(Application::APPNAME, self::READ_ONLY_FEATURE_LOCK, 'no') === 'yes';
+	}
+
+	private function splitGroups(string $groupString): array {
+		return explode('|', $groupString);
 	}
 }

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -30,6 +30,7 @@ use OCA\Richdocuments\Events\DocumentOpenedEvent;
 use OCA\Richdocuments\Exceptions\ExpiredTokenException;
 use OCA\Richdocuments\Exceptions\UnknownTokenException;
 use OCA\Richdocuments\Helper;
+use OCA\Richdocuments\PermissionManager;
 use OCA\Richdocuments\Service\FederationService;
 use OCA\Richdocuments\Service\UserScopeService;
 use OCA\Richdocuments\TemplateManager;
@@ -80,6 +81,8 @@ class WopiController extends Controller {
 	private $appConfig;
 	/** @var TokenManager */
 	private $tokenManager;
+	/** @var PermissionManager */
+	private $permissionManager;
 	/** @var IUserManager */
 	private $userManager;
 	/** @var WopiMapper */
@@ -114,6 +117,7 @@ class WopiController extends Controller {
 		IConfig $config,
 		AppConfig $appConfig,
 		TokenManager $tokenManager,
+		PermissionManager $permissionManager,
 		IUserManager $userManager,
 		WopiMapper $wopiMapper,
 		ILogger $logger,
@@ -132,6 +136,7 @@ class WopiController extends Controller {
 		$this->config = $config;
 		$this->appConfig = $appConfig;
 		$this->tokenManager = $tokenManager;
+		$this->permissionManager = $permissionManager;
 		$this->userManager = $userManager;
 		$this->wopiMapper = $wopiMapper;
 		$this->logger = $logger;
@@ -215,6 +220,7 @@ class WopiController extends Controller {
 			'HidePrintOption' => $wopi->getHideDownload(),
 			'DownloadAsPostMessage' => $wopi->getDirect(),
 			'SupportsLocks' => $this->lockManager->isLockProviderAvailable(),
+			'IsUserLocked' => $this->permissionManager->userIsFeatureLocked($wopi->getEditorUid()),
 		];
 
 		if ($wopi->hasTemplateId()) {

--- a/lib/PermissionManager.php
+++ b/lib/PermissionManager.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2017 Lukas Reschke <lukas@statuscode.ch>
  *
@@ -21,38 +23,29 @@
 
 namespace OCA\Richdocuments;
 
-use OCA\Richdocuments\AppInfo\Application;
-use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IUserManager;
 use OCP\IUserSession;
 
 class PermissionManager {
-	/** @var IConfig */
-	private $config;
-	/** @var IGroupManager */
-	private $groupManager;
-	/** @var IUserSession */
-	private $userSession;
+	private AppConfig $config;
+	private IGroupManager $groupManager;
+	private IUserManager $userManager;
+	private IUserSession $userSession;
 
 	public function __construct(
-		IConfig $config,
+		AppConfig $config,
 		IGroupManager $groupManager,
+		IUserManager $userManager,
 		IUserSession $userSession
 	) {
 		$this->config = $config;
 		$this->groupManager = $groupManager;
+		$this->userManager = $userManager;
 		$this->userSession = $userSession;
 	}
 
-	/**
-	 * @param string $groupString
-	 * @return array
-	 */
-	private function splitGroups($groupString) {
-		return explode('|', $groupString);
-	}
-
-	public function isEnabledForUser(string $userId = null) {
+	private function userMatchesGroupList(?string $userId = null, ?array $groupList = []): bool {
 		if ($userId === null) {
 			$user = $this->userSession->getUser();
 			$userId = $user ? $user->getUID() : null;
@@ -62,19 +55,43 @@ class PermissionManager {
 			return true;
 		}
 
-		$enabledForGroups = $this->config->getAppValue(Application::APPNAME, 'use_groups', '');
-		if ($enabledForGroups === '') {
+		if ($groupList === null || $groupList === []) {
 			return true;
 		}
 
-		$groups = $this->splitGroups($enabledForGroups);
-		foreach ($groups as $group) {
-			if ($this->groupManager->isInGroup($userId, $group)) {
+		if ($this->groupManager->isAdmin($userId)) {
+			return true;
+		}
+
+		$userGroups = $this->groupManager->getUserGroupIds($this->userManager->get($userId));
+
+		foreach ($groupList as $group) {
+			if (in_array($group, $userGroups)) {
 				return true;
 			}
 		}
 
-		if ($this->groupManager->isAdmin($userId)) {
+		return false;
+	}
+
+	public function isEnabledForUser(string $userId = null): bool {
+		if ($this->userMatchesGroupList($userId, $this->config->getUseGroups())) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public function userCanEdit(string $userId = null): bool {
+		if ($this->userMatchesGroupList($userId, $this->config->getEditGroups())) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public function userIsFeatureLocked(string $userId = null): bool {
+		if ($this->config->isReadOnlyFeatureLocked() && !$this->userCanEdit($userId)) {
 			return true;
 		}
 


### PR DESCRIPTION
Implementing the option to enable [feature locking](https://sdk.collaboraonline.com/docs/installation/Configuration.html?highlight=isuserlocked#feature-locking) for all users that are not within edit groups


Can be enabled with:

```
occ config:app:set richdocuments read_only_feature_lock --value=yes
```
