### PR TITLE
Disable sharing for public links and versions if app is disabled

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -206,7 +206,7 @@ class WopiController extends Controller {
 			'SupportsRename' => !$isVersion,
 			'UserCanRename' => !$isPublic && !$isVersion,
 			'EnableInsertRemoteImage' => !$isPublic,
-			'EnableShare' => $file->isShareable() && !$isVersion,
+			'EnableShare' => $file->isShareable() && !$isVersion && !$isPublic,
 			'HideUserList' => '',
 			'DisablePrint' => $wopi->getHideDownload(),
 			'DisableExport' => $wopi->getHideDownload(),

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -33,6 +33,9 @@ const getSearchParam = (name) => {
 }
 
 const getWopiUrl = ({ fileId, title, readOnly, closeButton, revisionHistory }) => {
+	// Only set the revision history parameter if the versions app is enabled
+	revisionHistory = revisionHistory && window?.oc_appswebroots?.files_versions
+
 	// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
 	// index.php is forced here to avoid different wopi srcs for the same document
 	const wopiurl = window.location.protocol + '//' + window.location.host + getRootUrl() + '/index.php/apps/richdocuments/wopi/files/' + fileId


### PR DESCRIPTION
- Do not pass the revision history parameter if files_versions is disabled
- Do not enable sharing for public links