### PR TITLE
Use proper product name in capabilities

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -124,7 +124,7 @@ class Capabilities implements ICapability {
 					'collabora' => $collaboraCapabilities,
 					'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) ?: false,
 					'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ?: false,
-					'productName' => isset($collaboraCapabilities['productName']) ? $collaboraCapabilities['productName'] : $this->l10n->t('Nextcloud Office'),
+					'productName' => $this->capabilitiesService->getProductName(),
 					'config' => [
 						'wopi_url' => $this->config->getAppValue('wopi_url'),
 						'public_wopi_url' => $this->config->getAppValue('public_wopi_url'),


### PR DESCRIPTION
Otherwise collabora online might still be used in some places like

https://github.com/nextcloud/richdocuments/pull/2298/files#diff-245646583d4a8774103504d6d7c723409a67b490d2adf2bf6c90fb7c6372214dR46
