### PR TITLE
Keep passing light theme values to Collabora as long as the dark mode is not available there

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -61,12 +61,13 @@ const generateCSSVarTokens = () => {
 		'--border-radius-pill': '--co-border-radius-pill',
 	}
 	let str = ''
+	const element = document.getElementById('documents-content') ?? document.documentElement
 	try {
 		for (const cssVarKey in cssVarMap) {
-			let cStyle = window.parent.getComputedStyle(document.documentElement).getPropertyValue(cssVarKey)
+			let cStyle = window.getComputedStyle(element).getPropertyValue(cssVarKey)
 			if (!cStyle) {
 				// try suffix -dark instead
-				cStyle = window.parent.getComputedStyle(document.documentElement).getPropertyValue(cssVarKey + '-dark')
+				cStyle = window.getComputedStyle(element).getPropertyValue(cssVarKey + '-dark')
 			}
 			if (!cStyle) continue // skip if it is not set
 			const varNames = cssVarMap[cssVarKey].split(':')

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -22,6 +22,6 @@ script('richdocuments', 'richdocuments-document');
 	<div id="proxyLoadingIcon"></div>
 	<div id="proxyLoadingMessage"></div>
 </div>
-<div id="documents-content"></div>
+<div id="documents-content" data-theme-light></div>
 
 


### PR DESCRIPTION
Otherwise the primary tinted colors are wrong and lead to dark icons on dark background

Fixes https://github.com/nextcloud/richdocuments/issues/2302

## Considerations for Nextcloud 24 and lower

For back porting we will need to add the removal of the user accessibility stylesheet, e.g. with this:

```
document.querySelector("link[href*='accessibility\/css\/user']").remove()
```

Quite ugly but I don't see a better way to get the light mode css variables.