### PR TITLE
Add app config to override wopi checkFileInfo

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -162,4 +162,16 @@ class AppConfig {
 	private function splitGroups(string $groupString): array {
 		return explode('|', $groupString);
 	}
+
+	/**
+	 * Allow to override values from the WOPI checkFileInfo response through app config
+	 */
+	public function getWopiOverride(): array {
+		$wopiOverride = $this->config->getAppValue(Application::APPNAME, 'wopi_override', '');
+		if ($wopiOverride !== '') {
+			$wopiOverride = json_decode($wopiOverride, true);
+			return $wopiOverride ?: [];
+		}
+		return [];
+	}
 }

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -267,6 +267,8 @@ class WopiController extends Controller {
 			$response = $this->setFederationFileInfo($wopi, $response);
 		}
 
+		$response = array_merge($response, $this->appConfig->getWopiOverride());
+
 		$this->eventDispatcher->dispatchTyped(new DocumentOpenedEvent(
 			$user ? $user->getUID() : null,
 			$file


### PR DESCRIPTION
Allows to fine tune options e.g. with:

```
occ config:app:set richdocuments wopi_override --value='{"EnableShare":false}'
```
