### PR TITLE
Fix redundant port number in url

### DIFF
--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -90,7 +90,7 @@ const getDocumentUrlForFile = (fileDir, fileId) => {
 }
 
 const getNextcloudUrl = () => {
-	return window.location.host + (window.location.port ? `:${window.location.port}` : '')
+	return window.location.host
 }
 
 export {


### PR DESCRIPTION
* Resolves: #2572
* Target version: master 

### Summary
Fix redundant port number in the url. `window.location.host` already includes the port, but the code appends another port after this. see https://developer.mozilla.org/en-US/docs/Web/API/Location/host .

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
