### PR TITLE
Fix the theming adjustments when accesibility app is disabled

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -62,9 +62,12 @@ const generateCSSVarTokens = () => {
 		'--color-border-dark': '--co-border-dark',
 		'--border-radius-pill': '--co-border-radius-pill',
 	}
+
+	const accessibilityCss = document.querySelector("link[href*='accessibility/css/user']")
+	accessibilityCss && accessibilityCss.remove()
+
 	let str = ''
 	const element = document.getElementById('documents-content') ?? document.documentElement
-	document.querySelector("link[href*='accessibility/css/user']").remove()
 	try {
 		for (const cssVarKey in cssVarMap) {
 			let cStyle = window.getComputedStyle(element).getPropertyValue(cssVarKey)


### PR DESCRIPTION
* Resolves: https://help.nextcloud.com/t/nextcloud-office-does-not-load/148321
* Target version: master 

### Summary
When the accessibility app the query-selector returns `null` which causes a failure.