### PR TITLE
Improve error handling for global template uploads

### DIFF
--- a/templates/admin.php
+++ b/templates/admin.php
@@ -8,7 +8,7 @@ script('files', 'jquery.fileupload');
 
 <?php if ($_['settings']['templatesAvailable'] === true) { ?>
 <form class="section" id="richdocuments-templates" method="post" action="/template/">
-	<input class="hidden-visually" id="add-template" type="file" />
+	<input name="files" class="hidden-visually" id="add-template" type="file" />
 	<h2>
 		<?php p($l->t('Global templates')) ?>
 		<label for="add-template" class="icon-add" title="<?php p($l->t('Add a new template')); ?>"></label>


### PR DESCRIPTION
Make the validation code of global template upload a bit easier and properly log php error codes. In addition we now try to get the mime type from the path if the browser doesn't send one.