### PR TITLE
Another attempt to work around Safari issues

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -4,6 +4,7 @@ import { getRequestToken } from '@nextcloud/auth'
 import Config from './services/config.tsx'
 import { setGuestName, shouldAskForGuestName } from './helpers/guestName.js'
 import { getUIDefaults, generateCSSVarTokens, getCollaboraTheme } from './helpers/coolParameters.js'
+import { enableScrollLock } from './helpers/safariFixer.js'
 
 import PostMessageService from './services/postMessage.tsx'
 import {
@@ -20,6 +21,10 @@ const PostMessages = new PostMessageService({
 	parent: window.parent,
 	loolframe: () => document.getElementById('loleafletframe').contentWindow,
 })
+
+if (isDirectEditing()) {
+	enableScrollLock()
+}
 
 let checkingProxyStatus = false
 
@@ -613,7 +618,7 @@ const documentsMain = {
 			{
 				type: OC.dialogs.YES_NO_BUTTONS,
 				confirm: t('richdocuments', 'Try again'),
-				cancel: t('richdocuments', 'Close')
+				cancel: t('richdocuments', 'Close'),
 			},
 			(decision) => {
 				if (decision) {

--- a/src/files.js
+++ b/src/files.js
@@ -10,28 +10,13 @@ import Config from './services/config.tsx'
 import Types from './helpers/types.js'
 import FilesAppIntegration from './view/FilesAppIntegration.js'
 import { splitPath } from './helpers/index.js'
+import { enableScrollLock, disableScrollLock } from './helpers/safariFixer.js'
 import NewFileMenu from './view/NewFileMenu.js'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
 const PostMessages = new PostMessageService({
 	FRAME_DOCUMENT: () => document.getElementById('richdocumentsframe').contentWindow,
 })
-
-const isBrandedVersion = OC.getCapabilities().richdocuments.collabora.productVersion.split('.')[0] >= 21
-
-// Workaround for Safari to resize the iframe to the proper height
-// as 100vh is not the proper viewport height there
-const handleResize = () => {
-	const frame = document.getElementById('richdocumentsframe')
-	if (frame) {
-		const headerOffset = (!isBrandedVersion && window.innerWidth > 768) ? 50 : 0
-		frame.style.maxHeight = (document.documentElement.clientHeight - headerOffset) + 'px'
-	}
-}
-window.addEventListener('resize', handleResize)
-if (window && window.visualViewport) {
-	visualViewport.addEventListener('resize', handleResize)
-}
 
 const isDownloadHidden = document.getElementById('hideDownload') && document.getElementById('hideDownload').value === 'true'
 
@@ -53,6 +38,8 @@ const odfViewer = {
 		let fileDir
 		let fileId
 		let templateId
+
+		enableScrollLock()
 
 		if (!odfViewer.isCollaboraConfigured) {
 			$.get(generateOcsUrl('cloud/capabilities?format=json')).then(
@@ -162,6 +149,7 @@ const odfViewer = {
 	},
 
 	onClose() {
+		disableScrollLock()
 		odfViewer.open = false
 		clearTimeout(odfViewer.loadingTimeout)
 		odfViewer.receivedLoading = false
@@ -291,7 +279,6 @@ $(document).ready(function() {
 					...FilesAppIntegration.loggingContext(),
 				})
 			} else {
-				handleResize()
 				emit('richdocuments:file-open:succeeded', {
 					...FilesAppIntegration.loggingContext(),
 				})

--- a/src/helpers/safariFixer.js
+++ b/src/helpers/safariFixer.js
@@ -1,0 +1,97 @@
+/*
+ * @copyright Copyright (c) 2022 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+let scrollLock = false
+let intervalHandler
+
+const isiOS = [
+	'iPad Simulator',
+	'iPhone Simulator',
+	'iPod Simulator',
+	'iPad',
+	'iPhone',
+	'iPod',
+].includes(navigator.platform) || (navigator.userAgent.includes('Mac') && navigator.maxTouchPoints > 1)
+
+// Workaround for Safari automatically scrolling the body when the hidden input is focussed
+const handleScrollReset = () => {
+	document.documentElement.scrollTop = 0
+	document.scrollingElement.scrollTop = 0
+}
+
+// Workaround for Safari to resize the iframe to the proper height
+// as 100vh is not the proper viewport height there
+const handleResize = () => {
+	const expectedHeight = window.visualViewport.height ?? document.documentElement.clientHeight
+	const frame = document.getElementById('richdocumentsframe')
+	if (frame) {
+		frame.style.maxHeight = expectedHeight + 'px'
+	}
+	const viewer = document.querySelector('.office-viewer')
+	if (viewer) {
+		viewer.style.height = expectedHeight + 'px'
+	}
+}
+
+const fixThemAll = () => {
+	if (!isiOS) {
+		return
+	}
+	if (!scrollLock) {
+		return
+	}
+	handleScrollReset()
+	handleResize()
+}
+
+const preventDefault = (e) => e.preventDefault()
+
+export const enableScrollLock = () => {
+	if (scrollLock || !isiOS) {
+		return
+	}
+
+	scrollLock = true
+
+	window?.visualViewport?.addEventListener('resize', fixThemAll)
+		|| window.addEventListener('resize', fixThemAll)
+
+	document.addEventListener('touchstart', preventDefault, false)
+	document.addEventListener('touchmove', preventDefault, false)
+
+	intervalHandler = setInterval(fixThemAll, 200)
+}
+
+export const disableScrollLock = () => {
+	if (!scrollLock || !isiOS) {
+		return
+	}
+
+	scrollLock = false
+
+	window?.visualViewport?.removeEventListener('resize', fixThemAll)
+		|| window.removeEventListener('resize', fixThemAll)
+
+	document.removeEventListener('touchstart', preventDefault, false)
+	document.removeEventListener('touchmove', preventDefault, false)
+
+	clearInterval(intervalHandler)
+}

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -76,6 +76,7 @@ import { getDocumentUrlForFile, getDocumentUrlForPublicFile } from '../helpers/u
 import PostMessageService from '../services/postMessage.tsx'
 import FilesAppIntegration from './FilesAppIntegration.js'
 import { LOADING_ERROR, checkCollaboraConfiguration, checkProxyStatus } from '../services/collabora.js'
+import { enableScrollLock, disableScrollLock } from '../helpers/safariFixer.js'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
 const PostMessages = new PostMessageService({
@@ -187,6 +188,7 @@ export default {
 	},
 	methods: {
 		async load() {
+			enableScrollLock()
 			const isPublic = document.getElementById('isPublic') && document.getElementById('isPublic').value === '1'
 			this.src = getDocumentUrlForFile(this.filename, this.fileid) + '&path=' + encodeURIComponent(this.filename)
 			if (isPublic) {
@@ -207,6 +209,7 @@ export default {
 			FilesAppIntegration.share()
 		},
 		close() {
+			disableScrollLock()
 			this.$parent.close()
 		},
 		postMessageHandler({ parsed, data }) {


### PR DESCRIPTION
The problems with Safari still seem to cause some issues, therefore this
consolidates the fixes into a helper file and provides enable/disable
methods to be turned on during document loading/closing.

There are two issues:
- Safari does have a weired understanding of the document height in css,
  so we need to resize containers accordingly to fit the visible
  viewport when the keyboard is shown
- Safari does not always respect fixed positioning on the body element
  and still allows scrolling if the keyboard is shown, therefore
  manually setting the scrollTop is required when resizing or attempts to
  scroll

Fixes https://github.com/nextcloud/richdocuments/issues/1738

Some things left to still check:
- [ ] See if we actually need the interval callback
- [ ] Maybe we can only run the code on iOS to avoid side effects with other platforms 