### PR TITLE
Fix array access error when requesting preview while not having access to Collabora

### DIFF
--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -42,9 +42,10 @@ abstract class Office extends Provider {
 	private $logger;
 
 	public function __construct(IClientService $clientService, IConfig $config, Capabilities $capabilities, ILogger $logger) {
+		parent::__construct();
 		$this->clientService = $clientService;
 		$this->config = $config;
-		$this->capabilitites = $capabilities->getCapabilities()['richdocuments'];
+		$this->capabilitites = $capabilities->getCapabilities()['richdocuments'] ?? [];
 		$this->logger = $logger;
 	}
 


### PR DESCRIPTION
### Summary

Fixes `Undefined array key 'richdocuments'` errors when users without access to Collabora are requesting previews.

In this case the getCapabilities method returns an empty array.


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
