### PR TITLE
Remove deprecation warning if no access groups are defined

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -59,10 +59,10 @@ class AppConfig {
 	/**
 	 * Get a value by key
 	 * @param string $key
+	 * @param string|null $defaultValue The fallback value if no configuration and global fallback was found.
 	 * @return string
 	 */
-	public function getAppValue($key) {
-		$defaultValue = null;
+	public function getAppValue($key, $defaultValue = null) {
 		if (array_key_exists($key, $this->defaults)) {
 			$defaultValue = $this->defaults[$key];
 		}

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -139,7 +139,7 @@ class TokenManager {
 				// UserCanWrite only if
 				// 1. No edit groups are set or
 				// 2. if they are set, it is in one of the edit groups
-				$editGroups = array_filter(explode('|', $this->appConfig->getAppValue('edit_groups')));
+				$editGroups = array_filter(explode('|', $this->appConfig->getAppValue('edit_groups', '')));
 				$editorUser = $this->userManager->get($editoruid);
 				if ($updatable && count($editGroups) > 0 && $editorUser) {
 					$updatable = false;


### PR DESCRIPTION
* Resolves: _Not reported yet_
* Target version: master 

### Summary
If the edit group configuration is not explicitly set, the `getApiValue` returns `null`. This is not allowed as a second argument to `explode` (deprecated in PHP).

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
