### PR TITLE
[stable25] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -563,12 +563,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "9b19a5a12c990cafe832aa8ccc95be4f57f24c9d"
+                "reference": "8040e907ed5feab42013d68cf5143a33cc93dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9b19a5a12c990cafe832aa8ccc95be4f57f24c9d",
-                "reference": "9b19a5a12c990cafe832aa8ccc95be4f57f24c9d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8040e907ed5feab42013d68cf5143a33cc93dfc5",
+                "reference": "8040e907ed5feab42013d68cf5143a33cc93dfc5",
                 "shasum": ""
             },
             "require": {
@@ -598,7 +598,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable25"
             },
-            "time": "2022-11-11T00:48:02+00:00"
+            "time": "2022-12-12T00:39:14+00:00"
         },
         {
             "name": "php-cs-fixer/diff",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency