### PR TITLE
Be less strict with splitting the wopi allow list

### DIFF
--- a/lib/Middleware/WOPIMiddleware.php
+++ b/lib/Middleware/WOPIMiddleware.php
@@ -95,7 +95,7 @@ class WOPIMiddleware extends Middleware {
 		if ($allowedRanges === '') {
 			return true;
 		}
-		$allowedRanges = explode(',', $allowedRanges);
+		$allowedRanges = preg_split('/(\s|,|;|\|)+/', $allowedRanges);
 
 		$userIp = $this->request->getRemoteAddress();
 		foreach ($allowedRanges as $range) {


### PR DESCRIPTION
Fixes #2685 

TO make the parsing of the wopi allow list less strict for formats that admins might enter.