### PR TITLE
fix(viewer): Do not attempt to register file actions if not available

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -40,7 +40,7 @@ if (OCA.Viewer) {
 
 // TODO: Viewer.openWith introduced with https://github.com/nextcloud/viewer/pull/1273
 //       This check can be replaced with `if(OCA.Viewer)` once NC 24 is EOL.
-if (OCA.Viewer.openWith) {
+if (OCA.Viewer.openWith && OCA?.Files?.fileActions) {
 	const supportedMimes = getCapabilities().richdocuments.mimetypesNoDefaultOpen
 	const actionName = 'Edit with ' + getCapabilities().richdocuments.productName
 	const actionDisplayNameEdit = t('richdocuments', 'Edit with {productName}', { productName: getCapabilities().richdocuments.productName }, undefined, { escape: false })


### PR DESCRIPTION
### Summary

Fixes a js console error that may cause cypress failures on other apps. The viewer script may also be loaded outside of the files app, therefore we need to check before accessing OCA.Files... to avoid uncatched errors

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
