### PR TITLE
fix: Open pdf files by default on share links if files_pdfviewer is disabled

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -104,6 +104,7 @@ class Capabilities implements ICapability {
 		if (!$this->capabilities) {
 			$collaboraCapabilities = $this->capabilitiesService->getCapabilities();
 			$filteredMimetypes = self::MIMETYPES;
+			$optionalMimetypes = self::MIMETYPES_OPTIONAL;
 			// If version is too old, draw is not supported
 			if (!$this->capabilitiesService->hasDrawSupport()) {
 				$filteredMimetypes = array_diff($filteredMimetypes, [
@@ -114,13 +115,14 @@ class Capabilities implements ICapability {
 
 			if (!$this->appManager->isEnabledForUser('files_pdfviewer')) {
 				$filteredMimetypes[] = 'application/pdf';
+				$optionalMimetypes = array_diff($optionalMimetypes, ['application/pdf']);
 			}
 
 			$this->capabilities = [
 				'richdocuments' => [
 					'version' => \OC::$server->getAppManager()->getAppVersion('richdocuments'),
-					'mimetypes' => $filteredMimetypes,
-					'mimetypesNoDefaultOpen' => self::MIMETYPES_OPTIONAL,
+					'mimetypes' => array_values($filteredMimetypes),
+					'mimetypesNoDefaultOpen' => array_values($optionalMimetypes),
 					'collabora' => $collaboraCapabilities,
 					'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) ?: false,
 					'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ?: false,


### PR DESCRIPTION
### Summary

Fixes an issue where pdf files were not opened in Collabra on public share links when the files_pdfviewer app is disabled. If the pdf mimetype is in the default list it should not be part of the optional mimetypes.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
