### PR TITLE
Avoid exception when uploading epub

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -675,6 +675,11 @@ class WopiController extends Controller {
 				return new JSONResponse(['message' => 'File locked'], Http::STATUS_INTERNAL_SERVER_ERROR);
 			}
 
+			// epub is exception (can be uploaded but not opened so don't try to get access token)
+			if ($file->getMimeType() == 'application/epub+zip') {
+				return new JSONResponse([ 'Name' => $file->getName() ], Http::STATUS_OK);
+			}
+
 			// generate a token for the new file (the user still has to be
 			// logged in)
 			list(, $wopiToken) = $this->tokenManager->getToken((string)$file->getId(), null, $wopi->getEditorUid(), $wopi->getDirect());


### PR DESCRIPTION
When Collabora Online exported epub file to the storage WopiController tried to get access token what fails because in discovery there is no epub entry (Collabora Online cannot open epub files).
Export functionality doesn't require url in response at all as it doesn't open newly uploaded file. Let's just return status OK as upload was successful.

This is related to "export to storage" functionality: https://github.com/CollaboraOnline/online/pull/5738