### PR TITLE
Fix viewer height on safari mobile

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -360,6 +360,7 @@ export default {
 <style lang="scss">
 .viewer .office-viewer {
 	height: 100vh;
+	height: 100dvh;
 	top: -50px;
 }
 </style>


### PR DESCRIPTION
Use dvh unit for viewer height for safari mobile compatibility.