### PR TITLE
[stable24] Fix viewer height on safari mobile

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -344,6 +344,8 @@ export default {
 
 		.viewer & {
 			height: 100vh;
+			/* stylelint-disable-next-line */
+			height: 100dvh;
 			top: -50px;
 		}
 	}


### PR DESCRIPTION
Manual backport of #2801 
Use dvh unit for viewer height for safari mobile compatibility.