### PR TITLE
Fix base64 image generation

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -695,7 +695,7 @@ const documentsMain = {
 							const b64Image = e.target.result
 							PostMessages.sendWOPIPostMessage('loolframe', 'Action_GetLinkPreview_Resp', { url, title, image: b64Image })
 						})
-						reader.readAsDataURL(new Blob([imageResponse.data]))
+						reader.readAsDataURL(imageResponse.data)
 					}
 				} catch (e) {
 					console.error('Error loading the reference image', e)


### PR DESCRIPTION
Axios directly returns a blob that can be directly passed to the `FileReader`. This way the mimetype does not get lost in the base64 result.

I didn't spot this because having a `application/octet-stream` mimetype for PNG or JPEG images works fine when used as src of `<img>`. But for SVG it only works if the correct mimetype is specified in the `data:` string.