### PR TITLE
fix: Avoid error when federation is disabled

### DIFF
--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -36,8 +36,9 @@ class Personal implements ISettings {
 	private $capabilities;
 
 	public function __construct(IConfig $config, Capabilities $capabilities, $userId) {
+		$capabilities = $capabilities->getCapabilities();
 		$this->config = $config;
-		$this->capabilities = $capabilities->getCapabilities()['richdocuments'];
+		$this->capabilities = isset($capabilities['richdocuments']) ? $capabilities['richdocuments'] : [];
 		$this->userId = $userId;
 	}
 


### PR DESCRIPTION
Moving code to only be called if federation is enabled. This is already fixed on newer stable branches/master during refactoring.