### PR TITLE
Workaround for en-AU language/locale

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -60,9 +60,9 @@ const languageToBCP47 = () => {
 		return matchingWhitelist[locale]
 	}
 
-	// loleaflet expects a BCP47 language tag syntax
-	// when a the nextcloud language constist of two parts we sent both
-	// as the region is then provided by the language setting
+	// Collabora Online expects BCP47 language tag syntax.
+	// When the Nextcloud language consists of two parts, we send both,
+	// as the region is then provided by the language setting.
 	return language
 }
 


### PR DESCRIPTION
### Summary
A customer in Australia wanted to have AUD as currency by default in new spreadsheets. In Nextcloud they could not select English (Australia) as a language, only English (British). The combination of language en_GB and locale en_AU in Nextcloud should result in language en-AU for Collabora Online. 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
