### PR TITLE
fix(auto_logout): Register auto_logout listeners to prevent auto_logout while editing

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -1,6 +1,7 @@
 import { emit } from '@nextcloud/event-bus'
 import { generateOcsUrl, getRootUrl, imagePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
+import { loadState } from '@nextcloud/initial-state'
 import { showError } from '@nextcloud/dialogs'
 import { getLinkWithPicker } from '@nextcloud/vue-richtext'
 import '@nextcloud/vue-richtext/dist/style.css'
@@ -270,6 +271,8 @@ const documentsMain = {
 			$('#mainContainer').append(form)
 			$('#mainContainer').append(frame)
 			$('#loleafletframe').focus()
+
+			documentsMain.registerAutoLogout($('#loleafletframe')[0])
 
 			emit('richdocuments:wopi-load:started', {
 				wopiFileId: fileId,
@@ -812,6 +815,27 @@ const documentsMain = {
 	 */
 	postGrabFocus() {
 		PostMessages.sendWOPIPostMessage('loolframe', 'Grab_Focus')
+	},
+
+	/**
+	 * Register activity listeners that prevent auto_logout from kicking in
+	 * (Core mechanism for this doesn't work, because we create a new frame)
+	 * @param window
+	 */
+	registerAutoLogout(window) {
+		const config = loadState('core', 'config')
+
+		if (!config.auto_logout) {
+			return
+		}
+
+		window.addEventListener('mousemove', e => {
+			localStorage.setItem('lastActive', Date.now())
+		})
+
+		window.addEventListener('touchstart', e => {
+			localStorage.setItem('lastActive', Date.now())
+		})
 	},
 }
 


### PR DESCRIPTION
* Resolves: -
* Target version: main

### Summary
When the collabora frame is visible the core auto_logout mechanism in session-heartbeat.js isn't tickled anymore and logs the user out after session_lifetime even if there has been activity.

### Checklist

- [x] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
