### PR TITLE
fix: Trigger initial setup earlier

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -240,7 +240,7 @@ window.OCA.RichDocuments = {
 	},
 }
 
-$(document).ready(function() {
+addEventListener('DOMContentLoaded', () => {
 	// register file actions and menu
 	if (typeof OCA !== 'undefined'
 		&& typeof OCA.Files !== 'undefined'


### PR DESCRIPTION
### Summary

There is no need to wait for the full ready event and DOMContentLoaded helps to not run into problems when a file opening is triggered before.
