### PR TITLE
Add modal to set zotero API key during editing

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -226,8 +226,9 @@ class WopiController extends Controller {
 			'EnableRemoteLinkPicker' => (bool)$wopi->getCanwrite() && !$isPublic && !$wopi->getDirect(),
 		];
 
-		$zoteroAPIKey = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'zoteroAPIKey', '');
-		if (!empty($zoteroAPIKey)) {
+		$enableZotero = $this->config->getAppValue(Application::APPNAME, 'zoteroEnabled', 'yes') === 'yes';
+		if (!$isPublic && $enableZotero) {
+			$zoteroAPIKey = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'zoteroAPIKey', '');
 			$response['UserPrivateInfo']['ZoteroAPIKey'] = $zoteroAPIKey;
 		}
 		if ($wopi->hasTemplateId()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
 				"@nextcloud/moment": "^1.2.1",
 				"@nextcloud/router": "^2.0.1",
 				"@nextcloud/vue": "^7.8.5",
-				"vue": "^2.7.14"
+				"vue": "^2.7.14",
+				"vue-material-design-icons": "^5.2.0"
 			},
 			"devDependencies": {
 				"@cypress/browserify-preprocessor": "^3.0.2",
@@ -14798,9 +14799,9 @@
 			}
 		},
 		"node_modules/vue-material-design-icons": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.1.2.tgz",
-			"integrity": "sha512-nD1qFM2qAkMlVoe23EfNKIeMfYl6YjHZjSty9q0mwc2gXmPmvEhixywJQhM+VF5KVBI1zAkVTNLoUEERPY10pA=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.2.0.tgz",
+			"integrity": "sha512-fcdcJHQ9fQw2CAytuLAzWSELcxH138sCdMItVhvmO7Lu9afIgojB/UCWv7XHt/lURsnq/n6O+muM4AQgw8yfig=="
 		},
 		"node_modules/vue-multiselect": {
 			"version": "2.1.6",
@@ -26659,9 +26660,9 @@
 			}
 		},
 		"vue-material-design-icons": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.1.2.tgz",
-			"integrity": "sha512-nD1qFM2qAkMlVoe23EfNKIeMfYl6YjHZjSty9q0mwc2gXmPmvEhixywJQhM+VF5KVBI1zAkVTNLoUEERPY10pA=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-5.2.0.tgz",
+			"integrity": "sha512-fcdcJHQ9fQw2CAytuLAzWSELcxH138sCdMItVhvmO7Lu9afIgojB/UCWv7XHt/lURsnq/n6O+muM4AQgw8yfig=="
 		},
 		"vue-multiselect": {
 			"version": "2.1.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"@nextcloud/moment": "^1.2.1",
 		"@nextcloud/router": "^2.0.1",
 		"@nextcloud/vue": "^7.8.5",
-		"vue": "^2.7.14"
+		"vue": "^2.7.14",
+		"vue-material-design-icons": "^5.2.0"
 	},
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"

--- a/src/components/Modal/ZoteroHint.vue
+++ b/src/components/Modal/ZoteroHint.vue
@@ -20,7 +20,7 @@
   -->
 
 <template>
-	<NcModal>
+	<NcModal :show="show" @close="close">
 		<div class="zotero-hint">
 			<h2>{{ t('richdocument', 'Link to your Zotero library') }}</h2>
 			<BookOpenPageVariantOutline :size="96" />
@@ -58,6 +58,12 @@ export default {
 		NcButton,
 		NcTextField,
 	},
+	props: {
+		show: {
+			type: Boolean,
+			default: false,
+		},
+	},
 	emits: ['submit'],
 	data() {
 		return {
@@ -75,6 +81,10 @@ export default {
 				showError(t('richdocuments', 'Failed to set Zotero API key'))
 			}
 			this.$emit('submit')
+			this.close()
+		},
+		close() {
+			this.$emit('update:show', false)
 		},
 	},
 }

--- a/src/components/Modal/ZoteroHint.vue
+++ b/src/components/Modal/ZoteroHint.vue
@@ -1,0 +1,97 @@
+<!--
+  - @copyright Copyright (c) 2023 Julius Härtl <jus@bitgrid.net>
+  -
+  - @author Julius Härtl <jus@bitgrid.net>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<NcModal>
+		<div class="zotero-hint">
+			<h2>{{ t('richdocument', 'Link to your Zotero library') }}</h2>
+			<BookOpenPageVariantOutline :size="96" />
+			<p>{{ t('richdocuments', 'Connect your Zotero account to make use for references within Office.') }}</p>
+			<p>
+				{{ t('richdocuments', 'You can generate an account key here:') }}
+				<a href="https://www.zotero.org/settings/keys/new" target="_blank" class="external">
+					{{ t('richdocuments', 'Zotero account settings') }}
+				</a>
+			</p>
+			<form @submit.prevent="submit">
+				<NcTextField :value.sync="apiKey"
+					:label="t('richdocuments', 'Zotero API key')"
+					:placeholder="t('richdocuments', 'Zotero API key')" />
+				<div class="submit">
+					<NcButton :aria-label="t('richdocuments', 'Submit')" type="primary" @click="submit">
+						{{ t('richdocuments', 'Submit') }}
+					</NcButton>
+				</div>
+			</form>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import { NcModal, NcButton, NcTextField } from '@nextcloud/vue'
+import { showError } from '@nextcloud/dialogs'
+import BookOpenPageVariantOutline from 'vue-material-design-icons/BookOpenPageVariantOutline.vue'
+import { savePersonalSetting } from '../../services/api.js'
+export default {
+	name: 'ZoteroHint',
+	components: {
+		BookOpenPageVariantOutline,
+		NcModal,
+		NcButton,
+		NcTextField,
+	},
+	emits: ['submit'],
+	data() {
+		return {
+			apiKey: '',
+		}
+	},
+	methods: {
+		async submit() {
+			try {
+				await savePersonalSetting({
+					zoteroAPIKeyInput: this.apiKey,
+				})
+			} catch (e) {
+				console.error('Failed to set zotero api key', e)
+				showError(t('richdocuments', 'Failed to set Zotero API key'))
+			}
+			this.$emit('submit')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.zotero-hint {
+	margin: 24px;
+
+	form, .input-field {
+		margin-top: 24px;
+	}
+
+	div.submit {
+		margin-top: 12px;
+		display: flex;
+		justify-content: end;
+	}
+}
+</style>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -21,7 +21,7 @@
  */
 
 import axios from '@nextcloud/axios'
-import { generateOcsUrl } from '@nextcloud/router'
+import { generateOcsUrl, generateFilePath } from '@nextcloud/router'
 import { getCurrentDirectory } from '../helpers/filesApp.js'
 
 export const createEmptyFile = async (mimeType, fileName) => {
@@ -36,4 +36,8 @@ export const createEmptyFile = async (mimeType, fileName) => {
 	})
 
 	return response.data
+}
+
+export const savePersonalSetting = (data) => {
+	return axios.post(generateFilePath('richdocuments', 'ajax', 'personal.php'), data)
 }

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -219,8 +219,9 @@ export default {
 			this.$parent.close()
 		},
 		reload() {
-			this.showZotero = false
-			this.$forceUpdate()
+			this.loading = LOADING_STATE.LOADING
+			this.load()
+			this.$refs.documentFrame.contentWindow.location.replace(this.src)
 		},
 		postMessageHandler({ parsed, data }) {
 			if (data === 'NC_ShowNamePicker') {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -64,6 +64,8 @@
 				class="office-viewer__iframe"
 				:style="{visibility: showIframe ? 'visible' : 'hidden' }"
 				:src="src" />
+
+			<ZoteroHint v-if="showZotero" @submit="reload" />
 		</div>
 	</transition>
 </template>
@@ -72,6 +74,7 @@
 import { NcAvatar, NcActions, NcActionButton, NcEmptyContent } from '@nextcloud/vue'
 import { loadState } from '@nextcloud/initial-state'
 
+import ZoteroHint from '../components/Modal/ZoteroHint.vue'
 import { basename, dirname } from 'path'
 import { getDocumentUrlForFile, getDocumentUrlForPublicFile } from '../helpers/url.js'
 import PostMessageService from '../services/postMessage.tsx'
@@ -98,6 +101,7 @@ export default {
 		NcActions,
 		NcActionButton,
 		NcEmptyContent,
+		ZoteroHint,
 	},
 	props: {
 		filename: {
@@ -121,6 +125,7 @@ export default {
 			loadingTimeout: null,
 			error: null,
 			views: [],
+			showZotero: false,
 		}
 	},
 	computed: {
@@ -213,6 +218,10 @@ export default {
 			disableScrollLock()
 			this.$parent.close()
 		},
+		reload() {
+			this.showZotero = false
+			this.$forceUpdate()
+		},
 		postMessageHandler({ parsed, data }) {
 			if (data === 'NC_ShowNamePicker') {
 				this.documentReady()
@@ -279,6 +288,9 @@ export default {
 				break
 			case 'UI_Share':
 				this.share()
+				break
+			case 'UI_ZoteroKeyMissing':
+				this.showZotero = true
 				break
 			}
 		},


### PR DESCRIPTION
- feat: Add zotero admin setting and enable integration by default
- feat(Zotero): Add modal to set API key

Fixes #2764 

Cannot fully test right now as I'm on the train with outdated CODE container, but should work.

@pedropintosilva Currently we reload the iframe after setting the API key, but would probably be a good enhancement to also have a post message to pass back the api key to the current editing session, to make sure the user can continue just where they left.
