### PR TITLE
Fix file templates on public links

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -27,10 +27,9 @@ namespace OCA\Richdocuments\AppInfo;
 
 return [
 	'routes' => [
-		//documents
+		// Page rendering of documents
 		['name' => 'document#index', 'url' => 'index', 'verb' => 'GET'],
 		['name' => 'document#remote', 'url' => 'remote', 'verb' => 'GET'],
-
 		['name' => 'document#createFromTemplate', 'url' => 'indexTemplate', 'verb' => 'GET'],
 		['name' => 'document#publicPage', 'url' => '/public', 'verb' => 'GET'],
 
@@ -44,7 +43,7 @@ return [
 		['name' => 'wopi#postFile', 'url' => 'wopi/files/{fileId}', 'verb' => 'POST'],
 		['name' => 'wopi#getTemplate', 'url' => 'wopi/template/{fileId}', 'verb' => 'GET'],
 
-		//settings
+		// Settings
 		['name' => 'settings#setPersonalSettings', 'url' => 'ajax/personal.php', 'verb' => 'POST'],
 		['name' => 'settings#setSettings', 'url' => 'ajax/admin.php', 'verb' => 'POST'],
 		['name' => 'settings#getSettings', 'url' => 'ajax/settings.php', 'verb' => 'GET'],
@@ -58,10 +57,10 @@ return [
 		['name' => 'settings#deleteFontFile', 'url' => 'settings/fonts/{name}', 'verb' => 'DELETE'],
 		['name' => 'settings#uploadFontFile', 'url' => 'settings/fonts', 'verb' => 'POST'],
 
-		//Mobile access
+		// Direct Editing: Webview
 		['name' => 'directView#show', 'url' => '/direct/{token}', 'verb' => 'GET'],
 
-		//assets
+		// Direct Editing: Assets
 		['name' => 'assets#create', 'url' => 'assets', 'verb' => 'POST'],
 		['name' => 'assets#get', 'url' => 'assets/{token}', 'verb' => 'GET'],
 
@@ -71,13 +70,15 @@ return [
 		['name' => 'templates#delete', 'url' => '/template/{fileId}', 'verb' => 'DELETE'],
 	],
 	'ocs' => [
+		// Public pages: new file creation
 		['name' => 'documentAPI#create', 'url' => '/api/v1/file', 'verb' => 'POST'],
 
+		// Client API endpoints
 		['name' => 'OCS#createDirect', 'url' => '/api/v1/document', 'verb' => 'POST'],
 		['name' => 'OCS#createPublic', 'url' => '/api/v1/share', 'verb' => 'POST'],
 		['name' => 'OCS#createPublicFromInitiator', 'url' => '/api/v1/direct/share/initiator', 'verb' => 'POST'],
-		['name' => 'OCS#getTemplates', 'url' => '/api/v1/templates/{type}', 'verb' => 'GET'],
 		['name' => 'OCS#createFromTemplate', 'url' => '/api/v1/templates/new', 'verb' => 'POST'],
+		['name' => 'OCS#getTemplates', 'url' => '/api/v1/templates/{type}', 'verb' => 'GET'],
 
 		['name' => 'OCS#updateGuestName', 'url' => '/api/v1/wopi/guestname', 'verb' => 'POST'],
 

--- a/cypress/e2e/templates.spec.js
+++ b/cypress/e2e/templates.spec.js
@@ -56,4 +56,74 @@ describe('Create new office files from templates', function() {
 		cy.waitForViewer()
 		cy.waitForCollabora()
 	})
+
+	it('Create a file from a system template as user', () => {
+		cy.uploadSystemTemplate()
+		cy.login(randUser)
+		cy.visit('/apps/files')
+		cy.get('.files-controls .button.new')
+			.should('be.visible')
+			.click()
+
+		cy.get('.newFileMenu', { timeout: 10000 })
+			.should('be.visible')
+			.contains('.menuitem', 'New presentation')
+			.as('menuitem')
+			.should('be.visible')
+			.click()
+
+		cy.get('@menuitem').find('.filenameform input[type=text]').type('FileFromTemplate')
+		cy.get('@menuitem').find('.filenameform .icon-confirm').click()
+
+		cy.get('.templates-picker__form')
+			.as('form')
+			.should('be.visible')
+			.contains('.template-picker__label', 'systemtemplate')
+			.should('be.visible')
+			.click()
+
+		cy.get('@form').find('.templates-picker__buttons input[type=submit]').click()
+
+		cy.waitForViewer()
+		cy.waitForCollabora()
+	})
+
+	it.only('Create a file from a system template as guest', () => {
+		cy.uploadSystemTemplate()
+		cy.createFolder(randUser, '/my-share')
+
+		cy.shareLink(randUser, '/my-share', { permissions: 31 }).then((token) => {
+			cy.visit(`/s/${token}`, {
+				onBeforeLoad(win) {
+					cy.spy(win, 'postMessage').as('postMessage')
+				},
+			})
+
+			cy.get('.files-controls .button.new')
+				.should('be.visible')
+				.click()
+
+			cy.get('.newFileMenu', { timeout: 10000 })
+				.should('be.visible')
+				.contains('.menuitem', 'New presentation')
+				.as('menuitem')
+				.should('be.visible')
+				.click()
+
+			cy.get('@menuitem').find('.filenameform input[type=text]').type('FileFromTemplate')
+			cy.get('@menuitem').find('.filenameform .icon-confirm').click()
+
+			cy.get('#template-picker')
+				.as('form')
+				.should('be.visible')
+				.contains('h2', 'systemtemplate')
+				.should('be.visible')
+				.click()
+
+			cy.get('.oc-dialog').find('button.primary').click()
+
+			cy.waitForViewer()
+			cy.waitForCollabora()
+		})
+	})
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -223,3 +223,15 @@ Cypress.Commands.add('waitForCollabora', (wrapped = true) => {
 		.as('loleafletframe')
 	cy.get('@loleafletframe').find('#main-document-content').should('be.visible')
 })
+
+Cypress.Commands.add('uploadSystemTemplate', () => {
+	cy.login(new User('admin', 'admin'))
+	cy.visit('/settings/admin/richdocuments')
+	cy.get('#richdocuments-templates').scrollIntoView()
+	cy.get('input[type=file]#add-template').selectFile({
+		contents: 'cypress/fixtures/templates/presentation.otp',
+		fileName: 'systemtemplate.otp',
+		mimeType: 'application/vnd.oasis.opendocument.presentation-template',
+	}, { force: true })
+	cy.get('#richdocuments-templates li').contains('systemtemplate.otp')
+})

--- a/lib/Controller/DocumentAPIController.php
+++ b/lib/Controller/DocumentAPIController.php
@@ -67,7 +67,7 @@ class DocumentAPIController extends \OCP\AppFramework\OCSController {
 	 * @NoAdminRequired
 	 * @PublicPage
 	 */
-	public function create(string $mimeType, string $fileName, string $directoryPath = '/', string $shareToken = null): JSONResponse {
+	public function create(string $mimeType, string $fileName, string $directoryPath = '/', string $shareToken = null, ?int $templateId = null): JSONResponse {
 		try {
 			if ($shareToken !== null) {
 				$share = $this->shareManager->getShareByToken($shareToken);
@@ -122,8 +122,14 @@ class DocumentAPIController extends \OCP\AppFramework\OCSController {
 		try {
 			$file = $folder->newFile($fileName);
 			$templateType = $this->templateManager->getTemplateTypeForExtension(pathinfo($fileName, PATHINFO_EXTENSION));
+
 			$empty = $this->templateManager->getEmpty($templateType);
 			$templateFile = array_shift($empty);
+
+			if ($templateId) {
+				$templateFile = $this->templateManager->get($templateId);
+			}
+
 			$file->putContent($this->templateManager->getEmptyFileContent($file->getExtension()));
 			if ($this->templateManager->isSupportedTemplateSource($templateFile->getExtension())) {
 				// Only use TemplateSource if supported filetype

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -294,8 +294,13 @@ class DocumentController extends Controller {
 					'isPublicShare' => true,
 				];
 
-				list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($item->getId(), $shareToken, $this->uid);
-				$params['token'] = $token;
+				$templateFile = $this->templateManager->getTemplateSource($item->getId());
+				if ($templateFile) {
+					list($urlSrc, $wopi) = $this->tokenManager->getTokenForTemplate($templateFile, $this->uid, $item->getId());
+				} else {
+					list($urlSrc, $token, $wopi) = $this->tokenManager->getToken($item->getId(), $shareToken, $this->uid);
+				}
+				$params['token'] = $wopi->getToken();
 				$params['token_ttl'] = $wopi->getExpiry();
 				$params['urlsrc'] = $urlSrc;
 				$params['hideCloseButton'] = $node instanceof File && $wopi->getHideDownload();

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -293,6 +293,7 @@ class OCSController extends \OCP\AppFramework\OCSController {
 
 	/**
 	 * @NoAdminRequired
+	 * @PublicPage
 	 *
 	 * @param string $type The template type
 	 * @return DataResponse

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -478,7 +478,7 @@ class TemplateManager {
 			'preview' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.templates.getPreview', ['fileId' => $template->getId()]),
 			'type' => $this->flipTypes()[$template->getMimeType()],
 			'delete' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.templates.delete', ['fileId' => $template->getId()]),
-			'extension' => ($ooxml && isset(self::TYPE_EXTENSION_OOXML[$documentType])) ? self::TYPE_EXTENSION_OOXML[$documentType] : self::TYPE_EXTENTION[$documentType],
+			'extension' => $template->getExtension(),
 		];
 	}
 

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -154,7 +154,7 @@ class TemplateManager {
 	 * @param int $fileId
 	 * @return File
 	 */
-	public function get($fileId) {
+	public function get(int $fileId) {
 		// is this a global template ?
 		$files = $this->getEmptyTemplateDir()->getDirectoryListing();
 

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -164,6 +164,10 @@ class TemplateManager {
 			}
 		}
 
+		if ($this->userId === null && $this->config->getAppValue(Application::APPNAME, 'template_public', 'yes') !== 'yes') {
+			throw new NotFoundException();
+		}
+
 		// is this a global template ?
 		$files = $this->getSystemTemplateDir()->getDirectoryListing();
 
@@ -259,6 +263,9 @@ class TemplateManager {
 	 * @return File[]
 	 */
 	public function getSystem($type = null) {
+		if ($this->userId === null && $this->config->getAppValue(Application::APPNAME, 'template_public', 'yes') !== 'yes') {
+			return [];
+		}
 		$folder = $this->getSystemTemplateDir();
 
 		$templateFiles = $folder->getDirectoryListing();
@@ -289,6 +296,10 @@ class TemplateManager {
 	 * @return File[]
 	 */
 	public function getUser($type = null) {
+		if ($this->userId === null) {
+			return [];
+		}
+
 		try {
 			$templateDir = $this->getUserTemplateDir();
 			$templateFiles = $templateDir->getDirectoryListing();
@@ -303,6 +314,10 @@ class TemplateManager {
 	 * @return array
 	 */
 	public function getUserFormatted($type) {
+		if ($this->userId === null) {
+			return [];
+		}
+
 		$templates = $this->getUser($type);
 
 		return array_map(function (File $file) {
@@ -316,12 +331,12 @@ class TemplateManager {
 	 * @return File[]
 	 */
 	public function getAll($type = 'document') {
-		$system = $this->getSystem();
-		$user = $this->getUser();
-
 		if (!array_key_exists($type, self::$tplTypes)) {
 			return [];
 		}
+
+		$system = $this->getSystem();
+		$user = $this->getUser();
 
 		return array_values(array_filter(array_merge($user, $system), function (File $template) use ($type) {
 			foreach (self::$tplTypes[$type] as $mime) {

--- a/src/admin.js
+++ b/src/admin.js
@@ -32,6 +32,7 @@ new Vue({
 function appendTemplateFromData(data) {
 	const template = document.querySelector('.template-model').cloneNode(true)
 	template.className = ''
+	template.dataset.filename = data.name
 	template.querySelector('img').src = data.preview
 	template.querySelector('figcaption').textContent = data.name
 	template.querySelector('.delete-template').href = data.delete
@@ -117,6 +118,7 @@ function initTemplateManager() {
 		},
 
 		success(e) {
+			document.querySelector(`[data-filename="${e.data.name}"]`)?.remove()
 			inputElmt.disabled = false
 			buttonElmt.className = 'icon-add'
 			// add template to dom

--- a/src/components/SettingsSelectTag.vue
+++ b/src/components/SettingsSelectTag.vue
@@ -98,6 +98,10 @@ const xmlToTagList = (xml) => {
 	for (const index in list) {
 		const tag = list[index]['d:propstat']
 
+		if (!tag) {
+			continue
+		}
+
 		if (tag['d:status']['#text'] !== 'HTTP/1.1 200 OK') {
 			continue
 		}

--- a/src/document.js
+++ b/src/document.js
@@ -821,6 +821,7 @@ const documentsMain = {
 	/**
 	 * Register activity listeners that prevent auto_logout from kicking in
 	 * (Core mechanism for this doesn't work, because we create a new frame)
+	 *
 	 * @param window
 	 */
 	registerAutoLogout(window) {

--- a/src/helpers/types.js
+++ b/src/helpers/types.js
@@ -38,6 +38,10 @@ const getFileTypes = () => {
 				extension: 'pptx',
 				mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
 			},
+			drawing: {
+				extension: 'odg',
+				mime: 'application/vnd.oasis.opendocument.graphics',
+			},
 		}
 	}
 	return {
@@ -52,6 +56,10 @@ const getFileTypes = () => {
 		presentation: {
 			extension: 'odp',
 			mime: 'application/vnd.oasis.opendocument.presentation',
+		},
+		drawing: {
+			extension: 'odg',
+			mime: 'application/vnd.oasis.opendocument.graphics',
 		},
 	}
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -24,7 +24,7 @@ import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 import { getCurrentDirectory } from '../helpers/filesApp.js'
 
-export const createEmptyFile = async (mimeType, fileName) => {
+export const createEmptyFile = async (mimeType, fileName, templateId = null) => {
 	const shareToken = document.getElementById('sharingToken')?.value
 	const directoryPath = getCurrentDirectory()
 
@@ -33,6 +33,7 @@ export const createEmptyFile = async (mimeType, fileName) => {
 		fileName,
 		directoryPath,
 		shareToken,
+		templateId,
 	})
 
 	return response.data

--- a/src/view/NewFileMenu.js
+++ b/src/view/NewFileMenu.js
@@ -20,12 +20,11 @@
  *
  */
 
+import axios from '@nextcloud/axios'
 import { getCurrentDirectory } from '../helpers/filesApp.js'
 import Types from '../helpers/types.js'
 import { createEmptyFile } from '../services/api.js'
 import { generateUrl, generateFilePath, generateOcsUrl } from '@nextcloud/router'
-
-const isPublic = window.document.getElementById('isPublic')?.value === '1'
 
 /** @type OC.Plugin */
 const NewFileMenu = {
@@ -34,6 +33,7 @@ const NewFileMenu = {
 		const document = Types.getFileType('document')
 		const spreadsheet = Types.getFileType('spreadsheet')
 		const presentation = Types.getFileType('presentation')
+		const drawing = Types.getFileType('drawing')
 
 		newFileMenu.addMenuEntry({
 			id: 'add-' + document.extension,
@@ -42,7 +42,7 @@ const NewFileMenu = {
 			iconClass: 'icon-filetype-document',
 			fileType: 'x-office-document',
 			actionHandler(filename) {
-				if (!isPublic && OC.getCapabilities().richdocuments.templates) {
+				if (OC.getCapabilities().richdocuments.templates) {
 					self._openTemplatePicker('document', document.mime, filename)
 				} else {
 					self._createDocument(document.mime, filename)
@@ -57,7 +57,7 @@ const NewFileMenu = {
 			iconClass: 'icon-filetype-spreadsheet',
 			fileType: 'x-office-spreadsheet',
 			actionHandler(filename) {
-				if (!isPublic && OC.getCapabilities().richdocuments.templates) {
+				if (OC.getCapabilities().richdocuments.templates) {
 					self._openTemplatePicker('spreadsheet', spreadsheet.mime, filename)
 				} else {
 					self._createDocument(spreadsheet.mime, filename)
@@ -72,7 +72,7 @@ const NewFileMenu = {
 			iconClass: 'icon-filetype-presentation',
 			fileType: 'x-office-presentation',
 			actionHandler(filename) {
-				if (!isPublic && OC.getCapabilities().richdocuments.templates) {
+				if (OC.getCapabilities().richdocuments.templates) {
 					self._openTemplatePicker('presentation', presentation.mime, filename)
 				} else {
 					self._createDocument(presentation.mime, filename)
@@ -81,11 +81,11 @@ const NewFileMenu = {
 		})
 	},
 
-	_createDocument(mimetype, filename) {
+	_createDocument(mimetype, filename, templateId = null) {
 		OCA.Files.Files.isFileNameValid(filename)
 		filename = FileList.getUniqueName(filename)
 
-		createEmptyFile(mimetype, filename).then((response) => {
+		createEmptyFile(mimetype, filename, templateId).then((response) => {
 			if (response && response.status === 'success') {
 				FileList.add(response.data, { animate: true, scrollTo: true })
 				const fileModel = FileList.getModelForFile(filename)
@@ -102,46 +102,16 @@ const NewFileMenu = {
 		})
 	},
 
-	_createDocumentFromTemplate(templateId, mimetype, filename) {
-		const dir = getCurrentDirectory()
-		OCA.Files.Files.isFileNameValid(filename)
-		filename = FileList.getUniqueName(filename)
-
-		$.post(
-			generateUrl('apps/richdocuments/ajax/documents/create'),
-			{ mimetype, filename, dir },
-			function(response) {
-				if (response && response.status === 'success') {
-					FileList.add(response.data, { animate: false, scrollTo: false })
-					const fileModel = FileList.getModelForFile(filename)
-					const path = dir + '/' + filename
-					OCA.RichDocuments.openWithTemplate({
-						fileId: -1,
-						path,
-						templateId,
-						fileList: window.FileList,
-						fileModel,
-					})
-				} else {
-					OC.dialogs.alert(response.data.message, t('core', 'Could not create file'))
-				}
-			}
-		)
-	},
-
 	_openTemplatePicker(type, mimetype, filename) {
-		const self = this
-		$.ajax({
-			url: generateOcsUrl(`apps/richdocuments/api/v1/templates/${type}`, 2) + type,
-			dataType: 'json',
-		}).then(function(response) {
+		axios.get(generateOcsUrl(`apps/richdocuments/api/v1/templates/${type}`, 2)).then(({ data: response }) => {
 			if (response.ocs.data.length === 1) {
 				const { id } = response.ocs.data[0]
-				self._createDocumentFromTemplate(id, mimetype, filename)
+				this._createDocument(mimetype, filename, id)
 				return
 			}
-			self._buildTemplatePicker(response.ocs.data)
-				.then(function() {
+			this._buildTemplatePicker(response.ocs.data)
+				.then(() => {
+					const self = this
 					const buttonlist = [{
 						text: t('core', 'Cancel'),
 						classes: 'cancel',
@@ -153,7 +123,7 @@ const NewFileMenu = {
 						classes: 'primary',
 						click() {
 							const templateId = this.dataset.templateId
-							self._createDocumentFromTemplate(templateId, mimetype, filename)
+							self._createDocument(mimetype, filename, templateId)
 							$(this).ocdialog('close')
 						},
 					}]
@@ -168,8 +138,7 @@ const NewFileMenu = {
 	},
 
 	_buildTemplatePicker(data) {
-		const self = this
-		return $.get(generateFilePath('richdocuments', 'templates', 'templatePicker.html'), function(tmpl) {
+		return axios.get(generateFilePath('richdocuments', 'templates', 'templatePicker.html')).then(({ data: tmpl }) => {
 			const $tmpl = $(tmpl)
 			// init template picker
 			const $dlg = $tmpl.octemplate({
@@ -178,9 +147,9 @@ const NewFileMenu = {
 			})
 
 			// create templates list
-			const templates = _.values(data)
-			templates.forEach(function(template) {
-				self._appendTemplateFromData($dlg[0], template)
+			const templates = Object.values(data)
+			templates.forEach((template) => {
+				this._appendTemplateFromData($dlg[0], template)
 			})
 
 			$('body').append($dlg)
@@ -192,7 +161,8 @@ const NewFileMenu = {
 		template.className = ''
 		template.querySelector('img').src = generateUrl('apps/richdocuments/template/preview/' + data.id)
 		template.querySelector('h2').textContent = data.name
-		template.onclick = function() {
+		template.onclick = function(e) {
+			e.preventDefault()
 			dlg.dataset.templateId = data.id
 		}
 		if (!dlg.dataset.templateId) {

--- a/src/view/NewFileMenu.js
+++ b/src/view/NewFileMenu.js
@@ -79,6 +79,21 @@ const NewFileMenu = {
 				}
 			},
 		})
+
+		newFileMenu.addMenuEntry({
+			id: 'add-' + drawing.extension,
+			displayName: t('richdocuments', 'New drawing'),
+			templateName: t('richdocuments', 'New drawing') + '.' + drawing.extension,
+			iconClass: 'icon-filetype-draw',
+			fileType: 'x-office-drawing',
+			actionHandler(filename) {
+				if (OC.getCapabilities().richdocuments.templates) {
+					self._openTemplatePicker('drawing', drawing.mime, filename)
+				} else {
+					self._createDocument(drawing.mime, filename)
+				}
+			},
+		})
 	},
 
 	_createDocument(mimetype, filename, templateId = null) {

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -30,7 +30,7 @@ script('files', 'jquery.fileupload');
 			<div class="delete-cover"></div>
 		</li>
 		<?php foreach ($_['settings']['templates'] as $template) {?>
-			<li>
+			<li data-filename="<?php p($template['name']); ?>">
 				<figure>
 					<?php if (isset($template['preview'])) { ?>
 						<img src="<?php p($template['preview']) ?>?y=297&x=210" alt="<?php p($l->t('template preview')) ?>" />


### PR DESCRIPTION
### Summary

Bring back the template picker on public share links of folders for file creation when the admin has setup global templates.

Furthermore this adds a app config value to disable this in case templates shall not be leaked to anonymous users and fixes missing draw file creation for share links as well.