### PR TITLE
fix: Properly select save as dialog buttons

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -523,7 +523,7 @@ const documentsMain = {
 							false
 						).then(function() {
 							const $dialog = $('.oc-dialog:visible')
-							const $buttons = $dialog.find('button')
+							const $buttons = $dialog.find('.oc-dialog-buttonrow button')
 							$buttons.eq(0).text(t('richdocuments', 'Cancel'))
 							$buttons.eq(1).text(t('richdocuments', 'Save'))
 							const nameInput = $dialog.find('input')[0]


### PR DESCRIPTION
The OC dialogs layout has changed on Nextcloud 25 due to accessibility works so we need to adjust the selector to adjust the button text.


| Before | After |
|---|---|
| <img width="456" alt="Screenshot 2023-03-29 at 17 21 26" src="https://user-images.githubusercontent.com/3404133/228587669-3bb72fd8-2e90-4799-9058-303afd2e6aec.png"> | <img width="432" alt="Screenshot 2023-03-29 at 17 18 33" src="https://user-images.githubusercontent.com/3404133/228587683-464ad330-4c81-4b85-8e40-f7903f3d359d.png"> |
