### PR TITLE
fix(files): Avoid reloading the file list and use update methods instead

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -91,10 +91,8 @@ export default {
 			return
 		}
 
-		if (this.getFileList()) {
-			this.getFileList().setViewerMode && this.getFileList().setViewerMode(false)
-			this.getFileList().reload && this.getFileList().reload()
-		}
+		this.updateFileInfo(undefined, Date.now())
+
 		this.fileModel = null
 		if (!isPublic) {
 			this.removeVersionSidebarEvents()
@@ -103,6 +101,8 @@ export default {
 	},
 
 	saveAs(newName) {
+		const oldFile = this.getFileModel()
+
 		if (this.handlers.saveAs && this.handlers.saveAs(this)) {
 			return
 		}
@@ -112,8 +112,12 @@ export default {
 		}
 
 		if (this.getFileList()) {
+			const newFileModel = oldFile.clone()
+			newFileModel.set('name', newName)
+			newFileModel.set('mtime', Date.now())
 			this.getFileList()
-				.reload()
+				.add(newFileModel.toJSON())
+
 			OC.Apps.hideAppSidebar()
 		}
 	},
@@ -133,13 +137,15 @@ export default {
 	},
 
 	rename(newName) {
+		this.updateFileInfo(newName, Date.now())
+
 		this.fileName = newName
 
 		if (this.handlers.rename && this.handlers.rename(this)) {
 			return
 		}
+
 		if (this.getFileList()) {
-			this.getFileList().reload && this.getFileList().reload()
 			OC.Apps.hideAppSidebar()
 		}
 	},
@@ -574,6 +580,22 @@ export default {
 				filePath: (this.filePath ?? '') + '/' + this.fileName,
 			},
 		}
+	},
+
+	updateFileInfo(name, mtime) {
+		const fileInfo = this.getFileModel()
+		if (!fileInfo) {
+			return
+		}
+
+		if (name) {
+			fileInfo.set('name', name)
+		}
+
+		if (mtime) {
+			fileInfo.set('mtime', mtime)
+		}
+		fileInfo.trigger('change', this.getFileModel())
 	},
 
 }

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -210,6 +210,7 @@ export default {
 			FilesAppIntegration.share()
 		},
 		close() {
+			FilesAppIntegration.close()
 			disableScrollLock()
 			this.$parent.close()
 		},
@@ -256,6 +257,11 @@ export default {
 			case 'Get_Views_Resp':
 			case 'Views_List':
 				this.views = args
+				break
+			case 'Action_Save_Resp':
+				if (args.fileName !== this.filename) {
+					FilesAppIntegration.saveAs(args.fileName)
+				}
 				break
 			case 'UI_InsertGraphic':
 				FilesAppIntegration.insertGraphic((filename, url) => {


### PR DESCRIPTION
### Summary

Using a file list reload causes quite some troubles like changing the URL and also has a performance impact of loading all file metadata again. We can actually just update the affected file rows during rename, save and save as.

### TODO

- [x] Add cypress tests: Time change related topics are hard to test on e2e reliably, so let's skip this for now
- [x] File bug at collabora that on rename the old filename shows up again and there is no loading indication about the operation. At some point the filename then changes to the expected new one. https://github.com/CollaboraOnline/online/issues/6131

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
