### PR TITLE
[stable25] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -563,12 +563,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "bbdf512d23b94bf6e7eeb54635bd24caa14ad42f"
+                "reference": "6ee42ac471622be945e2396791f968d9345a1e06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/bbdf512d23b94bf6e7eeb54635bd24caa14ad42f",
-                "reference": "bbdf512d23b94bf6e7eeb54635bd24caa14ad42f",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6ee42ac471622be945e2396791f968d9345a1e06",
+                "reference": "6ee42ac471622be945e2396791f968d9345a1e06",
                 "shasum": ""
             },
             "require": {
@@ -598,7 +598,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable25"
             },
-            "time": "2023-03-25T00:35:37+00:00"
+            "time": "2023-03-31T00:37:20+00:00"
         },
         {
             "name": "php-cs-fixer/diff",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency