### PR TITLE
fix: Avoid error when browser cannot detect font mimetype

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -39,6 +39,7 @@ class SettingsController extends Controller {
 	public const FONT_MIME_TYPES = [
 		'font/ttf',
 		'application/font-sfnt',
+		'font/sfnt',
 		'font/opentype',
 		'application/vnd.oasis.opendocument.formula-template',
 	];
@@ -432,8 +433,15 @@ class SettingsController extends Controller {
 		try {
 			$file = $this->getUploadedFile('fontfile');
 			if (isset($file['tmp_name'], $file['name'], $file['type'])) {
-				if (!in_array($file['type'], self::FONT_MIME_TYPES, true)) {
-					return new JSONResponse(['error' => 'Font type not supported'], Http::STATUS_BAD_REQUEST);
+				$fileType = $file['type'];
+				if (function_exists('mime_content_type')) {
+					$fileType = @mime_content_type($file['tmp_name']);
+				}
+				if (!$fileType) {
+					$fileType = $file['type'];
+				}
+				if (!in_array($fileType, self::FONT_MIME_TYPES, true)) {
+					return new JSONResponse(['error' => 'Font type not supported: ' . $fileType], Http::STATUS_BAD_REQUEST);
 				}
 				$newFileResource = fopen($file['tmp_name'], 'rb');
 				if ($newFileResource === false) {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -715,7 +715,7 @@ export default {
 			// TODO define font format list
 			const files = event.target.files
 			const file = files[0]
-			if (!fontMimes.includes(file.type)) {
+			if (file.type !== '' && !fontMimes.includes(file.type)) {
 				showError(t('richdocuments', 'Font format not supported ({mime})', { mime: file.type }))
 				return
 			}


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/API/File/type file type checking in Javascript is unreliable and we should not fail hard if an empty string is detected:

> Uncommon file extensions would return an empty string. Client configuration (for instance, the Windows Registry) may result in unexpected values even for common types. Developers are advised not to rely on this property as a sole validation scheme.

Added some further validation on the backend to make use of mime_content_type if available.