### PR TITLE
fix: Avoid setting user scope for share links

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -803,7 +803,6 @@ class WopiController extends Controller {
 	 * @throws ShareNotFound
 	 */
 	private function getFileForWopiToken(Wopi $wopi) {
-		$this->userScopeService->setUserScope($wopi->getEditorUid());
 		if (!empty($wopi->getShare())) {
 			$share = $this->shareManager->getShareByToken($wopi->getShare());
 			$node = $share->getNode();


### PR DESCRIPTION
fix #2896 

Setting the current user on public share links doesn't work for file operations as the storage backend does not consider this case. Any operation on share links are considered to be performed by guest users. Therefore we cannot set the editing user.

For files in the user folder this is already set further below.