### PR TITLE
Improve group multiselect behaviour with multiple and long group names

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -765,8 +765,9 @@ export default {
 
 	input[type='text'],
 	.multiselect {
-		width: 100%;
-		max-width: 400px;
+		width: auto;
+		min-width: 200px;
+		max-width: 100%;
 	}
 
 	input#wopi_url {

--- a/src/components/SettingsSelectGroup.vue
+++ b/src/components/SettingsSelectGroup.vue
@@ -23,14 +23,13 @@
 <template>
 	<NcMultiselect v-model="inputValObjects"
 		:options="groupsArray"
-		:options-limit="5"
+		:auto-limit="false"
 		:placeholder="label"
 		track-by="id"
 		label="displayname"
 		class="multiselect-vue"
 		:multiple="true"
 		:close-on-select="false"
-		:tag-width="60"
 		:disabled="disabled"
 		@input="update"
 		@search-change="asyncFindGroup">

--- a/src/components/SettingsSelectGroup.vue
+++ b/src/components/SettingsSelectGroup.vue
@@ -77,7 +77,9 @@ export default {
 			return 'settings-select-group-' + this.uuid
 		},
 		groupsArray() {
-			return Object.values(this.groups)
+			return Object.values(this.groups).sort((a, b) => {
+				return this.inputValObjects.indexOf(b) - this.inputValObjects.indexOf(a)
+			})
 		},
 	},
 	watch: {
@@ -88,6 +90,13 @@ export default {
 	created() {
 		this.uuid = uuid.toString()
 		uuid += 1
+
+		// Preseed with placeholder entries for groups
+		this.getValueObject().forEach((element) => {
+			this.$set(this.groups, element.id, element)
+		})
+		this.inputValObjects = this.getValueObject()
+		// Fetch actual group metadata
 		this.asyncFindGroup('').then((result) => {
 			this.inputValObjects = this.getValueObject()
 		})
@@ -111,7 +120,7 @@ export default {
 		},
 		asyncFindGroup(query) {
 			query = typeof query === 'string' ? encodeURI(query) : ''
-			return axios.get(generateOcsUrl(`cloud/groups/details?search=${query}&limit=10`, 2))
+			return axios.get(generateOcsUrl(`cloud/groups/details?search=${query}&limit=100`, 2))
 				.then((response) => {
 					if (Object.keys(response.data.ocs.data.groups).length > 0) {
 						response.data.ocs.data.groups.forEach((element) => {


### PR DESCRIPTION
- fix: Do not limit group selector in settings
- fix: Avoid cutting off group list too early
- fix: Filter selected groups first and properly display groups that are not fetched in the initial result response


* Resolves: #2943 
* Target version: main

Backportable implementation, draft for moving to the new component at https://github.com/nextcloud/richdocuments/pull/2945

### Summary

| Before | After |
|---|---|
| ![Screenshot 2023-05-12 at 09 21 50](https://github.com/nextcloud/richdocuments/assets/3404133/32292e6f-7525-4e2d-97e3-9d7776448d43) ![Screenshot 2023-05-12 at 09 21 53](https://github.com/nextcloud/richdocuments/assets/3404133/4e625520-2208-400c-aa8c-45e9f3134f17) | ![Screenshot 2023-05-12 at 09 23 02](https://github.com/nextcloud/richdocuments/assets/3404133/ba151a45-4bb7-4e00-99dd-bf53a21972ec) ![Screenshot 2023-05-12 at 09 21 12](https://github.com/nextcloud/richdocuments/assets/3404133/8425e0d8-5e58-484a-aafb-afe177e4e994) |

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
