### PR TITLE
fix(event): Replace deprecated 3rdparty event with our OCP event

### DIFF
--- a/lib/Events/BeforeFederationRedirectEvent.php
+++ b/lib/Events/BeforeFederationRedirectEvent.php
@@ -2,8 +2,8 @@
 
 namespace OCA\Richdocuments\Events;
 
+use OCP\EventDispatcher\Event;
 use OCP\Files\Node;
-use Symfony\Component\EventDispatcher\Event;
 
 class BeforeFederationRedirectEvent extends Event {
 	/** @var Node */
@@ -16,6 +16,7 @@ class BeforeFederationRedirectEvent extends Event {
 	private $remote;
 
 	public function __construct($node, $relativePath, $remote) {
+		parent::__construct();
 		$this->node = $node;
 		$this->relativePath = $relativePath;
 		$this->remote = $remote;


### PR DESCRIPTION
Otherwise this breaks when we upgrade symfony/event-dispatcher to the next major.
But couldn't find any listener?

### Summary

![grafik](https://github.com/nextcloud/richdocuments/assets/213943/9f569dff-b9b0-42a1-a38d-4168fc49a56e)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
