### PR TITLE
ci: Switch to ghcr.io images

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -98,6 +98,7 @@ jobs:
           php occ user:add --password-from-env user1
           php occ user:add --password-from-env user2
           php occ config:system:set force_language --value en
+          php occ app:enable --force testing
           php occ app:enable --force viewer
           php occ app:enable --force richdocuments
           php occ app:list

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       collabora:
-        image: collabora/code
+        image: ghcr.io/juliushaertl/nextcloud-dev-code:latest
         env:
           extra_params: '--o:ssl.enable=false --o:home_mode.enable=true'
           aliasgroup1: 'http://172.17.0.1'
@@ -82,12 +82,6 @@ jobs:
           ini-values:
             apc.enable_cli=on
           coverage: none
-
-      - name: Find Docker Host IP
-        uses: addnab/docker-run-action@v1
-        with:
-          image: alpine:latest
-          run: "apk update > /dev/null && apk add iproute2 > /dev/null && ip -4 route show default | cut -d' ' -f3"
 
       - name: Set up Nextcloud
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,7 +31,7 @@ jobs:
 
     services:
       collabora:
-        image: collabora/code
+        image: ghcr.io/juliushaertl/nextcloud-dev-code:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'
@@ -100,14 +100,14 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:10.5
+        image: ghcr.io/nextcloud/continuous-integration-mariadb-10.6:latest
         ports:
           - 4444:3306/tcp
         env:
           MYSQL_ROOT_PASSWORD: rootpassword
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
       collabora:
-        image: collabora/code
+        image: ghcr.io/juliushaertl/nextcloud-dev-code:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'
@@ -176,7 +176,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:14
+        image: ghcr.io/nextcloud/continuous-integration-postgres-14:latest
         ports:
           - 4444:5432/tcp
         env:
@@ -185,7 +185,7 @@ jobs:
           POSTGRES_DB: nextcloud
         options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
       collabora:
-        image: collabora/code
+        image: ghcr.io/juliushaertl/nextcloud-dev-code:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'
@@ -254,11 +254,26 @@ jobs:
 
     services:
       oracle:
-        image: deepdiver/docker-oracle-xe-11g
+        image: ghcr.io/gvenzl/oracle-xe:11
+
+        # Provide passwords and other environment variables to container
+        env:
+          ORACLE_RANDOM_PASSWORD: true
+          APP_USER: autotest
+          APP_USER_PASSWORD: owncloud
+
+        # Forward Oracle port
         ports:
-          - "1521:1521"
+          - 1521:1521/tcp
+
+        # Provide healthcheck script options for startup
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
       collabora:
-        image: collabora/code
+        image: ghcr.io/juliushaertl/nextcloud-dev-code:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'

--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -39,7 +39,7 @@ describe('Open existing office files', function() {
 	fileTests.forEach((filename) => {
 
 		it('Classic UI: Open ' + filename + ' the viewer on file click', function() {
-			cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'classic')
+			cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'compact')
 			cy.login(randUser)
 
 			cy.visit('/apps/files', {

--- a/tests/lib/PermissionManagerTest.php
+++ b/tests/lib/PermissionManagerTest.php
@@ -45,6 +45,8 @@ class PermissionManagerTest extends TestCase {
 	private $userSession;
 	/** @var PermissionManager */
 	private $permissionManager;
+	/** @var ISystemTagObjectMapper */
+	private $systemTagMapper;
 
 	public function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
- [x] Wait for dispatch of phpunit- actions from templates
- [x] collabora/code image is not on ghcr.io, asked if they would be open for having that in their repo
  - [x] For now switched to https://github.com/juliushaertl/nextcloud-docker-dev/pkgs/container/nextcloud-dev-code which is nightly built and a copy of collabora/code
- [x] cypress uses alpine for getting the docker ip

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
