### PR TITLE
fix: Catch and skip errors for adjusting the files view when the file is not present in the list

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -199,13 +199,18 @@ export default {
 		if (!this.getFileList() || !this.getFileList().getModelForFile || !this.getFileList()._updateDetailsView) {
 			return null
 		}
-		this.getFileList()._updateDetailsView(this.fileName, false)
-		this.fileModel = this.getFileList().getModelForFile(this.fileName)
+		try {
+			this.getFileList()._updateDetailsView(this.fileName, false)
 
-		if (this.fileModel && this.fileModel.on) {
-			this.fileModel.on('change', () => {
-				this._addHeaderFileActions()
-			})
+			this.fileModel = this.getFileList().getModelForFile(this.fileName)
+
+			if (this.fileModel && this.fileModel.on) {
+				this.fileModel.on('change', () => {
+					this._addHeaderFileActions()
+				})
+			}
+		} catch (e) {
+			return null
 		}
 
 		return this.fileModel


### PR DESCRIPTION

* Resolves: #2933
* Target version: main

### Summary

When opening a file from the recommended files there is no need to update it in the file list so we can safely ignore the error in this case.

Handling file updates is quite hacky but hopefully gets a better way to handle once the files to vue migration moves on.