### PR TITLE
fix: Remove broken way of updating the encryption access list

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -199,16 +199,6 @@ class DocumentController extends Controller {
 				}
 			}
 
-			$encryptionManager = \OC::$server->getEncryptionManager();
-			if ($encryptionManager->isEnabled()) {
-				// Update the current file to be accessible with system public shared key
-				$owner = $item->getOwner()->getUID();
-				$absPath = '/' . $owner . '/' .  $item->getInternalPath();
-				$accessList = \OC::$server->getEncryptionFilesHelper()->getAccessList($absPath);
-				$accessList['public'] = true;
-				$encryptionManager->getEncryptionModule()->update($absPath, $owner, $accessList);
-			}
-
 			return $this->documentTemplateResponse($wopi, $params);
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage(), ['exception' => $e]);


### PR DESCRIPTION
Fix server side encryption as we actually access the file in the user scope with the system key these days.

This broke with 27 as there has been some changes to how the file keys are managed in https://github.com/nextcloud/server/pull/37243

* Resolves: https://github.com/nextcloud/richdocuments/issues/2996
* Target version: main

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
