### PR TITLE
Fix document target picker and add slide support

### DIFF
--- a/lib/Service/FileTargetService.php
+++ b/lib/Service/FileTargetService.php
@@ -6,6 +6,7 @@ use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\ICacheFactory;
 use OCP\IL10N;
+use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
 
 class FileTargetService {
@@ -16,6 +17,7 @@ class FileTargetService {
 		private IRootFolder $rootFolder,
 		private LoggerInterface $logger,
 		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
 		private ?string $userId,
 	) {
 	}
@@ -64,6 +66,13 @@ class FileTargetService {
 			];
 		}
 
+		if (isset($targets['Slide'])) {
+			$categories['slides'] = [
+				'label' => $this->l10n->t('Slides'),
+				'entries' => $this->mapTargets($filePath, $targets['Slide'], true)
+			];
+		}
+
 		$cache->set($cacheKey, $categories);
 
 		return $categories;
@@ -73,18 +82,22 @@ class FileTargetService {
 		return $this->remoteService->fetchTargetThumbnail($file, $target);
 	}
 
-	private function mapTargets(string $filePath, array $targets): array {
+	private function mapTargets(string $filePath, array $targets, bool $showPreview = false): array {
 		$result = [];
 		foreach ($targets as $name => $identifier) {
-			$result[] = [
+			$targetData = [
 				'id' => $identifier,
 				'name' => $name,
-				// Disable previews for now as they may cause endless requests against Collabora
-				// 'preview' => $this->urlGenerator->linkToOCSRouteAbsolute('richdocuments.Target.getPreview', [
-				// 	'path' => $filePath,
-				// 	'target' => $identifier,
-				// ]),
 			];
+
+			if ($showPreview) {
+				$targetData['preview'] = $this->urlGenerator->linkToOCSRouteAbsolute('richdocuments.Target.getPreview', [
+					'path' => $filePath,
+					'target' => $identifier,
+				]);
+			}
+
+			$result[] = $targetData;
 
 		}
 		return $result;

--- a/src/view/DocumentTargetPicker.vue
+++ b/src/view/DocumentTargetPicker.vue
@@ -201,4 +201,9 @@ h3 {
 	box-shadow: none !important;
 	flex-shrink: 0;
 }
+
+img {
+	max-width: 100px;
+	margin-left: 20px;
+}
 </style>

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -86,7 +86,6 @@ import FilesAppIntegration from './FilesAppIntegration.js'
 import { LOADING_ERROR, checkCollaboraConfiguration, checkProxyStatus } from '../services/collabora.js'
 import { enableScrollLock, disableScrollLock } from '../helpers/safariFixer.js'
 import { getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
-import { showError } from '@nextcloud/dialogs'
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
@@ -136,7 +135,9 @@ export default {
 			loadingTimeout: null,
 			error: null,
 			views: [],
+
 			showZotero: false,
+			showLinkPicker: false,
 		}
 	},
 	computed: {
@@ -227,6 +228,10 @@ export default {
 		},
 		async pickLink() {
 			try {
+				if (this.showLinkPicker) {
+					return
+				}
+				this.showLinkPicker = true
 				const link = await getLinkWithPicker(null, true)
 				try {
 					const url = new URL(link)
@@ -239,8 +244,9 @@ export default {
 				}
 				PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, 'Action_Paste', { Mimetype: 'text/plain', Data: link })
 			} catch (e) {
-				showError(t('richdocuments', 'Failed to get a link with the picker'))
 				console.error('Link picker promise rejected :', e)
+			} finally {
+				this.showLinkPicker = false
 			}
 		},
 		async resolveLink(url) {
@@ -271,7 +277,6 @@ export default {
 					PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, 'Action_GetLinkPreview_Resp', { url, title, image: null })
 				}
 			} catch (e) {
-				showError(t('richdocuments', 'Failed to get the link preview'))
 				console.error('Error resolving a reference', e)
 			}
 		},

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -85,6 +85,10 @@ import PostMessageService from '../services/postMessage.tsx'
 import FilesAppIntegration from './FilesAppIntegration.js'
 import { LOADING_ERROR, checkCollaboraConfiguration, checkProxyStatus } from '../services/collabora.js'
 import { enableScrollLock, disableScrollLock } from '../helpers/safariFixer.js'
+import { getLinkWithPicker } from '@nextcloud/vue/dist/Components/NcRichText.js'
+import { showError } from '@nextcloud/dialogs'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
 const PostMessages = new PostMessageService({
@@ -221,6 +225,56 @@ export default {
 		async share() {
 			FilesAppIntegration.share()
 		},
+		async pickLink() {
+			try {
+				const link = await getLinkWithPicker(null, true)
+				try {
+					const url = new URL(link)
+					if (url.protocol === 'http:' || url.protocol === 'https:') {
+						PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, 'Action_InsertLink', { url: link })
+						return
+					}
+				} catch (e) {
+					console.debug('error when parsing the link picker result')
+				}
+				PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, 'Action_Paste', { Mimetype: 'text/plain', Data: link })
+			} catch (e) {
+				showError(t('richdocuments', 'Failed to get a link with the picker'))
+				console.error('Link picker promise rejected :', e)
+			}
+		},
+		async resolveLink(url) {
+			try {
+				const result = await axios.get(generateOcsUrl('references/resolve', 2), {
+					params: {
+						reference: url,
+					},
+				})
+				const resolvedLink = result.data.ocs.data.references[url]
+				const title = resolvedLink?.openGraphObject?.name
+				const thumbnailUrl = resolvedLink?.openGraphObject?.thumb
+				if (thumbnailUrl) {
+					try {
+						const imageResponse = await axios.get(thumbnailUrl, { responseType: 'blob' })
+						if (imageResponse?.status === 200 && imageResponse?.data) {
+							const reader = new FileReader()
+							reader.addEventListener('loadend', (e) => {
+								const b64Image = e.target.result
+								PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, 'Action_GetLinkPreview_Resp', { url, title, image: b64Image })
+							})
+							reader.readAsDataURL(imageResponse.data)
+						}
+					} catch (e) {
+						console.error('Error loading the reference image', e)
+					}
+				} else {
+					PostMessages.sendWOPIPostMessage(FRAME_DOCUMENT, 'Action_GetLinkPreview_Resp', { url, title, image: null })
+				}
+			} catch (e) {
+				showError(t('richdocuments', 'Failed to get the link preview'))
+				console.error('Error resolving a reference', e)
+			}
+		},
 		close() {
 			FilesAppIntegration.close()
 			disableScrollLock()
@@ -305,6 +359,12 @@ export default {
 				break
 			case 'UI_ZoteroKeyMissing':
 				this.showZotero = true
+				break
+			case 'UI_PickLink':
+				this.pickLink()
+				break
+			case 'Action_GetLinkPreview':
+				this.resolveLink(args.url)
 				break
 			}
 		},


### PR DESCRIPTION
- fix: Expose slides and previews where suitable
- fix: Move link picker and metadata extraction to viewer to act in the user session aware iframe

Fixes https://github.com/nextcloud/richdocuments/issues/3043
Fixes https://github.com/nextcloud/richdocuments/issues/3027 

Picking another document target within Collabora as previously the smart picker was launched in the anonymous iframe without a user session (mostly just moving code around from document.js to the viewer component)

### Screenshot for slide picking

![Screenshot 2023-07-11 at 12 38 01](https://github.com/nextcloud/richdocuments/assets/3404133/64230edb-107d-4c51-9426-aa04c3d5caf9)


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
