### PR TITLE
fix: Create empty files from template if available

### DIFF
--- a/lib/Listener/FileCreatedFromTemplateListener.php
+++ b/lib/Listener/FileCreatedFromTemplateListener.php
@@ -52,6 +52,13 @@ class FileCreatedFromTemplateListener implements IEventListener {
 		// Empty template
 		if ($templateFile === null) {
 			$event->getTarget()->putContent($this->templateManager->getEmptyFileContent($event->getTarget()->getExtension()));
+			$templateType = $this->templateManager->getTemplateTypeForExtension($event->getTarget()->getExtension());
+			$emptyTemplates = $this->templateManager->getEmpty($templateType);
+			$emptyTemplate = array_shift($emptyTemplates);
+			if ($emptyTemplate && $this->templateManager->isSupportedTemplateSource($emptyTemplate->getExtension())) {
+				// Only use TemplateSource if supported filetype
+				$this->templateManager->setTemplateSource($event->getTarget()->getId(), $emptyTemplate->getId());
+			}
 			return;
 		}
 


### PR DESCRIPTION
Before this change empty files were always just created with a copy of the empty documents, which enforced US spell checking. With this we create a file from the present empty template files.

Fixes https://github.com/nextcloud/richdocuments/issues/3029
Fixes https://github.com/nextcloud/richdocuments/issues/2983

Steps to reproduce:
- Change user language to german
- Create a new empty file
- See that the spell checking language of the new document properly adapts

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
