### PR TITLE
fix: Log invalid wopi tokens at info level instead of error

### DIFF
--- a/lib/Middleware/WOPIMiddleware.php
+++ b/lib/Middleware/WOPIMiddleware.php
@@ -30,6 +30,8 @@ namespace OCA\Richdocuments\Middleware;
 use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\Controller\WopiController;
 use OCA\Richdocuments\Db\WopiMapper;
+use OCA\Richdocuments\Exceptions\ExpiredTokenException;
+use OCA\Richdocuments\Exceptions\UnknownTokenException;
 use OCA\Richdocuments\Helper;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
@@ -77,6 +79,13 @@ class WOPIMiddleware extends Middleware {
 			if ((int)$fileId !== $wopi->getFileid() && (int)$fileId !== $wopi->getTemplateId()) {
 				throw new NotPermittedException();
 			}
+		} catch (UnknownTokenException|ExpiredTokenException $e) {
+			if ($this->request->getMethod() === 'POST') {
+				$this->logger->error('Failed to validate WOPI access during save', [ 'exception' => $e ]);
+			} else {
+				$this->logger->info('Invalid token for WOPI access', [ 'exception' => $e ]);
+			}
+			throw new NotPermittedException();
 		} catch (\Exception $e) {
 			$this->logger->error('Failed to validate WOPI access', [ 'exception' => $e ]);
 			throw new NotPermittedException();


### PR DESCRIPTION
This is a quite common case when inactive browser tabs are reconnecting so we should rather log at info than error.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
