### PR TITLE
fix: Disable pdf preview gnerator through Collabora if server already has support for it

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -172,9 +172,11 @@ class Application extends App implements IBootstrap {
 			return $container->get(OpenDocument::class);
 		});
 
-		$previewManager->registerProvider('/application\/pdf/', function () use ($container) {
-			return $container->get(Pdf::class);
-		});
+		if (!$previewManager->isMimeSupported('application/pdf')) {
+			$previewManager->registerProvider('/application\/pdf/', function () use ($container) {
+				return $container->get(Pdf::class);
+			});
+		}
 	}
 
 	public function checkAndEnableCODEServer() {


### PR DESCRIPTION
If the core preview provider for PDF is enabled we don't need to register the one from Collabora which involves additional network transfer and is likely slower due to that.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
