### PR TITLE
bugfix/css colors 23.05

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -85,6 +85,11 @@ const generateCSSVarTokens = () => {
 		// Skip extracting css vars if we cannot access parent
 	}
 
+	const primaryText = window.getComputedStyle(element).getPropertyValue('--color-primary-text')
+	if (primaryText.trim() === '#ffffff') {
+		str += '--nc-dark-primary-invert-if-dark=invert(100%);--nc-dark-primary-invert-if-bright=none;'
+	}
+
 	const customLogo = loadState('richdocuments', 'theming-customLogo', false)
 	if (customLogo) {
 		str += ';--nc-custom-logo=' + window.OCA?.Theming?.cacheBuster ?? 0 + ';'

--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -46,7 +46,7 @@ const getCollaboraTheme = () => {
 const generateCSSVarTokens = () => {
 	/* NC versus COOL */
 	const cssVarMap = {
-		'--color-primary-text': '--co-primary-text',
+		'--color-primary-text': '--co-primary-text:--nc-color-primary-element-text',
 		'--color-primary-element': '--co-primary-element:--co-text-accent',
 		'--color-primary-light': '--co-primary-light',
 		'--color-primary-element-light': '--co-primary-element-light',


### PR DESCRIPTION
Small adjustemts to make stable24 compatible with the new branding color options in Collabora 23.05.

- fix: Pass over relevant variables for 23.05 (fixes text color hover style of menu entries)
- fix: Proper invert colors for dark mode (visible in the sidebar on active icons)