### PR TITLE
[stable24] fix: Provide valid fileList and fileId context on new file action

### DIFF
--- a/src/view/NewFileMenu.js
+++ b/src/view/NewFileMenu.js
@@ -1,5 +1,5 @@
 /*
- * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
+git add  * @copyright Copyright (c) 2020 Julius Härtl <jus@bitgrid.net>
  *
  * @author Julius Härtl <jus@bitgrid.net>
  *
@@ -107,7 +107,8 @@ const NewFileMenu = {
 				fileAction.action(filename, {
 					$file: null,
 					dir: FileList.getCurrentDirectory(),
-					FileList,
+					fileId: fileModel.id,
+					fileList: FileList,
 					fileActions: FileList.fileActions,
 				})
 			} else {


### PR DESCRIPTION
Backport of https://github.com/nextcloud/richdocuments/pull/3114