### PR TITLE
fix: Allow to opt-in loading image mimes on hide download shares

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -24,6 +24,10 @@ class AppConfig {
 
 	public const READ_ONLY_FEATURE_LOCK = 'read_only_feature_lock';
 
+	// Load additional mime types (like images) on public share links when hide download is enabled
+	// Default: 'no', set to 'yes' to enable
+	public const USE_SECURE_VIEW_ADDITIONAL_MIMES = 'use_secure_view_additional_mimes';
+
 	private $defaults = [
 		'wopi_url' => '',
 		'timeout' => 15,
@@ -177,5 +181,9 @@ class AppConfig {
 			return $wopiOverride ?: [];
 		}
 		return [];
+	}
+
+	public function useSecureViewAdditionalMimes(): bool {
+		return $this->config->getAppValue(Application::APPNAME, self::USE_SECURE_VIEW_ADDITIONAL_MIMES, 'no') === 'yes';
 	}
 }

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -73,7 +73,26 @@ class Capabilities implements ICapability {
 		'image/svg+xml',
 		'application/pdf',
 		'text/plain',
-		'text/spreadsheet'
+		'text/spreadsheet',
+	];
+
+	public const SECURE_VIEW_ADDITIONAL_MIMES = [
+		'image/jpeg',
+		'image/svg+xml',
+		'image/cgm',
+		'image/vnd.dxf',
+		'image/x-emf',
+		'image/x-wmf',
+		'image/x-wpg',
+		'image/x-freehand',
+		'image/bmp',
+		'image/png',
+		'image/gif',
+		'image/tiff',
+		'image/jpg',
+		'image/jpeg',
+		'text/plain',
+		'application/pdf',
 	];
 
 	private IL10N $l10n;
@@ -124,6 +143,7 @@ class Capabilities implements ICapability {
 					'version' => \OC::$server->getAppManager()->getAppVersion('richdocuments'),
 					'mimetypes' => array_values($filteredMimetypes),
 					'mimetypesNoDefaultOpen' => array_values($optionalMimetypes),
+					'mimetypesSecureView' => $this->config->useSecureViewAdditionalMimes() ? self::SECURE_VIEW_ADDITIONAL_MIMES : [],
 					'collabora' => $collaboraCapabilities,
 					'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) && $this->config->getAppValue('mobile_editing') ?: false,
 					'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ?: false,

--- a/src/files.js
+++ b/src/files.js
@@ -32,7 +32,7 @@ const odfViewer = {
 		|| (typeof OC.getCapabilities().richdocuments.collabora === 'object' && OC.getCapabilities().richdocuments.collabora.length !== 0)),
 	supportedMimes: OC.getCapabilities().richdocuments.mimetypes.concat(OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen),
 	excludeMimeFromDefaultOpen: OC.getCapabilities().richdocuments.mimetypesNoDefaultOpen,
-	hideDownloadMimes: ['image/jpeg', 'image/svg+xml', 'image/cgm', 'image/vnd.dxf', 'image/x-emf', 'image/x-wmf', 'image/x-wpg', 'image/x-freehand', 'image/bmp', 'image/png', 'image/gif', 'image/tiff', 'image/jpg', 'image/jpeg', 'text/plain', 'application/pdf'],
+	hideDownloadMimes: OC.getCapabilities().richdocuments.mimetypesSecureView,
 
 	onEdit(fileName, context) {
 		let fileDir


### PR DESCRIPTION
- fix: Allow to opt-in loading image mimes on hide download shares
- chore: Cleanup capabilities code

```
occ config:app:set richdocuments use_secure_view_additional_mimes --value=yes
```


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
