### PR TITLE
fix: Use userId as a fallback for new file creation token

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -460,7 +460,7 @@ class DocumentController extends Controller {
 		// Pass through $version
 		$templateFile = $this->templateManager->getTemplateSource($file->getId());
 		if ($templateFile) {
-			return $this->tokenManager->generateWopiTokenForTemplate($templateFile, $share?->getShareOwner(), $file->getId());
+			return $this->tokenManager->generateWopiTokenForTemplate($templateFile, $share?->getShareOwner() ?? $this->userId, $file->getId());
 		}
 
 		return  $this->tokenManager->generateWopiToken($this->getWopiFileId($file->getId(), $version), $share?->getToken(), $this->userId);


### PR DESCRIPTION
Follow up fix to https://github.com/nextcloud/richdocuments/pull/3152


Found in https://github.com/nextcloud/richdocuments/pull/3172 as main currently doesn't have file creation due to the ongoing f2v migration.