### PR TITLE
fix: Mobile support shall be enabled by default

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -149,7 +149,7 @@ class Capabilities implements ICapability {
 					'mimetypesNoDefaultOpen' => array_values($optionalMimetypes),
 					'mimetypesSecureView' => $this->config->useSecureViewAdditionalMimes() ? self::SECURE_VIEW_ADDITIONAL_MIMES : [],
 					'collabora' => $collaboraCapabilities,
-					'direct_editing' => ($collaboraCapabilities['hasMobileSupport'] ?? false) && $this->config->getAppValue('mobile_editing') ?: false,
+					'direct_editing' => ($collaboraCapabilities['hasMobileSupport'] ?? false) && $this->config->getAppValue('mobile_editing', 'yes') === 'yes',
 					'templates' => ($collaboraCapabilities['hasTemplateSaveAs'] ?? false) || ($collaboraCapabilities['hasTemplateSource'] ?? false),
 					'productName' => $this->capabilitiesService->getProductName(),
 					'editonline_endpoint' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.document.editOnline'),


### PR DESCRIPTION
Seems we broke the default with #3141 

Now it compares against the default of 'yes' which does not evaluate to false by default.

To disable one can use:
```
occ config:app:set richdocuments mobile_editing --value="no"
```