### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "8999be903f6fa719dc26394ce1022f1bff11ae0e"
+                "reference": "5abffee6a1ce4252148ff64d85ef1164e5ea6df2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8999be903f6fa719dc26394ce1022f1bff11ae0e",
-                "reference": "8999be903f6fa719dc26394ce1022f1bff11ae0e",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5abffee6a1ce4252148ff64d85ef1164e5ea6df2",
+                "reference": "5abffee6a1ce4252148ff64d85ef1164e5ea6df2",
                 "shasum": ""
             },
             "require": {
@@ -273,7 +273,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-09-12T00:29:25+00:00"
+            "time": "2023-10-07T00:30:40+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency