### PR TITLE
[stable27] fix: Mobile support shall be enabled by default

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -125,7 +125,7 @@ class Capabilities implements ICapability {
 					'mimetypes' => array_values($filteredMimetypes),
 					'mimetypesNoDefaultOpen' => array_values($optionalMimetypes),
 					'collabora' => $collaboraCapabilities,
-					'direct_editing' => isset($collaboraCapabilities['hasMobileSupport']) && $this->config->getAppValue('mobile_editing') ?: false,
+					'direct_editing' => ($collaboraCapabilities['hasMobileSupport'] ?? false) && $this->config->getAppValue('mobile_editing', 'yes') === 'yes',
 					'templates' => isset($collaboraCapabilities['hasTemplateSaveAs']) || isset($collaboraCapabilities['hasTemplateSource']) ?: false,
 					'productName' => $this->capabilitiesService->getProductName(),
 					'editonline_endpoint' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.document.editOnline'),


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/richdocuments/pull/3184 to stable27