### PR TITLE
[stable26] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -741,12 +741,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c2f4514e717e60c492c4d62031bd84a0cabde52c"
+                "reference": "e190b8f76e21b46d921f61883b88f18ca4e7b8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c2f4514e717e60c492c4d62031bd84a0cabde52c",
-                "reference": "c2f4514e717e60c492c4d62031bd84a0cabde52c",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e190b8f76e21b46d921f61883b88f18ca4e7b8a1",
+                "reference": "e190b8f76e21b46d921f61883b88f18ca4e7b8a1",
                 "shasum": ""
             },
             "require": {
@@ -776,7 +776,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable26"
             },
-            "time": "2023-09-06T00:30:37+00:00"
+            "time": "2023-10-04T09:19:39+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency