### PR TITLE
added new 'Error_Messages' postmessage

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -312,6 +312,14 @@ export default {
 				} else if (args.Status === 'Failed') {
 					this.loading = LOADING_STATE.FAILED
 					this.$emit('update:loaded', true)
+				} else if (args.Status === 'Initialized') {
+					// collabora iframe is ready to handle postMessages
+					this.sendPostMessage('Error_Messages', {
+						websocketconnectionfailed: {
+							msg: t('richdocuments', 'Failed to load {productName} - socket connection closed unexpectedly. The reverse proxy might be misconfigured, please contact the administrator. For more info on proxy configuration please checkout', { productName: loadState('richdocuments', 'productName', 'Nextcloud Office') }) + ' %url',
+							url: 'https://docs.nextcloud.com/server/latest/admin_manual/office/proxy.html',
+						},
+					})
 				}
 				break
 			case 'Action_Load_Resp':


### PR DESCRIPTION
- so that collbora online can show a custom with nextcloud documentation link

### TODO

- [x] Requires https://github.com/CollaboraOnline/online/pull/7375
- [ ] https://github.com/CollaboraOnline/online/issues/7709
- [ ] Only display additional docs hint for admins
- [ ] Test different scenarios where connection does not work (see admin messages in https://github.com/nextcloud/richdocuments/pull/3315)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
