### PR TITLE
[stable27] fix: Update file metadata only if file was changed

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -86,8 +86,6 @@ export default {
 			return
 		}
 
-		this.updateFileInfo(undefined, Date.now())
-
 		this.fileModel = null
 		$('#richdocuments-header').remove()
 	},

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -157,6 +157,7 @@ export default {
 
 			showLinkPicker: false,
 			showZotero: false,
+			modified: false,
 
 			formData: {
 				action: null,
@@ -281,6 +282,9 @@ export default {
 		},
 		close() {
 			FilesAppIntegration.close()
+			if (this.modified) {
+				FilesAppIntegration.updateFileInfo(undefined, Date.now())
+			}
 			disableScrollLock()
 			this.$parent.close()
 		},
@@ -371,8 +375,19 @@ export default {
 			case 'Action_GetLinkPreview':
 				this.resolveLink(args.url)
 				break
+			case 'Action_Save':
+				if (this.modified) {
+					FilesAppIntegration.updateFileInfo(undefined, Date.now())
+				}
+				break
 			case 'Clicked_Button':
 				this.buttonClicked(args)
+				break
+			case 'Doc_ModifiedStatus':
+				if (args.Modified !== this.modified) {
+					FilesAppIntegration.updateFileInfo(undefined, Date.now())
+				}
+				this.modified = args.Modified
 				break
 			}
 		},


### PR DESCRIPTION
Track the state of the document modification status through the incoming post messages to make sure that we only update the mtime displayed in the file list if the file was actually changed.