### PR TITLE
Revert "Chore(deps-dev): Bump cypress from 13.3.0 to 13.3.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@nextcloud/stylelint-config": "^2.3.1",
         "@nextcloud/webpack-vue-config": "^6.0.0",
         "babel-loader-exclude-node-modules-except": "^1.2.1",
-        "cypress": "^13.3.1",
+        "cypress": "^13.3.0",
         "eslint-plugin-cypress": "^2.15.1",
         "ts-loader": "^9.5.0",
         "typescript": "^4.9.5"
@@ -7131,9 +7131,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/cypress": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.1.tgz",
-      "integrity": "sha512-g4mJLZxYN+UAF2LMy3Znd4LBnUmS59Vynd81VES59RdW48Yt+QtR2cush3melOoVNz0PPbADpWr8DcUx6mif8Q==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.0.tgz",
+      "integrity": "sha512-mpI8qcTwLGiA4zEQvTC/U1xGUezVV4V8HQCOYjlEOrVmU1etVvxOjkCXHGwrlYdZU/EPmUiWfsO3yt1o+Q2bgw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -24570,9 +24570,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "cypress": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.1.tgz",
-      "integrity": "sha512-g4mJLZxYN+UAF2LMy3Znd4LBnUmS59Vynd81VES59RdW48Yt+QtR2cush3melOoVNz0PPbADpWr8DcUx6mif8Q==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.3.0.tgz",
+      "integrity": "sha512-mpI8qcTwLGiA4zEQvTC/U1xGUezVV4V8HQCOYjlEOrVmU1etVvxOjkCXHGwrlYdZU/EPmUiWfsO3yt1o+Q2bgw==",
       "dev": true,
       "requires": {
         "@cypress/request": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@nextcloud/stylelint-config": "^2.3.1",
     "@nextcloud/webpack-vue-config": "^6.0.0",
     "babel-loader-exclude-node-modules-except": "^1.2.1",
-    "cypress": "^13.3.1",
+    "cypress": "^13.3.0",
     "eslint-plugin-cypress": "^2.15.1",
     "ts-loader": "^9.5.0",
     "typescript": "^4.9.5"


### PR DESCRIPTION
Reverts nextcloud/richdocuments#3225

Seems to cause endless runs of cypress on CI