### PR TITLE
Improve logging for WOPI Parser

### DIFF
--- a/lib/WOPI/Parser.php
+++ b/lib/WOPI/Parser.php
@@ -21,15 +21,22 @@
 
 namespace OCA\Richdocuments\WOPI;
 
+use Psr\Log\LoggerInterface;
+
 class Parser {
 	/** @var DiscoveryManager */
 	private $discoveryManager;
 
+	/** @var LoggerInterface */
+	private $logger;
+
 	/**
 	 * @param DiscoveryManager $discoveryManager
+	 * @param LoggerInterface $logger
 	 */
-	public function __construct(DiscoveryManager $discoveryManager) {
+	public function __construct(DiscoveryManager $discoveryManager, LoggerInterface $logger) {
 		$this->discoveryManager = $discoveryManager;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -39,6 +46,7 @@ class Parser {
 	 */
 	public function getUrlSrc($mimetype) {
 		$discovery = $this->discoveryManager->get();
+		$this->logger->debug('WOPI::getUrlSrc discovery: {discovery}', ['discovery' => $discovery]);
 		if (\PHP_VERSION_ID < 80000) {
 			$loadEntities = libxml_disable_entity_loader(true);
 			$discoveryParsed = simplexml_load_string($discovery);
@@ -56,6 +64,7 @@ class Parser {
 			];
 		}
 
+		$this->logger->warning('Didn\'t find urlsrc for mimetype {mimetype} in this WOPI discovery response: {discovery}', ['mimetype' => $mimetype, 'discovery' => $discovery]);
 		throw new \Exception('Could not find urlsrc in WOPI');
 	}
 }


### PR DESCRIPTION
* Helps to find errors related to https://github.com/nextcloud/richdocuments/issues/3080 (see also https://github.com/CollaboraOnline/richdocumentscode/issues/119#issuecomment-1774850066)
* Target version: main

### Summary

Improve logging to be able to troubleshoot problems with WOPI discovery. If an admin sees a message like this in the logs:

```
[richdocuments] Error: Exception: Could not find urlsrc in WOPI
```

this usually means, that the WOPI discovery response was faulty.

A valid discovery response, which is received [here](https://github.com/nextcloud/richdocuments/blob/11a0387687dc0c8bd6d3c129641a3a56a5101800/lib/WOPI/Parser.php#L41), looks like this:

```xml
<wopi-discovery>
    <net-zone name="external-http">
        <app name="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">
            <action default="true" ext="" name="edit" urlsrc="https://<NC_URL>/custom_apps/richdocumentscode/proxy.php?req=/browser/<TOKEN>/cool.html?"/>
        </app>
        <!-- Many more app entries ...-->
    </net-zone>
</wopi-discovery>
```

Im my case (because of some backend server error) the response was:

```html
<html><body>
<h1>Socket proxy error</h1>
<p>Error: Timed out opening local socket: 99 - Cannot assign requested address</p>
</body></html>
```

but I wasn't able to see this message until I added the logging lines of this PR.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
