### PR TITLE
fix: Clear loading timeout when guest name is asked

### DIFF
--- a/src/files.js
+++ b/src/files.js
@@ -266,6 +266,9 @@ addEventListener('DOMContentLoaded', () => {
 		if (deprecated) { return }
 
 		switch (msgId) {
+		case 'NC_ShowNamePicker':
+			clearTimeout(odfViewer.loadingTimeout)
+			break
 		case 'loading':
 			odfViewer.onReceiveLoading()
 			break


### PR DESCRIPTION
Steps to reproduce:
- Share an office file as link with edit rights
- Open the link in a private browser

Without this change the iframe disappears after the loading timeout and the users might miss the chance to enter their name

This is an richdocuments internal post message that is emitted by document.js when the guest name picker is shown