### PR TITLE
fix: Emit warning instead of info when WOIP request is denied

### DIFF
--- a/lib/Middleware/WOPIMiddleware.php
+++ b/lib/Middleware/WOPIMiddleware.php
@@ -112,7 +112,7 @@ class WOPIMiddleware extends Middleware {
 			return true;
 		}
 
-		$this->logger->info('WOPI request denied from ' . $userIp . ' as it does not match the configured ranges: ' . implode(', ', $allowedRanges));
+		$this->logger->warning('WOPI request denied from ' . $userIp . ' as it does not match the configured ranges: ' . implode(', ', $allowedRanges));
 		return false;
 	}
 }


### PR DESCRIPTION



* Related to: #2685
* Target version: main

### Summary

As discussed in #2685 the message s quite important when trying to fix WOIP issues. The reasoning is that something fails from the perspective of an admin and it should emit a warning.
Ofc. one could argue that the deny is expected behavior and should therefore emit only an info. Yet I believe that it'd be beneficial overall to consider admins that struggle to correctly set this up in that case.

### TODO


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
