### PR TITLE
fix: Set expect guzzle option to false

### DIFF
--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -78,7 +78,11 @@ abstract class Office extends Provider {
 		}
 
 		$client = $this->clientService->newClient();
-		$options = ['timeout' => 25];
+		$options = [
+			'timeout' => 25,
+			// FIXME: Can be removed once https://github.com/CollaboraOnline/online/issues/6983 is fixed upstream
+			'expect' => false,
+		];
 
 		if ($this->config->getAppValue('richdocuments', 'disable_certificate_verification') === 'yes') {
 			$options['verify'] = false;


### PR DESCRIPTION
This option can be removed once Collabora Online has proper support for
the Expect: 100-Continue header - until then this will avoid issues with
larger file previews.

https://docs.guzzlephp.org/en/stable/request-options.html#expect

* Resolves: https://github.com/nextcloud/richdocuments/issues/3089

