### PR TITLE
feat: add preview provider for emf files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 		"lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",
 		"psalm": "psalm.phar",
 		"psalm:fix": "psalm.phar --alter --issues=InvalidReturnType,InvalidNullableReturnType,MismatchingDocblockParamType,MismatchingDocblockReturnType,MissingParamType,InvalidFalsableReturnType",
+		"psalm:update-baseline": "psalm.phar --threads=1 --update-baseline --set-baseline=tests/psalm-baseline.xml",
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
 		"test:unit": "vendor/bin/phpunit -c tests/phpunit.xml"

--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -52,6 +52,7 @@ return array(
     'OCA\\Richdocuments\\Migration\\Version30717Date20210310164901' => $baseDir . '/../lib/Migration/Version30717Date20210310164901.php',
     'OCA\\Richdocuments\\Migration\\Version50200Date20211220212457' => $baseDir . '/../lib/Migration/Version50200Date20211220212457.php',
     'OCA\\Richdocuments\\PermissionManager' => $baseDir . '/../lib/PermissionManager.php',
+    'OCA\\Richdocuments\\Preview\\EMF' => $baseDir . '/../lib/Preview/EMF.php',
     'OCA\\Richdocuments\\Preview\\MSExcel' => $baseDir . '/../lib/Preview/MSExcel.php',
     'OCA\\Richdocuments\\Preview\\MSWord' => $baseDir . '/../lib/Preview/MSWord.php',
     'OCA\\Richdocuments\\Preview\\OOXML' => $baseDir . '/../lib/Preview/OOXML.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -67,6 +67,7 @@ class ComposerStaticInitRichdocuments
         'OCA\\Richdocuments\\Migration\\Version30717Date20210310164901' => __DIR__ . '/..' . '/../lib/Migration/Version30717Date20210310164901.php',
         'OCA\\Richdocuments\\Migration\\Version50200Date20211220212457' => __DIR__ . '/..' . '/../lib/Migration/Version50200Date20211220212457.php',
         'OCA\\Richdocuments\\PermissionManager' => __DIR__ . '/..' . '/../lib/PermissionManager.php',
+        'OCA\\Richdocuments\\Preview\\EMF' => __DIR__ . '/..' . '/../lib/Preview/EMF.php',
         'OCA\\Richdocuments\\Preview\\MSExcel' => __DIR__ . '/..' . '/../lib/Preview/MSExcel.php',
         'OCA\\Richdocuments\\Preview\\MSWord' => __DIR__ . '/..' . '/../lib/Preview/MSWord.php',
         'OCA\\Richdocuments\\Preview\\OOXML' => __DIR__ . '/..' . '/../lib/Preview/OOXML.php',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -37,6 +37,7 @@ use OCA\Richdocuments\Listener\ReferenceListener;
 use OCA\Richdocuments\Listener\ShareLinkListener;
 use OCA\Richdocuments\Middleware\WOPIMiddleware;
 use OCA\Richdocuments\PermissionManager;
+use OCA\Richdocuments\Preview\EMF;
 use OCA\Richdocuments\Preview\MSExcel;
 use OCA\Richdocuments\Preview\MSWord;
 use OCA\Richdocuments\Preview\OOXML;
@@ -173,6 +174,10 @@ class Application extends App implements IBootstrap {
 
 		$previewManager->registerProvider('/application\/vnd.oasis.opendocument.*/', function () use ($container) {
 			return $container->get(OpenDocument::class);
+		});
+
+		$previewManager->registerProvider('/image\/emf/', function () use ($container) {
+			return $container->get(EMF::class);
 		});
 
 		if (!$previewManager->isMimeSupported('application/pdf')) {

--- a/lib/Preview/EMF.php
+++ b/lib/Preview/EMF.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @author Daniel Kesselberg <mail@danielkesselberg.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Richdocuments\Preview;
+
+class EMF extends Office {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMimeType() {
+		return '/image\/emf/';
+	}
+}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -10,6 +10,7 @@
   </file>
   <file src="lib/AppInfo/Application.php">
     <MissingDependency>
+      <code>EMF</code>
       <code>MSExcel</code>
       <code>MSWord</code>
       <code>OOXML</code>
@@ -47,7 +48,7 @@
       <code><![CDATA[$node->getId()]]></code>
     </InvalidScalarArgument>
     <RedundantCondition>
-      <code>$app !== ''</code>
+      <code><![CDATA[$app !== '']]></code>
     </RedundantCondition>
   </file>
   <file src="lib/Controller/TemplatesController.php">
@@ -66,7 +67,7 @@
       <code>null</code>
     </NullArgument>
     <TypeDoesNotContainType>
-      <code>$path === ''</code>
+      <code><![CDATA[$path === '']]></code>
     </TypeDoesNotContainType>
     <UndefinedInterfaceMethod>
       <code>putContent</code>
@@ -82,6 +83,11 @@
     <RedundantCondition>
       <code><![CDATA[$share && method_exists($share, 'getAttributes')]]></code>
     </RedundantCondition>
+  </file>
+  <file src="lib/Preview/EMF.php">
+    <MissingDependency>
+      <code>Office</code>
+    </MissingDependency>
   </file>
   <file src="lib/Preview/MSExcel.php">
     <MissingDependency>


### PR DESCRIPTION
* Target version: main

### Summary

For https://github.com/nextcloud/files_emfviewer/issues/1
In addition to https://github.com/nextcloud/server/pull/41395

We added support for image/emf via LibreOffice for 28. 

For setups already using Richdocuments/Collabora it's nicer to let the previews generate via collabora web and no local LibreOffice installation is required. 

### TODO

- [x] CI
- [ ] Test
- [ ] Documentation


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
