### PR TITLE
[stable27] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f2efa5d9d620b194cda6a6698447a2dad451a7a3"
+                "reference": "4b22dae0cacc0e776d4cb83aa4c3b54fea99794a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f2efa5d9d620b194cda6a6698447a2dad451a7a3",
-                "reference": "f2efa5d9d620b194cda6a6698447a2dad451a7a3",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4b22dae0cacc0e776d4cb83aa4c3b54fea99794a",
+                "reference": "4b22dae0cacc0e776d4cb83aa4c3b54fea99794a",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable27"
             },
-            "time": "2023-11-11T00:31:29+00:00"
+            "time": "2023-11-17T00:33:22+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency