### PR TITLE
Do not hide speadsheet statusbar by default

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -39,7 +39,7 @@ const getUIDefaults = () => {
 	let uiDefaults = 'TextRuler=' + textRuler + ';'
 	uiDefaults += 'TextSidebar=' + sidebar + ';TextStatusbar=' + statusBar + ';'
 	uiDefaults += 'PresentationSidebar=' + sidebar + ';PresentationStatusbar=' + statusBar + ';'
-	uiDefaults += 'SpreadsheetSidebar=' + sidebar + ';SpreadsheetStatusbar=' + statusBar + ';'
+	uiDefaults += 'SpreadsheetSidebar=' + sidebar + ';SpreadsheetStatusbar=true;'
 	uiDefaults += 'UIMode=' + uiMode + ';'
 	uiDefaults += 'UITheme=' + uiTheme + ';'
 	uiDefaults += 'SaveAsMode=' + saveAsMode + ';'


### PR DESCRIPTION
Status bar is crucial for productivity tool (specially when it comes
to office suites and in specific spreadsheets).

Context, this is a regression from:
- https://github.com/nextcloud/richdocuments/pull/2059
- fabed162ea07ac27c031f288f0fab6f027badf78

Even if,  and as noted in
https://github.com/nextcloud/richdocuments/pull/2053#issuecomment-1044371555,
the status bar was still being hidden for safari I think it's best to
don't break the spreadsheet experience for every browser. On top of
that I think the richdocuments frame suffer some changes and that
safari issue might not be present anymore.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
