### PR TITLE
Fix opening file after rename in COOL

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -150,9 +150,9 @@ export default {
 	},
 
 	rename(newName) {
-		this.updateFileInfo(newName, Date.now())
+		this.updateFileInfo(decodeURIComponent(newName), Date.now())
 
-		this.fileName = newName
+		this.fileName = decodeURIComponent(newName)
 
 		if (this.handlers.rename && this.handlers.rename(this)) {
 			return


### PR DESCRIPTION
There is a bug which happens after renaming a file inside Collabora Online (using fiels on the headerbar).

1. Open any document
2. Rename it so it will contain spaces
3. Close document
4. Try to open renamed document from the list Result: error, cannot find file

Notice that name was encoded so space become %20.
If you look at requests - the name of a file become encoded second time in one of them so it failed.
eg. file '1 1.odt' after rename does request:
http://192.168.0.108/remote.php/dav/files/admin/1%25201.odt

In Nextcloud 27 visible name doesn't contain %20 but still doesn't work.
