### PR TITLE
fix: Make rename update the file list properly on files2vue

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -506,6 +506,10 @@ export default {
 		const node = await this.getFileNode()
 
 		if (node) {
+			if (name) {
+				node.rename(name)
+				emit('files:node:renamed', this.source)
+			}
 			if (mtime) {
 				node._data.mtime = new Date(mtime)
 			}

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -356,7 +356,7 @@ export default {
 				FilesAppIntegration.createNewFile(args.DocumentType)
 				break
 			case 'File_Rename':
-				FilesAppIntegration.rename(args.NewName)
+				FilesAppIntegration.rename(decodeURIComponent(args.NewName))
 				break
 			case 'UI_FileVersions':
 				FilesAppIntegration.showRevHistory()


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/3344
* Target version: main

### Summary

@eszkadev I've wondered a bit why the post message content would actually be url encoded, I don't think there is a real need, on the other hand it is proably easier adjusting here then in online which could be considered a breaking change.

Also the File_Rename post message does not seem to be documented at https://sdk.collaboraonline.com/docs/postmessage_api.html