### PR TITLE
fix: mention popup reappears after inserting the mention

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -350,7 +350,9 @@ export default {
 				})
 				break
 			case 'UI_Mention':
-				this.uiMention(parsed.args.text)
+				if (parsed.args.type === 'autocomplete') {
+					this.uiMention(parsed.args.text)
+				}
 				break
 			case 'UI_CreateFile':
 				FilesAppIntegration.createNewFile(args.DocumentType)


### PR DESCRIPTION
- when COOL inserts the mention it sends 'UI_Mention' with 'type: selected', we don't want to send 'Action_Mention' for 'selected' type


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
