### PR TITLE
fix: Avoid 3px offset on public share links

### DIFF
--- a/css/files.scss
+++ b/css/files.scss
@@ -21,10 +21,10 @@
 #richdocumentsframe {
 	background-color: #fff;
 	width:100%;
-	height: calc(100vh - 50px + 3px);
+	height: 100vh;
 	display:block;
 	position:absolute;
-	top: -3px;
+	top: 0px;
 	left: 0;
 	z-index:110;
 	&.full {


### PR DESCRIPTION
Avoid that the background page is shining through at the bottom of public share links