### PR TITLE
fix: Consider owner group membership for public share links

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -105,11 +105,11 @@ class TokenManager {
 				throw new ShareNotFound();
 			}
 
-			$updatable = (bool)($share->getPermissions() & \OCP\Constants::PERMISSION_UPDATE);
-			$hideDownload = $share->getHideDownload();
 			$owneruid = $share->getShareOwner();
+			$updatable = (bool)($share->getPermissions() & \OCP\Constants::PERMISSION_UPDATE);
+			$updatable = $updatable && $this->permissionManager->userCanEdit($owneruid);
+			$hideDownload = $share->getHideDownload();
 			$rootFolder = $this->rootFolder->getUserFolder($owneruid);
-
 		} elseif ($this->userId !== null) {
 			try {
 				$editoruid = $this->userId;


### PR DESCRIPTION
Fix #3358 

Make sure that restrictions to limit editing to certain groups also applies to share links where the group membership of the owner is taken into account.