### PR TITLE
enh(Issue_Template) Request richdocuments config in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -42,6 +42,10 @@ If applicable, add screenshots to help explain your problem.
 
 **Version of Collabora Online**
 
+**Configuration of the richdocuments app**
+```
+Insert the output of `./occ config:list richdocuments` (or equivalent adapted for your runtime environment)
+```
 
 <details>
 <summary>Logs</summary>


### PR DESCRIPTION
The configuration is often needed to reproduce, isolate, or troubleshoot bug reports.

* Resolves: (does so much as resolve as make processing of all inbound bug report more efficient)
* Target version: main

### Summary

* Cut down on need to manually request configuration from reporters
* Make triaging a bit more efficient

### TODO

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
