### PR TITLE
test(ci): use only 3 runners for cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16.x]
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2, 3]
         php-versions: [ '8.0' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'master' ]


### PR DESCRIPTION
### More runners do not help as `open.spec.js` runs so long.

![grafik](https://github.com/nextcloud/richdocuments/assets/97337118/dae67607-b299-4d70-b523-3f8cc4421826)

### On the contrary - more runners increase the risk that a runner gets stuck when starting:

![grafik](https://github.com/nextcloud/richdocuments/assets/97337118/bf312cfd-3347-4378-972f-9eb8a09fdc05)

### This runner attempted to download cypress for more than one hour.

![grafik](https://github.com/nextcloud/richdocuments/assets/97337118/1ac8fbc8-c4e6-4cce-b927-ab4430ddca12)
