### PR TITLE
test(ci): use only 3 runners for cypress

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16.x]
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2, 3]
         php-versions: [ '8.0' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'stable28' ]


### PR DESCRIPTION
More runners do not help as `open.spec.js` runs so long.

* Backports #3410 
