### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b7856e08cee00963906f367286763515878cbd83"
+                "reference": "ef30cb8584a788bf01916ab00c39303e5f58f260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b7856e08cee00963906f367286763515878cbd83",
-                "reference": "b7856e08cee00963906f367286763515878cbd83",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ef30cb8584a788bf01916ab00c39303e5f58f260",
+                "reference": "ef30cb8584a788bf01916ab00c39303e5f58f260",
                 "shasum": ""
             },
             "require": {
@@ -273,7 +273,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2023-12-23T00:31:42+00:00"
+            "time": "2024-01-12T00:34:25+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency