### PR TITLE
fix #3209 collabora open when nextcloud is in a iframe

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -31,9 +31,9 @@ const getUIDefaults = () => {
 	const uiMode = defaults.UIMode ?? 'notebookbar' // or notebookbar
 
 	const systemDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-	// FIXME For now we need to access parent here as the public page loaded for collabora doesn't have the user theme
-	const nextcloudDarkMode = parent.document.body.dataset.themeDark === '' || parent.document.body.dataset.themeDarkHighcontrast === ''
-	const matchedDarkMode = parent.document.body.dataset.themeDefault === '' ? systemDarkMode : nextcloudDarkMode
+	const dataSet = document.body.dataset?.themeDark ? document.body.dataset : parent.document.body.dataset
+	const nextcloudDarkMode = dataset?.themeDark === '' || dataset?.themeDarkHighcontrast === ''
+	const matchedDarkMode = dataset?.themeDefault === '' ? systemDarkMode : nextcloudDarkMode
 	const uiTheme = matchedDarkMode ? 'dark' : 'light'
 
 	let uiDefaults = 'TextRuler=' + textRuler + ';'


### PR DESCRIPTION
* Resolves: #3209
* Target version: main

### Summary
collabora open when nextcloud is in a iframe

### Checklist

- [x] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
