### PR TITLE
fix: Run move in lock scope of the user

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -589,7 +589,13 @@ class WopiController extends Controller {
 
 				// create a unique new file
 				$path = $this->rootFolder->getNonExistingName($path);
-				$file = $file->move($path);
+				$this->lockManager->runInScope(new LockContext(
+					$this->getFileForWopiToken($wopi),
+					ILock::TYPE_APP,
+					Application::APPNAME
+				), function () use (&$file, $path) {
+					$file = $file->move($path);
+				});
 			} else {
 				$file = $this->getFileForWopiToken($wopi);
 


### PR DESCRIPTION
Otherwise the move could fail if the files_lock app is enabled