### PR TITLE
fix: Drop use of deprecated jquery load

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -365,7 +365,7 @@ const documentsMain = {
 				}, 45000)
 			})
 
-			$('#loleafletframe').load(function() {
+			$('#loleafletframe').on('load', function() {
 				const ViewerToLool = [
 					'Action_FollowUser',
 					'Host_VersionRestore',


### PR DESCRIPTION
Should make cypress pass again on main due to https://github.com/nextcloud/server/pull/43469

We should get rid of all of that jquery stuff of course but this fixes the regression breaking some file opening scenarios and makes CI passing again.