### PR TITLE
fix: emit allow attribute on iframe for the clipboard (fixes #3474)

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -78,6 +78,7 @@
 			data-cy="coolframe"
 			scrolling="no"
 			allowfullscreen
+			allow="clipboard-read *; clipboard-write *"
 			class="office-viewer__iframe"
 			:style="{visibility: showIframe ? 'visible' : 'hidden' }"
 			:src="iframeSrc" />


### PR DESCRIPTION
As described at
<https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes> newer Chrome requires explicit markup for code in an iframe to execute JS that requires permissions, like clipboard.

If this markup is missing, then the user won't be even asked.  Use the wildcard syntax, because the COOL JS code in the iframe is not the initial src attribute value of the iframe, it gets changed later.

With this, a permission popup on paste shows up in Chrome even if the paste is perssed on the notebookbar, even if nextcloud is served from one domain and COOL is served from an other domain.

This fixes the document edit case; possibly it should be also added at all other places where the allowfullscreen attribute is used, which is not done in this commit.


* Resolves: #3474