### PR TITLE
Fix open locally with files lock and wopi allow list

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -77,6 +77,7 @@ return [
 	'ocs' => [
 		// Public pages: new file creation
 		['name' => 'documentAPI#create', 'url' => '/api/v1/file', 'verb' => 'POST'],
+		['name' => 'documentAPI#openLocal', 'url' => '/api/v1/local', 'verb' => 'POST'],
 
 		// Client API endpoints
 		['name' => 'OCS#createDirect', 'url' => '/api/v1/document', 'verb' => 'POST'],

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -105,5 +105,7 @@ class InitialStateService {
 		$this->initialState->provideInitialState('theming-customLogo', ($logoSet ?
 			$this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo())
 			: false));
+
+		$this->initialState->provideInitialState('open_local_editor', $this->config->getAppValue(Application::APPNAME, 'open_local_editor', 'yes') === 'yes');
 	}
 }

--- a/src/mixins/openLocal.js
+++ b/src/mixins/openLocal.js
@@ -23,7 +23,7 @@ import { getCurrentUser } from '@nextcloud/auth'
 import axios from '@nextcloud/axios'
 import { spawnDialog } from '@nextcloud/dialogs'
 import { encodePath } from '@nextcloud/paths'
-import { getRootUrl, generateOcsUrl } from '@nextcloud/router'
+import { generateOcsUrl } from '@nextcloud/router'
 import { getNextcloudUrl } from '../helpers/url.js'
 import Confirmation from '../components/Modal/Confirmation.vue'
 
@@ -93,11 +93,7 @@ export default {
 		},
 
 		unlockFile() {
-			const unlockUrl = getRootUrl() + '/index.php/apps/richdocuments/wopi/files/' + this.fileid
-			const unlockConfig = {
-				headers: { 'X-WOPI-Override': 'UNLOCK' },
-			}
-			return axios.post(unlockUrl, { access_token: this.formData.accessToken }, unlockConfig)
+			return axios.post(generateOcsUrl('apps/richdocuments/api/v1/local'), { fileId: this.fileid })
 		},
 
 		openLocally() {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -306,14 +306,16 @@ export default {
 			this.loading = LOADING_STATE.DOCUMENT_READY
 			clearTimeout(this.loadingTimeout)
 			this.sendPostMessage('Host_PostmessageReady')
-			this.sendPostMessage('Insert_Button', {
-				id: 'Open_Local_Editor',
-				imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
-				mobile: false,
-				label: t('richdocuments', 'Open in local editor'),
-				hint: t('richdocuments', 'Open in local editor'),
-				insertBefore: 'print',
-			})
+			if (loadState('richdocuments', 'open_local_editor', true)) {
+				this.sendPostMessage('Insert_Button', {
+					id: 'Open_Local_Editor',
+					imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
+					mobile: false,
+					label: t('richdocuments', 'Open in local editor'),
+					hint: t('richdocuments', 'Open in local editor'),
+					insertBefore: 'print',
+				})
+			}
 		},
 		async share() {
 			FilesAppIntegration.share()


### PR DESCRIPTION
- fix: Add config option to disable edit locally
- fix: Allow to unlock through separate endpoint for edit locally

Fix https://github.com/nextcloud/richdocuments/issues/3487
Fix https://github.com/nextcloud/richdocuments/issues/3299

### Summary

We add a config value for disabling but also address that unlocking the file was no longer working with a WOPI allow list. We now move this to a separate endpoint to handle any prepare steps we need to do before moving to the local editor.

In a second iteration we can further extend this to update the other views to read only or notify them through Collabora.