### PR TITLE
fix: Properly use input model in settings text fields

### DIFF
--- a/src/components/SettingsInputText.vue
+++ b/src/components/SettingsInputText.vue
@@ -21,18 +21,17 @@
   -->
 
 <template>
-	<form @submit.prevent="">
+	<form @submit.prevent="submit">
 		<div class="input-wrapper">
 			<label :for="id">{{ label }}</label>
 			<input :id="id"
+				v-model="inputVal"
 				type="text"
-				:value="inputVal"
 				:disabled="disabled"
 				@input="$emit('input', $event.target.value)">
 			<input type="submit"
 				class="icon-confirm"
-				value=""
-				@click="$emit('update', inputVal)">
+				value="">
 		</div>
 		<p v-if="hint !== ''" class="hint">
 			{{ hint }}
@@ -74,12 +73,17 @@ export default {
 	},
 	watch: {
 		value(newVal) {
-			this.inputVal = this.value
+			this.inputVal = newVal
 		},
 	},
 	beforeCreate() {
 		this.uuid = uuid.toString()
 		uuid += 1
+	},
+	methods: {
+		submit() {
+			this.$emit('update', this.inputVal)
+		},
 	},
 }
 </script>


### PR DESCRIPTION
Fix https://github.com/nextcloud/richdocuments/issues/3377

Not sure where this broke but otherwise the wopi allow list is never updated