### PR TITLE
Fix preview URLs and migrate providers to new API

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -142,15 +142,15 @@ class AppConfig {
 	}
 
 	public function getCollaboraUrlPublic(): string {
-		return $this->config->getAppValue(Application::APPNAME, self::PUBLIC_WOPI_URL, $this->getCollaboraUrlInternal());
+		return rtrim($this->config->getAppValue(Application::APPNAME, self::PUBLIC_WOPI_URL, $this->getCollaboraUrlInternal()), '/');
 	}
 
 	public function getCollaboraUrlInternal(): string {
-		return $this->config->getAppValue(Application::APPNAME, self::WOPI_URL, '');
+		return rtrim($this->config->getAppValue(Application::APPNAME, self::WOPI_URL, ''), '/');
 	}
 
 	public function getNextcloudUrl(): string {
-		return $this->config->getAppValue(Application::APPNAME, self::WOPI_CALLBACK_URL, '');
+		return rtrim($this->config->getAppValue(Application::APPNAME, self::WOPI_CALLBACK_URL, ''), '/');
 	}
 
 	public function getDisableCertificateValidation(): bool {

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -61,7 +61,6 @@ use OCP\Files\Template\ITemplateManager;
 use OCP\Files\Template\TemplateFileCreator;
 use OCP\IConfig;
 use OCP\IL10N;
-use OCP\IPreview;
 use OCP\Preview\BeforePreviewFetchedEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
 use OCP\Security\FeaturePolicy\AddFeaturePolicyEvent;
@@ -92,6 +91,13 @@ class Application extends App implements IBootstrap {
 			'getPathForToken',
 			'getWopiForToken',
 		]);
+
+		$context->registerPreviewProvider(EMF::class, EMF::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(MSExcel::class, MSExcel::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(MSWord::class, MSWord::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(OOXML::class, OOXML::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(OpenDocument::class, OpenDocument::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(Pdf::class, Pdf::MIMETYPE_REGEX);
 	}
 
 	public function boot(IBootContext $context): void {
@@ -153,41 +159,7 @@ class Application extends App implements IBootstrap {
 			});
 		});
 
-		$this->registerProvider();
 		$this->checkAndEnableCODEServer();
-	}
-
-	public function registerProvider() {
-		$container = $this->getContainer();
-
-		/** @var IPreview $previewManager */
-		$previewManager = $container->get(IPreview::class);
-
-		$previewManager->registerProvider('/application\/vnd.ms-excel/', function () use ($container) {
-			return $container->get(MSExcel::class);
-		});
-
-		$previewManager->registerProvider('/application\/msword/', function () use ($container) {
-			return $container->get(MSWord::class);
-		});
-
-		$previewManager->registerProvider('/application\/vnd.openxmlformats-officedocument.*/', function () use ($container) {
-			return $container->get(OOXML::class);
-		});
-
-		$previewManager->registerProvider('/application\/vnd.oasis.opendocument.*/', function () use ($container) {
-			return $container->get(OpenDocument::class);
-		});
-
-		$previewManager->registerProvider('/image\/emf/', function () use ($container) {
-			return $container->get(EMF::class);
-		});
-
-		if (!$previewManager->isMimeSupported('application/pdf')) {
-			$previewManager->registerProvider('/application\/pdf/', function () use ($container) {
-				return $container->get(Pdf::class);
-			});
-		}
 	}
 
 	public function checkAndEnableCODEServer() {

--- a/lib/Preview/EMF.php
+++ b/lib/Preview/EMF.php
@@ -26,10 +26,11 @@ declare(strict_types=1);
 namespace OCA\Richdocuments\Preview;
 
 class EMF extends Office {
+	public const MIMETYPE_REGEX = '/image\/emf/';
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMimeType() {
-		return '/image\/emf/';
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
 	}
 }

--- a/lib/Preview/MSExcel.php
+++ b/lib/Preview/MSExcel.php
@@ -22,10 +22,11 @@
 namespace OCA\Richdocuments\Preview;
 
 class MSExcel extends Office {
+	public const MIMETYPE_REGEX = '/application\/vnd.ms-excel/';
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMimeType() {
-		return '/application\/vnd.ms-excel/';
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
 	}
 }

--- a/lib/Preview/MSWord.php
+++ b/lib/Preview/MSWord.php
@@ -22,10 +22,11 @@
 namespace OCA\Richdocuments\Preview;
 
 class MSWord extends Office {
+	public const MIMETYPE_REGEX = '/application\/msword/';
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMimeType() {
-		return '/application\/msword/';
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
 	}
 }

--- a/lib/Preview/OOXML.php
+++ b/lib/Preview/OOXML.php
@@ -22,10 +22,12 @@
 namespace OCA\Richdocuments\Preview;
 
 class OOXML extends Office {
+	public const MIMETYPE_REGEX = '/application\/vnd.openxmlformats-officedocument.*/';
+
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMimeType() {
-		return '/application\/vnd.openxmlformats-officedocument.*/';
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
 	}
 }

--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -22,31 +22,19 @@
 namespace OCA\Richdocuments\Preview;
 
 use OC\Preview\Provider;
+use OCA\Richdocuments\AppConfig;
 use OCA\Richdocuments\Capabilities;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Image;
+use Psr\Log\LoggerInterface;
 
 abstract class Office extends Provider {
-	/** @var IClientService */
-	private $clientService;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var array */
-	private $capabilitites;
-
-	/** @var ILogger */
-	private $logger;
-
-	public function __construct(IClientService $clientService, IConfig $config, Capabilities $capabilities, ILogger $logger) {
+	public function __construct(private IClientService $clientService, private AppConfig $config, Capabilities $capabilities, private LoggerInterface $logger) {
 		parent::__construct();
-		$this->clientService = $clientService;
-		$this->config = $config;
+
 		$this->capabilitites = $capabilities->getCapabilities()['richdocuments'] ?? [];
-		$this->logger = $logger;
 	}
 
 	private function getWopiURL() {
@@ -91,13 +79,9 @@ abstract class Office extends Provider {
 		$options['multipart'] = [['name' => $path, 'contents' => $stream]];
 
 		try {
-			$response = $client->post($this->getWopiURL(). '/lool/convert-to/png', $options);
+			$response = $client->post($this->config->getCollaboraUrlInternal() . '/cool/convert-to/png', $options);
 		} catch (\Exception $e) {
-			$this->logger->logException($e, [
-				'message' => 'Failed to convert file to preview',
-				'level' => ILogger::INFO,
-				'app' => 'richdocuments',
-			]);
+			$this->logger->info('Failed to convert preview: ' . $e->getMessage(), ['exception' => $e]);
 			return false;
 		}
 

--- a/lib/Preview/OpenDocument.php
+++ b/lib/Preview/OpenDocument.php
@@ -23,10 +23,11 @@ namespace OCA\Richdocuments\Preview;
 
 //.odt, .ott, .oth, .odm, .odg, .otg, .odp, .otp, .ods, .ots, .odc, .odf, .odb, .odi, .oxt
 class OpenDocument extends Office {
+	public const MIMETYPE_REGEX = '/application\/vnd.oasis.opendocument.*/';
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMimeType() {
-		return '/application\/vnd.oasis.opendocument.*/';
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
 	}
 }

--- a/lib/Preview/Pdf.php
+++ b/lib/Preview/Pdf.php
@@ -23,10 +23,11 @@
 namespace OCA\Richdocuments\Preview;
 
 class Pdf extends Office {
+	public const MIMETYPE_REGEX = '/application\/pdf/';
 	/**
 	 * {@inheritDoc}
 	 */
-	public function getMimeType() {
-		return '/application\/pdf/';
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
 	}
 }

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+<files psalm-version="5.21.1@8c473e2437be8b6a8fd8f630f0f11a16b114c494">
   <file src="lib/AppConfig.php">
     <InvalidArgument>
       <code>[]</code>
@@ -7,16 +7,6 @@
     <RedundantCondition>
       <code><![CDATA[array_key_exists($key, self::APP_SETTING_TYPES) && self::APP_SETTING_TYPES[$key] === 'array']]></code>
     </RedundantCondition>
-  </file>
-  <file src="lib/AppInfo/Application.php">
-    <MissingDependency>
-      <code>EMF</code>
-      <code>MSExcel</code>
-      <code>MSWord</code>
-      <code>OOXML</code>
-      <code>OpenDocument</code>
-      <code>Pdf</code>
-    </MissingDependency>
   </file>
   <file src="lib/Command/ActivateConfig.php">
     <UndefinedClass>
@@ -28,12 +18,12 @@
       <code>Command</code>
     </UndefinedClass>
   </file>
-  <file src="lib/Command/UpdateEmptyTemplates.php">
+  <file src="lib/Command/InstallDefaultFonts.php">
     <UndefinedClass>
       <code>Command</code>
     </UndefinedClass>
   </file>
-  <file src="lib/Command/InstallDefaultFonts.php">
+  <file src="lib/Command/UpdateEmptyTemplates.php">
     <UndefinedClass>
       <code>Command</code>
     </UndefinedClass>
@@ -53,7 +43,7 @@
       <code><![CDATA[$node->getId()]]></code>
     </InvalidScalarArgument>
     <RedundantCondition>
-      <code><![CDATA[$app !== '']]></code>
+      <code>$app !== ''</code>
     </RedundantCondition>
   </file>
   <file src="lib/Controller/SettingsController.php">
@@ -78,7 +68,7 @@
       <code>null</code>
     </NullArgument>
     <TypeDoesNotContainType>
-      <code><![CDATA[$path === '']]></code>
+      <code>$path === ''</code>
     </TypeDoesNotContainType>
     <UndefinedInterfaceMethod>
       <code>putContent</code>
@@ -95,35 +85,13 @@
       <code><![CDATA[$share && method_exists($share, 'getAttributes')]]></code>
     </RedundantCondition>
   </file>
-  <file src="lib/Preview/EMF.php">
+  <file src="lib/Preview/Office.php">
     <MissingDependency>
-      <code>Office</code>
+      <code>Image</code>
     </MissingDependency>
-  </file>
-  <file src="lib/Preview/MSExcel.php">
-    <MissingDependency>
-      <code>Office</code>
-    </MissingDependency>
-  </file>
-  <file src="lib/Preview/MSWord.php">
-    <MissingDependency>
-      <code>Office</code>
-    </MissingDependency>
-  </file>
-  <file src="lib/Preview/OOXML.php">
-    <MissingDependency>
-      <code>Office</code>
-    </MissingDependency>
-  </file>
-  <file src="lib/Preview/OpenDocument.php">
-    <MissingDependency>
-      <code>Office</code>
-    </MissingDependency>
-  </file>
-  <file src="lib/Preview/Pdf.php">
-    <MissingDependency>
-      <code>Office</code>
-    </MissingDependency>
+    <UndefinedThisPropertyAssignment>
+      <code><![CDATA[$this->capabilitites]]></code>
+    </UndefinedThisPropertyAssignment>
   </file>
   <file src="lib/Service/ConnectivityService.php">
     <UndefinedClass>


### PR DESCRIPTION
- fix: Preview url generation and cleanup
  - We use a trimmed url now (fix https://github.com/nextcloud/richdocuments/issues/3434)
  - Move from old url pattern `lool` to `cool`
  - Move to LoggerInterface and constructor property promition
- chore: Move to preview provider v2
  - Move to new preview provider API to register lazy in Application bootstrap