### PR TITLE
Fixes #3492 joining after document is renamed inside editor

### DIFF
--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -34,7 +34,7 @@ const getSearchParam = (name) => {
 
 const getCallbackBaseUrl = () => {
 	const callbackUrl = Config.get('wopi_callback_url')
-	return callbackUrl || window.location.protocol + '//' + window.location.host + getRootUrl() + '/'
+	return callbackUrl || window.location.protocol + '//' + window.location.host + getRootUrl()
 }
 
 const getWopiSrc = (fileId) => {


### PR DESCRIPTION
Bug:
1. Open document
2. Rename in Collabora Online using input in the title bar
3. In the new tab open the same document from file picker in NC Result: 2 sessions are in different instances of the same document

getCallbackBaseUrl() puts "/" at the end, but WOPISrc was adding additional one:
const wopiurl = getCallbackBaseUrl() + '/ ...

Then reconnected session after rename had single "/index.php" but new session used "//index.php" what caused that COOL server didn't consider both as the same identifier
