### PR TITLE
 chore(release): Bump version to 8.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 8.3.2
+
+### Fixed
+
+- [stable28] fix: emit allow attribute on iframe for the clipboard (fixes #3474) @backportbot[bot] [#3481](https://github.com/nextcloud/richdocuments/pull/3481)
+- [stable28] Fixes #3492 joining after document is renamed inside editor @backportbot[bot] [#3504](https://github.com/nextcloud/richdocuments/pull/3504)
+- [stable28] fix: emit allow attribute on all iframes for the clipboard (related t… @backportbot[bot] [#3483](https://github.com/nextcloud/richdocuments/pull/3483)
+- [stable28] fix: Properly use input model in settings text fields @backportbot[bot] [#3495](https://github.com/nextcloud/richdocuments/pull/3495)
+- [stable28] Fix open locally with files lock and wopi allow list @backportbot[bot] [#3503](https://github.com/nextcloud/richdocuments/pull/3503)
+
+### Other
+
+- test(ci): use only 3 runners for cypress @max-nextcloud [#3411](https://github.com/nextcloud/richdocuments/pull/3411)
+
 ## 8.3.1
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>8.3.1</version>
+	<version>8.3.2</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
## 8.3.2

### Fixed

- [stable28] fix: emit allow attribute on iframe for the clipboard (fixes #3474) @backportbot[bot] [#3481](https://github.com/nextcloud/richdocuments/pull/3481)
- [stable28] Fixes #3492 joining after document is renamed inside editor @backportbot[bot] [#3504](https://github.com/nextcloud/richdocuments/pull/3504)
- [stable28] fix: emit allow attribute on all iframes for the clipboard (related t… @backportbot[bot] [#3483](https://github.com/nextcloud/richdocuments/pull/3483)
- [stable28] fix: Properly use input model in settings text fields @backportbot[bot] [#3495](https://github.com/nextcloud/richdocuments/pull/3495)
- [stable28] Fix open locally with files lock and wopi allow list @backportbot[bot] [#3503](https://github.com/nextcloud/richdocuments/pull/3503)

### Other

- test(ci): use only 3 runners for cypress @max-nextcloud [#3411](https://github.com/nextcloud/richdocuments/pull/3411)