### PR TITLE
chore(release): Bump version to 8.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 8.2.5
+
+### Fixed
+
+- fix: emit allow attribute on all iframes for the clipboard (related t… @backportbot[bot] [#3484](https://github.com/nextcloud/richdocuments/pull/3484)
+- fix: emit allow attribute on iframe for the clipboard (fixes #3474) @backportbot[bot] [#3482](https://github.com/nextcloud/richdocuments/pull/3482)
+- Fix open locally with files lock and wopi allow list @backportbot[bot] [#3502](https://github.com/nextcloud/richdocuments/pull/3502)
+
+### Other
+
+- test(ci): use only 3 runners for cypress @max-nextcloud [#3412](https://github.com/nextcloud/richdocuments/pull/3412)
+
 ## 8.2.4
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>8.2.4</version>
+	<version>8.2.5</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "8.2.4",
+  "version": "8.2.5",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
## 8.2.5

### Fixed

- fix: emit allow attribute on all iframes for the clipboard (related t… @backportbot[bot] [#3484](https://github.com/nextcloud/richdocuments/pull/3484)
- fix: emit allow attribute on iframe for the clipboard (fixes #3474) @backportbot[bot] [#3482](https://github.com/nextcloud/richdocuments/pull/3482)
- Fix open locally with files lock and wopi allow list @backportbot[bot] [#3502](https://github.com/nextcloud/richdocuments/pull/3502)

### Other

- test(ci): use only 3 runners for cypress @max-nextcloud [#3412](https://github.com/nextcloud/richdocuments/pull/3412)