### PR TITLE
Fix open locally with files lock and wopi allow list (backport stable26)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -72,6 +72,7 @@ return [
 	'ocs' => [
 		// Public pages: new file creation
 		['name' => 'documentAPI#create', 'url' => '/api/v1/file', 'verb' => 'POST'],
+		['name' => 'documentAPI#openLocal', 'url' => '/api/v1/local', 'verb' => 'POST'],
 
 		// Client API endpoints
 		['name' => 'OCS#createDirect', 'url' => '/api/v1/document', 'verb' => 'POST'],

--- a/lib/Controller/DocumentAPIController.php
+++ b/lib/Controller/DocumentAPIController.php
@@ -30,11 +30,17 @@ use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\Helper;
 use OCA\Richdocuments\TemplateManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Lock\ILock;
+use OCP\Files\Lock\ILockManager;
+use OCP\Files\Lock\LockContext;
+use OCP\Files\Lock\NoLockProviderException;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\PreConditionNotMetException;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -45,15 +51,17 @@ class DocumentAPIController extends \OCP\AppFramework\OCSController {
 	private $templateManager;
 	private $l10n;
 	private $logger;
+	private $lockManager;
 	private $userId;
 
-	public function __construct(IRequest $request, IRootFolder $rootFolder, IManager $shareManager, TemplateManager $templateManager, IL10N $l10n, LoggerInterface $logger, $userId) {
+	public function __construct(IRequest $request, IRootFolder $rootFolder, IManager $shareManager, TemplateManager $templateManager, IL10N $l10n, LoggerInterface $logger, ILockManager $lockManager, $userId) {
 		parent::__construct(Application::APPNAME, $request);
 		$this->rootFolder = $rootFolder;
 		$this->shareManager = $shareManager;
 		$this->templateManager = $templateManager;
 		$this->l10n = $l10n;
 		$this->logger = $logger;
+		$this->lockManager = $lockManager;
 		$this->userId = $userId;
 	}
 
@@ -146,5 +154,25 @@ class DocumentAPIController extends \OCP\AppFramework\OCSController {
 			'status' => 'success',
 			'data' => \OCA\Files\Helper::formatFileInfo($file->getFileInfo())
 		]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function openLocal(int $fileId): DataResponse {
+		try {
+			$files = $this->rootFolder->getUserFolder($this->userId)->getById($fileId);
+			$file = array_shift($files);
+			$this->lockManager->unlock(new LockContext(
+				$file,
+				ILock::TYPE_APP,
+				Application::APPNAME
+			));
+			return new DataResponse([]);
+		} catch (NoLockProviderException|PreConditionNotMetException $e) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		} catch (\Exception $e) {
+			return new DataResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
 	}
 }

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -87,6 +87,7 @@ class InitialStateService {
 		$this->initialState->provideInitialState('theming-customLogo', ($logoSet ?
 			\OC::$server->getURLGenerator()->getAbsoluteURL(\OC::$server->getThemingDefaults()->getLogo())
 			: false));
+		$this->initialState->provideInitialState('open_local_editor', $this->config->getAppValue(Application::APPNAME, 'open_local_editor', 'yes') === 'yes');
 	}
 
 	public function prepareParams(array $params): array {

--- a/src/document.js
+++ b/src/document.js
@@ -326,7 +326,7 @@ const documentsMain = {
 							PostMessages.sendWOPIPostMessage('loolframe', 'Hide_Menu_Item', { id: 'insertgraphicremote' })
 						}
 
-						if (Config.get('userId') !== null && !Config.get('isPublicShare')) {
+						if (Config.get('userId') !== null && !Config.get('isPublicShare') && loadState('richdocuments', 'open_local_editor', true)) {
 							PostMessages.sendWOPIPostMessage('loolframe', 'Insert_Button', {
 								id: 'Open_Local_Editor',
 								imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
@@ -591,11 +591,7 @@ const documentsMain = {
 	},
 
 	unlockFile() {
-		const unlockUrl = getRootUrl() + '/index.php/apps/richdocuments/wopi/files/' + documentsMain.fileId
-		const unlockConfig = {
-			headers: { 'X-WOPI-Override': 'UNLOCK' },
-		}
-		return axios.post(unlockUrl, { access_token: documentsMain.token }, unlockConfig)
+		return axios.post(generateOcsUrl('apps/richdocuments/api/v1/local'), { fileId: this.fileid })
 	},
 
 	openLocally() {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -217,16 +217,6 @@ export default {
 		documentReady() {
 			this.loading = LOADING_STATE.DOCUMENT_READY
 			clearTimeout(this.loadingTimeout)
-			if (loadState('richdocuments', 'open_local_editor', true)) {
-				this.sendPostMessage('Insert_Button', {
-					id: 'Open_Local_Editor',
-					imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
-					mobile: false,
-					label: t('richdocuments', 'Open in local editor'),
-					hint: t('richdocuments', 'Open in local editor'),
-					insertBefore: 'print',
-				})
-			}
 		},
 		async share() {
 			FilesAppIntegration.share()

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -217,6 +217,16 @@ export default {
 		documentReady() {
 			this.loading = LOADING_STATE.DOCUMENT_READY
 			clearTimeout(this.loadingTimeout)
+			if (loadState('richdocuments', 'open_local_editor', true)) {
+				this.sendPostMessage('Insert_Button', {
+					id: 'Open_Local_Editor',
+					imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
+					mobile: false,
+					label: t('richdocuments', 'Open in local editor'),
+					hint: t('richdocuments', 'Open in local editor'),
+					insertBefore: 'print',
+				})
+			}
 		},
 		async share() {
 			FilesAppIntegration.share()


### PR DESCRIPTION
- fix: Add config option to disable edit locally
- fix: Allow to unlock through separate endpoint for edit locally

Fix https://github.com/nextcloud/richdocuments/issues/3487
Fix https://github.com/nextcloud/richdocuments/issues/3299

Summary
We add a config value for disabling but also address that unlocking the file was no longer working with a WOPI allow list. We now move this to a separate endpoint to handle any prepare steps we need to do before moving to the local editor.

In a second iteration we can further extend this to update the other views to read only or notify them through Collabora.

Configuration option to disable local editing
```
occ config:app:set richdocuments open_local_editor --value="no"
```

* Target version: stable26

backport from #3489
### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
