### PR TITLE
fix: Use new viewer api to open files again after open locally

### DIFF
--- a/src/mixins/openLocal.js
+++ b/src/mixins/openLocal.js
@@ -83,7 +83,7 @@ export default {
 				},
 				(decision) => {
 					if (!decision) {
-						window.OCA.Viewer.open(fileName)
+						window.OCA.Viewer.open({ path: fileName })
 						return
 					}
 					this.openingLocally = true


### PR DESCRIPTION
Steps to reproduce:
- Open a file in Collabora
- Click the open locally button
- Confirm to open locally
- Click continue editing online

Before:
- Nothing happened

After:
- Properly reopens Collabora