### PR TITLE
match dark theme of system if no nextcloud theme specified

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -28,12 +28,12 @@ const getUIDefaults = () => {
 	const textRuler = 'false'
 	const sidebar = 'false'
 	const saveAsMode = 'group'
-	const uiMode = defaults.UIMode ?? 'notebookbar' // or notebookbar
+	const uiMode = defaults.UIMode ?? 'notebookbar'
 
 	const systemDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-	// FIXME For now we need to access parent here as the public page loaded for collabora doesn't have the user theme
-	const nextcloudDarkMode = parent.document.body.dataset.themeDark === '' || parent.document.body.dataset.themeDarkHighcontrast === ''
-	const matchedDarkMode = parent.document.body.dataset.themeDefault === '' ? systemDarkMode : nextcloudDarkMode
+	const dataset = (document.body.dataset.themes ? document.body.dataset : parent?.document.body.dataset) ?? {}
+	const nextcloudDarkMode = dataset?.themeDark === '' || dataset?.themeDarkHighcontrast === ''
+	const matchedDarkMode = (!dataset?.themes || dataset?.themes === '' || dataset?.themeDefault === '') ? systemDarkMode : nextcloudDarkMode
 	const uiTheme = matchedDarkMode ? 'dark' : 'light'
 
 	let uiDefaults = 'TextRuler=' + textRuler + ';'


### PR DESCRIPTION
problem example:
a new user is created who uses system dark mode, so nextcloud will be in dark mode but collabora would not be turned to dark mode as all the themes(ie:themeDark and themeDarkHighcontrast) value are undefined


* Target version: main



### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
