### PR TITLE
fix: Close button should just exit for the edit local modal

### DIFF
--- a/src/mixins/openLocal.js
+++ b/src/mixins/openLocal.js
@@ -82,6 +82,10 @@ export default {
 					cancel: t('richdocuments', 'Continue editing online'),
 				},
 				(decision) => {
+					if (window.event?.target.classList.contains('oc-dialog-close')) {
+						return
+					}
+
 					if (!decision) {
 						window.OCA.Viewer.open({ path: fileName })
 						return


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
