### PR TITLE
fix(WopiController): In `putFile()` set editor user as user scope

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -425,7 +425,7 @@ class WopiController extends Controller {
 
 		if (!$this->encryptionManager->isEnabled() || $this->isMasterKeyEnabled()) {
 			// Set the user to register the change under his name
-			$this->userScopeService->setUserScope($wopi->getUserForFileAccess());
+			$this->userScopeService->setUserScope($wopi->getEditorUid());
 			$this->userScopeService->setFilesystemScope($isPutRelative ? $wopi->getEditorUid() : $wopi->getUserForFileAccess());
 		} else {
 			// Per-user encryption is enabled so that collabora isn't able to store the file by using the


### PR DESCRIPTION
This fixes saves in shares being attributed to the share owner. With this change, they're attributed to 'remote user' in the activity stream.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
