### PR TITLE
don't alter file when there is not enough free space

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -485,7 +485,13 @@ class WopiController extends Controller {
 
 			$content = fopen('php://input', 'rb');
 
+			$freespace = $file->getParent()->getFreeSpace();
+			$contentLength = (int)$this->request->getHeader('Content-Length');
+
 			try {
+				if ($freespace >= 0 && $contentLength > $freespace) {
+					throw new \Exception('Not enough storage');
+				}
 				$this->wrappedFilesystemOperation($wopi, function () use ($file, $content) {
 					return $file->putContent($content);
 				});


### PR DESCRIPTION
* Resolves: #3281 
* Target version: main

### Summary
When Updating files via WOPI the file used to be written from the beginning just to realize mid writing that there's not enough space and throw an error. Therefore the entire doc gets broken and mostly unusable.

Now: When a File is to be updated it gets checked if it would exceed the free space on storage/quota, if not an error is thrown and the file is left as is.