### PR TITLE
[stable27] fix: Allow configuring the wopi_callback_url

### DIFF
--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -54,6 +54,7 @@ class InitialStateService {
 		$this->initialState->provideInitialState('hasDrawSupport', $this->capabilitiesService->hasDrawSupport());
 		$this->initialState->provideInitialState('hasNextcloudBranding', $this->capabilitiesService->hasNextcloudBranding());
 		$this->initialState->provideInitialState('instanceId', $this->config->getSystemValue('instanceid'));
+		$this->initialState->provideInitialState('wopi_callback_url', $this->config->getAppValue(Application::APPNAME, 'wopi_callback_url', ''));
 
 		$this->provideOptions();
 
@@ -81,6 +82,7 @@ class InitialStateService {
 			'directGuest' => false,
 			'path' => '',
 			'urlsrc' => '',
+			'wopi_callback_url' => $this->config->getAppValue(Application::APPNAME, 'wopi_callback_url', ''),
 			'fileId' => '',
 			'title' => '',
 			'permissions' => '',

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -23,6 +23,7 @@
 import { getRootUrl, generateUrl } from '@nextcloud/router'
 import { languageToBCP47 } from './index.js'
 import Config from './../services/config.tsx'
+import { loadState } from '@nextcloud/initial-state'
 
 const getSearchParam = (name) => {
 	const results = new RegExp('[?&]' + name + '=([^&#]*)').exec(window.location.href)
@@ -32,13 +33,24 @@ const getSearchParam = (name) => {
 	return decodeURI(results[1]) || ''
 }
 
+const getCallbackBaseUrl = () => {
+	const callbackUrl = Config.get('wopi_callback_url') || loadState('richdocuments', 'wopi_callback_url', '')
+	return callbackUrl || window.location.protocol + '//' + window.location.host + getRootUrl()
+}
+
+const getWopiSrc = (fileId) => {
+	// WOPISrc - URL that Collabora will use to access Nextcloud
+	// index.php is forced here to avoid different wopi srcs for the same document
+	const wopiurl = getCallbackBaseUrl() + '/index.php/apps/richdocuments/wopi/files/' + fileId
+	console.debug('[getWopiUrl] ' + wopiurl)
+	return wopiurl
+}
+
 const getWopiUrl = ({ fileId, title, readOnly, closeButton, revisionHistory, target = undefined }) => {
 	// Only set the revision history parameter if the versions app is enabled
 	revisionHistory = revisionHistory && window?.oc_appswebroots?.files_versions
 
-	// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
-	// index.php is forced here to avoid different wopi srcs for the same document
-	const wopiurl = window.location.protocol + '//' + window.location.host + getRootUrl() + '/index.php/apps/richdocuments/wopi/files/' + fileId
+	const wopiurl = getWopiSrc(fileId)
 	console.debug('[getWopiUrl] ' + wopiurl)
 	const wopisrc = encodeURIComponent(wopiurl)
 


### PR DESCRIPTION
This is a minimal invasive backport of the parts of https://github.com/nextcloud/richdocuments/pull/3315 that allow configuring a separate callback URL for WOPI that can be used to use a different URL for requests Collabora is performing towards Nextcloud

```
occ config:app:set richdocuments wopi_callback_url --value="http://stable27"
```