### PR TITLE
fix: Use wopi callback url for all urls handed over to Collabora

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -194,9 +194,7 @@ class WopiController extends Controller {
 			$response['UserPrivateInfo']['ZoteroAPIKey'] = $zoteroAPIKey;
 		}
 		if ($wopi->hasTemplateId()) {
-			$templateUrl = 'index.php/apps/richdocuments/wopi/template/' . $wopi->getTemplateId() . '?access_token=' . $wopi->getToken();
-			$templateUrl = $this->urlGenerator->getAbsoluteURL($templateUrl);
-			$response['TemplateSource'] = $templateUrl;
+			$response['TemplateSource'] = $this->getWopiUrlForTemplate($wopi);
 		} elseif ($wopi->isTemplateToken()) {
 			// FIXME: Remove backward compatibility layer once TemplateSource is available in all supported Collabora versions
 			$userFolder = $this->rootFolder->getUserFolder($wopi->getOwnerUid());
@@ -283,7 +281,7 @@ class WopiController extends Controller {
 			$response['TemplateSource'] = $templateUrl;
 		}
 		if ($wopi->getTokenType() === Wopi::TOKEN_TYPE_REMOTE_USER || ($wopi->getTokenType() === Wopi::TOKEN_TYPE_REMOTE_GUEST && $initiator->getEditorUid())) {
-			$response['UserExtraInfo']['avatar'] = $wopi->getRemoteServer() . '/index.php/avatar/' . $initiator->getEditorUid() . '/'. self::WOPI_AVATAR_SIZE;
+			$response['UserExtraInfo']['avatar'] = $wopi->getRemoteServer() . '/index.php/avatar/' . $initiator->getEditorUid() . '/' . self::WOPI_AVATAR_SIZE;
 		}
 
 		return $response;
@@ -497,11 +495,7 @@ class WopiController extends Controller {
 			if ($isPutRelative) {
 				// generate a token for the new file (the user still has to be logged in)
 				$wopi = $this->tokenManager->generateWopiToken((string)$file->getId(), null, $wopi->getEditorUid(), $wopi->getDirect());
-
-				$wopiUrl = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->config->getSystemValue('instanceid') . '?access_token=' . $wopi->getToken();
-				$wopiUrl = $this->urlGenerator->getAbsoluteURL($wopiUrl);
-
-				return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $wopiUrl ], Http::STATUS_OK);
+				return new JSONResponse(['Name' => $file->getName(), 'Url' => $this->getWopiUrlForFile($wopi, $file)], Http::STATUS_OK);
 			}
 			if ($wopi->hasTemplateId()) {
 				$wopi->setTemplateId(null);
@@ -665,17 +659,14 @@ class WopiController extends Controller {
 
 			// epub is exception (can be uploaded but not opened so don't try to get access token)
 			if ($file->getMimeType() == 'application/epub+zip') {
-				return new JSONResponse([ 'Name' => $file->getName() ], Http::STATUS_OK);
+				return new JSONResponse(['Name' => $file->getName()], Http::STATUS_OK);
 			}
 
 			// generate a token for the new file (the user still has to be
 			// logged in)
 			$wopi = $this->tokenManager->generateWopiToken((string)$file->getId(), null, $wopi->getEditorUid(), $wopi->getDirect());
 
-			$wopiUrl = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->config->getSystemValue('instanceid') . '?access_token=' . $wopi->getToken();
-			$wopiUrl = $this->urlGenerator->getAbsoluteURL($wopiUrl);
-
-			return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $wopiUrl ], Http::STATUS_OK);
+			return new JSONResponse(['Name' => $file->getName(), 'Url' => $this->getWopiUrlForFile($wopi, $file)], Http::STATUS_OK);
 		} catch (NotFoundException $e) {
 			$this->logger->warning($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
@@ -706,6 +697,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
+
 	private function unlock(Wopi $wopi, string $lock): JSONResponse {
 		try {
 			$this->lockManager->unlock(new LockContext(
@@ -888,5 +880,15 @@ class WopiController extends Controller {
 			// No encryption module enabled
 			return false;
 		}
+	}
+
+	private function getWopiUrlForFile(Wopi $wopi, File $file): string {
+		$nextcloudUrl = $this->appConfig->getNextcloudUrl() ?: trim($this->urlGenerator->getAbsoluteURL(''), '/');
+		return $nextcloudUrl . '/index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->config->getSystemValue('instanceid') . '?access_token=' . $wopi->getToken();
+	}
+
+	private function getWopiUrlForTemplate(Wopi $wopi): string {
+		$nextcloudUrl = $this->appConfig->getNextcloudUrl() ?: trim($this->urlGenerator->getAbsoluteURL(''), '/');
+		return $nextcloudUrl . '/index.php/apps/richdocuments/wopi/template/' . $wopi->getTemplateId() . '?access_token=' . $wopi->getToken();
 	}
 }

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -38,7 +38,7 @@ const getCallbackBaseUrl = () => {
 }
 
 const getWopiSrc = (fileId) => {
-	// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
+	// WOPISrc - URL that Collabora will use to access Nextcloud
 	// index.php is forced here to avoid different wopi srcs for the same document
 	const wopiurl = getCallbackBaseUrl() + '/index.php/apps/richdocuments/wopi/files/' + fileId
 	console.debug('[getWopiUrl] ' + wopiurl)


### PR DESCRIPTION
Fix https://github.com/nextcloud/richdocuments/issues/3579

Some URLs were not respecting the wopi_callback_url setting that we have in place now to configure the URL that Collabora will use to talk to Nextcloud, so this PR adapts those.