### PR TITLE
chore: Cleanup old TemplateSaveAs code as this is no longer supported by Collabora

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -150,7 +150,7 @@ class Capabilities implements ICapability {
 					'mimetypesSecureView' => $this->config->useSecureViewAdditionalMimes() ? self::SECURE_VIEW_ADDITIONAL_MIMES : [],
 					'collabora' => $collaboraCapabilities,
 					'direct_editing' => ($collaboraCapabilities['hasMobileSupport'] ?? false) && $this->config->getAppValue('mobile_editing', 'yes') === 'yes',
-					'templates' => ($collaboraCapabilities['hasTemplateSaveAs'] ?? false) || ($collaboraCapabilities['hasTemplateSource'] ?? false),
+					'templates' => ($collaboraCapabilities['hasTemplateSource'] ?? false),
 					'productName' => $this->capabilitiesService->getProductName(),
 					'editonline_endpoint' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.document.editOnline'),
 					'config' => [

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -152,10 +152,6 @@ class Wopi extends Entity implements \JsonSerializable {
 		$this->addType('tokenType', 'int');
 	}
 
-	public function isTemplateToken() {
-		return $this->getTemplateDestination() !== 0 && $this->getTemplateDestination() !== null;
-	}
-
 	public function hasTemplateId() {
 		return $this->getTemplateId() !== 0 && $this->getTemplateId() !== null;
 	}

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -70,7 +70,7 @@ class WopiMapper extends QBMapper {
 	 * @param int $templateDestination
 	 * @return Wopi
 	 */
-	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname = null, $templateDestination = 0, $hideDownload = false, $direct = false, $templateId = 0, $share = null) {
+	public function generateFileToken($fileId, $owner, $editor, $version, $updatable, $serverHost, $guestDisplayname = null, $hideDownload = false, $direct = false, $templateId = 0, $share = null) {
 		$token = $this->random->generate(32, ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_DIGITS);
 
 		$wopi = Wopi::fromParams([
@@ -83,7 +83,6 @@ class WopiMapper extends QBMapper {
 			'token' => $token,
 			'expiry' => $this->calculateNewTokenExpiry(),
 			'guestDisplayname' => $guestDisplayname,
-			'templateDestination' => $templateDestination,
 			'hideDownload' => $hideDownload,
 			'direct' => $direct,
 			'templateId' => $templateId,

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -102,10 +102,6 @@ class CapabilitiesService {
 		return version_compare($productVersion, '6.4.7', '>=');
 	}
 
-	public function hasTemplateSaveAs(): bool {
-		return $this->getCapabilities()['hasTemplateSaveAs'] ?? false;
-	}
-
 	public function hasTemplateSource(): bool {
 		return $this->getCapabilities()['hasTemplateSource'] ?? false;
 	}

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -63,7 +63,7 @@ class Admin implements ISettings {
 					'canonical_webroot' => $this->config->getAppValue('richdocuments', 'canonical_webroot'),
 					'disable_certificate_verification' => $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') === 'yes',
 					'templates' => $this->manager->getSystemFormatted(),
-					'templatesAvailable' => $this->capabilitiesService->hasTemplateSaveAs() || $this->capabilitiesService->hasTemplateSource(),
+					'templatesAvailable' => $this->capabilitiesService->hasTemplateSource(),
 					'settings' => $this->appConfig->getAppSettings(),
 					'demo_servers' => $this->demoService->fetchDemoServers(),
 					'web_server' => strtolower($_SERVER['SERVER_SOFTWARE']),

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -51,7 +51,7 @@ class Personal implements ISettings {
 
 	/** @psalm-suppress InvalidNullableReturnType */
 	public function getForm() {
-		if (!$this->capabilitiesService->hasTemplateSaveAs() && !$this->capabilitiesService->hasTemplateSource()) {
+		if (!$this->capabilitiesService->hasTemplateSource()) {
 			/** @psalm-suppress NullableReturnStatement */
 			return null;
 		}
@@ -70,7 +70,7 @@ class Personal implements ISettings {
 	}
 
 	public function getSection() {
-		if (!$this->capabilitiesService->hasTemplateSaveAs() && !$this->capabilitiesService->hasTemplateSource()) {
+		if (!$this->capabilitiesService->hasTemplateSource()) {
 			return null;
 		}
 

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -199,7 +199,7 @@ class TokenManager {
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 		$guestName = $this->userId === null ? $this->prepareGuestName($this->helper->getGuestNameFromCookie()) : null;
-		return $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guestName, 0, $hideDownload, $direct, 0, $shareToken);
+		return $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guestName, $hideDownload, $direct, 0, $shareToken);
 	}
 
 	/**
@@ -255,12 +255,8 @@ class TokenManager {
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
-		if ($this->capabilitiesService->hasTemplateSource()) {
-			return $this->wopiMapper->generateFileToken($targetFile->getId(), $owneruid, $editoruid, 0, $updatable, $serverHost, null, 0, false, $direct, $templateFile->getId());
-		}
-
-		// Legacy way of creating new documents from a template
-		return $this->wopiMapper->generateFileToken($templateFile->getId(), $owneruid, $editoruid, 0, $updatable, $serverHost, null, $targetFile->getId(), $direct);
+		return $this->wopiMapper->generateFileToken($targetFile->getId(), $owneruid, $editoruid, 0, $updatable, $serverHost, null,
+			false, $direct, $templateFile->getId());
 	}
 
 	public function newInitiatorToken($sourceServer, ?Node $node = null, $shareToken = null, bool $direct = false, $userId = null): Wopi {


### PR DESCRIPTION
Came across this old todo to remove code, which already was disabled in 2019 https://github.com/CollaboraOnline/online/commit/f71522e7ff7c648ed14f1ef18c2c10f8ef12d997 and got its replacement in https://github.com/nextcloud/richdocuments/pull/514