### PR TITLE
[stable26] fix: Use Close_Session post message to properly end the Collabora editing before opening locally

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -224,6 +224,7 @@ class WopiController extends Controller {
 			'EnableInsertRemoteImage' => !$isPublic,
 			'EnableShare' => $file->isShareable() && !$isVersion && !$isPublic,
 			'HideUserList' => '',
+			'EnableOwnerTermination' => $wopi->getCanwrite() && !$isPublic,
 			'DisablePrint' => $wopi->getHideDownload(),
 			'DisableExport' => $wopi->getHideDownload(),
 			'DisableCopy' => $wopi->getHideDownload(),

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -271,6 +271,9 @@ export default {
 			case 'close':
 				this.close()
 				break
+			case 'close_other':
+				this.onSessionClosed()
+				break
 			case 'Get_Views_Resp':
 			case 'Views_List':
 				this.views = args
@@ -307,6 +310,10 @@ export default {
 				this.showZotero = true
 				break
 			}
+		},
+		onSessionClosed() {
+			window.OCP.Toast.error(t('richdocuments', 'The collaborative editing was terminated by another user'))
+			this.close()
 		},
 	},
 }


### PR DESCRIPTION
If we edit locally we want to ensure that the document is saved and all sessions are removed before handing over the file to the desktop client. The previous approach was somewhat flaky and could lead to opening the file locally too early. The Close_Session post message will ensure that the file is properly terminated on the Collabora side and the lock on it is removed. 

Further we can use the Session_Closed post message on other editing sessions to show a hint to the user why the document was auto-closed.