### PR TITLE
refactor: move to office.vue component

### DIFF
--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -20,7 +20,7 @@
 import { User } from '@nextcloud/cypress'
 
 const usesHttps = Cypress.env('baseUrl').substr(0, 5) === 'https'
-const collaboraUrl = Cypress.env('collaboraUrl')
+const collaboraUrl = Cypress.config('collaboraUrl')
 const defaultFonts = ['AmaticSC-Regular.ttf']
 
 describe('Office admin settings', function() {

--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -20,7 +20,7 @@
 import { User } from '@nextcloud/cypress'
 
 const usesHttps = Cypress.env('baseUrl').substr(0, 5) === 'https'
-const collaboraUrl = Cypress.config('collaboraUrl')
+const collaboraUrl = Cypress.env('collaboraUrl')
 const defaultFonts = ['AmaticSC-Regular.ttf']
 
 describe('Office admin settings', function() {

--- a/cypress/e2e/share-link.js
+++ b/cypress/e2e/share-link.js
@@ -51,11 +51,11 @@ describe('Public sharing of office documents', function() {
 							cy.spy(win, 'postMessage').as('postMessage')
 						},
 					})
-					cy.waitForCollabora(true)
+					cy.waitForCollabora()
 					cy.get('@loleafletframe').within(() => {
 						cy.get('#closebutton').click()
 					})
-					cy.get('#viewer', { timeout: 5000 }).should('not.exist')
+					cy.get('#viewer', { timeout: 10000 }).should('not.exist')
 				})
 			})
 		}

--- a/cypress/e2e/share-link.js
+++ b/cypress/e2e/share-link.js
@@ -55,7 +55,7 @@ describe('Public sharing of office documents', function() {
 					cy.get('@loleafletframe').within(() => {
 						cy.get('#closebutton').click()
 					})
-					cy.get('#viewer', { timeout: 10000 }).should('not.exist')
+					cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 				})
 			})
 		}

--- a/cypress/e2e/share-link.js
+++ b/cypress/e2e/share-link.js
@@ -51,7 +51,18 @@ describe('Public sharing of office documents', function() {
 							cy.spy(win, 'postMessage').as('postMessage')
 						},
 					})
+
 					cy.waitForCollabora()
+					cy.get('@postMessage', { timeout: 20000 }).should(spy => {
+						const calls = spy.getCalls()
+						const findMatchingCall = calls.find(call => call.args[0].indexOf('"MessageId":"App_LoadingStatus"') !== -1)
+						if (!findMatchingCall) {
+							return expect(findMatchingCall).to.not.be.undefined
+						}
+						const object = JSON.parse(findMatchingCall.args[0])
+						expect(object.Values).to.have.property('Status', 'Initialized')
+					})
+
 					cy.get('@loleafletframe').within(() => {
 						cy.get('#closebutton').click()
 					})

--- a/lib/Listener/ShareLinkListener.php
+++ b/lib/Listener/ShareLinkListener.php
@@ -61,6 +61,7 @@ class ShareLinkListener implements \OCP\EventDispatcher\IEventListener {
 			$this->initialStateService->provideCapabilities();
 			Util::addScript('richdocuments', 'richdocuments-files');
 			Util::addScript('richdocuments', 'richdocuments-viewer', 'viewer');
+			Util::addScript('richdocuments', 'richdocuments-public');
 		}
 	}
 }

--- a/src/files.js
+++ b/src/files.js
@@ -260,8 +260,6 @@ addEventListener('DOMContentLoaded', () => {
 		return
 	}
 
-	odfViewer.onEdit(document.getElementById('filename').value)
-
 	PostMessages.registerPostMessageHandler(({ parsed }) => {
 		console.debug('[viewer] Received post message', parsed)
 		const { msgId, args, deprecated } = parsed

--- a/src/helpers/isDocument.js
+++ b/src/helpers/isDocument.js
@@ -1,0 +1,17 @@
+import { getCapabilities } from '@nextcloud/capabilities'
+
+/** @type Array.<String> */
+const mimetypes = getCapabilities().richdocuments.mimetypes
+
+/**
+ * Determines if the mimetype of the resource is supported by richdocuments
+ * @return {boolean}
+ */
+function isDocument() {
+	/** @type HTMLInputElement */
+	const mimetypeElement = document.getElementById('mimetype')
+
+	return Boolean(mimetypeElement) && mimetypes.includes(mimetypeElement.value)
+}
+
+export default isDocument

--- a/src/helpers/isPublicPage.js
+++ b/src/helpers/isPublicPage.js
@@ -1,0 +1,12 @@
+/**
+ * Determines if the resource is a public share
+ * @return {boolean}
+ */
+function isPublic() {
+	/** @type HTMLInputElement */
+	const publicElement = document.getElementById('isPublic')
+
+	return Boolean(publicElement) && publicElement.value === '1'
+}
+
+export default isPublic

--- a/src/public.js
+++ b/src/public.js
@@ -1,0 +1,17 @@
+import isPublic from './helpers/isPublicPage.js'
+import isDocument from './helpers/isDocument.js'
+
+document.addEventListener('DOMContentLoaded', () => {
+
+	// Public share, but not a supported mimetype - do nothing
+	if (isPublic() && !isDocument()) {
+		return
+	}
+
+	// Public share, and is a supported mimetype - open viewer
+	if (isPublic() && isDocument()) {
+		if (OCA.Viewer) {
+			OCA.Viewer.open({ path: '/' })
+		}
+	}
+})

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -261,7 +261,7 @@ export default {
 		}
 		this.postMessage.registerPostMessageHandler(this.postMessageHandler)
 
-		this.load()
+		await this.load()
 	},
 	beforeDestroy() {
 		this.postMessage.unregisterPostMessageHandler(this.postMessageHandler)

--- a/webpack.js
+++ b/webpack.js
@@ -11,6 +11,7 @@ webpackConfig.entry = {
 	admin: path.join(__dirname, 'src', 'admin.js'),
 	personal: path.join(__dirname, 'src', 'personal.js'),
 	reference: path.join(__dirname, 'src', 'reference.js'),
+	public: path.join(__dirname, 'src', 'public.js'),
 }
 
 webpackRules.RULE_JS.test = /\.m?js$/


### PR DESCRIPTION
* Resolves: #3599

### Summary
Removes `document.js` which contains legacy code and is difficult to maintain, replacing it with the `Office.vue` component.

This will help complete #3557 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
