### PR TITLE
fix: Use Close_Session post message to properly end the Collabora editing before opening locally

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -176,6 +176,7 @@ class WopiController extends Controller {
 			'EnableInsertRemoteImage' => !$isPublic,
 			'EnableShare' => $file->isShareable() && !$isVersion && !$isPublic,
 			'HideUserList' => '',
+			'EnableOwnerTermination' => $wopi->getCanwrite() && !$isPublic,
 			'DisablePrint' => $wopi->getHideDownload(),
 			'DisableExport' => $wopi->getHideDownload(),
 			'DisableCopy' => $wopi->getHideDownload(),

--- a/src/mixins/openLocal.js
+++ b/src/mixins/openLocal.js
@@ -37,20 +37,6 @@ export default {
 		startOpenLocalProcess() {
 			this.showOpenLocalConfirmation()
 		},
-		async unlockAndOpenLocally() {
-			if (this.openingLocally) {
-				let shouldContinue = true
-				try {
-					await this.unlockFile()
-				} catch (e) {
-					shouldContinue = e.response.status === 400
-				}
-
-				if (shouldContinue) {
-					this.openLocally()
-				}
-			}
-		},
 
 		showOpenLocalConfirmation() {
 			spawnDialog(
@@ -66,9 +52,20 @@ export default {
 						return
 					}
 					this.openingLocally = true
-					this.sendPostMessage('Get_Views')
+					this.postMessage.registerPostMessageHandler(this.handleCloseSession)
+					this.sendPostMessage('Action_Save', {
+						DontTerminateEdit: false,
+						DontSaveIfUnmodified: false,
+						Notify: false,
+					})
+					this.sendPostMessage('Close_Session')
 				},
 			)
+		},
+
+		handleCloseSession() {
+			this.postMessage.unregisterPostMessageHandler(this.handleCloseSession)
+			this.openLocally()
 		},
 
 		showOpenLocalFinished() {
@@ -87,7 +84,7 @@ export default {
 						return
 					}
 					this.openingLocally = true
-					this.sendPostMessage('Get_Views')
+					this.openLocally()
 				},
 			)
 		},
@@ -111,7 +108,7 @@ export default {
 
 					this.showOpenLocalFinished(url, window.top)
 					this.close()
-					window.location.href = url
+					window.open(url, '_self')
 				})
 			}
 		},

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -93,6 +93,7 @@ import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import AlertOctagonOutline from 'vue-material-design-icons/AlertOctagonOutline.vue'
 import { loadState } from '@nextcloud/initial-state'
+import { showInfo } from '@nextcloud/dialogs'
 
 import ZoteroHint from '../components/Modal/ZoteroHint.vue'
 import { basename, dirname } from 'path'
@@ -175,7 +176,6 @@ export default {
 			error: null,
 			errorType: null,
 			loadingMsg: null,
-			views: [],
 
 			showLinkPicker: false,
 			showZotero: false,
@@ -371,10 +371,8 @@ export default {
 			case 'UI_Close':
 				this.close()
 				break
-			case 'Get_Views_Resp':
-			case 'Views_List':
-				this.views = args
-				this.unlockAndOpenLocally()
+			case 'Session_Closed':
+				this.handleSessionClosed(args)
 				break
 			case 'UI_SaveAs':
 				this.saveAs(args.format)
@@ -444,6 +442,18 @@ export default {
 			if (args?.Id === 'Open_Local_Editor') {
 				this.startOpenLocalProcess()
 			}
+		},
+
+		handleSessionClosed({ Reason }) {
+			if (Reason !== 'OwnerTermination') {
+				return
+			}
+			if (this.openingLocally) {
+				return
+			}
+
+			showInfo(t('richdocuments', 'The collaborative editing was terminated by another user'))
+			this.close()
 		},
 
 	},


### PR DESCRIPTION
Forward port of https://github.com/nextcloud/richdocuments/pull/3597

If we edit locally we want to ensure that the document is saved and all sessions are removed before handing over the file to the desktop client. The previous approach was somewhat flaky and could lead to opening the file locally too early. The Close_Session post message will ensure that the file is properly terminated on the Collabora side and the lock on it is removed. 

Further we can use the Session_Closed post message on other editing sessions to show a hint to the user why the document was auto-closed.

Steps to reproduce (with some back luck in timing):
1. Open a document in Collabora in multiple browser tabs
2. One tab clicks the open locally button so that the desktop client will take over editing

Now before this change there was a high chance that if the save and termination of individual sessions took longer, Collabora hadn't fully closed the document and may have ended in a inconsistent state (either the client failed to lock or Collabora hasn't finished writing the document). With the new post message handling the Collabora side should be fully terminated before we handover.