### PR TITLE
test(cypress): Adapt selectors to Collabora 24.04

### DIFF
--- a/cypress/e2e/integration.spec.js
+++ b/cypress/e2e/integration.spec.js
@@ -47,7 +47,7 @@ describe('Nextcloud integration', function() {
 	it('Sharing sidebar', function() {
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#File-tab-label').click()
-			cy.get('#ShareAs').click()
+			cy.get('#ShareAs-button').click()
 		})
 
 		cy.get('#app-sidebar-vue')
@@ -62,7 +62,7 @@ describe('Nextcloud integration', function() {
 	it('Versions sidebar', function() {
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#File-tab-label').click()
-			cy.get('#Rev-History').click()
+			cy.get('#Rev-History-button').click()
 		})
 
 		cy.get('#app-sidebar-vue')
@@ -76,11 +76,12 @@ describe('Nextcloud integration', function() {
 		cy.get('#tab-version_vue .version__info__label').contains('Current version')
 	})
 
+	// Currently it seems that Collabora is missing the save as button
 	it('Save as', function() {
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#File-tab-label').click()
 			cy.get('#saveas').click()
-			cy.get('#w2ui-overlay-download-as-menu .menu-text').eq(1).click()
+			cy.get('#saveas-entries #saveas-entry-1').click()
 		})
 
 		cy.get('.saveas-dialog').should('be.visible')
@@ -128,8 +129,8 @@ describe('Nextcloud integration', function() {
 	it('Insert image', function() {
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#Insert-tab-label').click()
-			cy.get('#insert-insert-graphic').click()
-			cy.get('#w2ui-overlay-insert-graphic-menu .menu-text').eq(1).click()
+			cy.get('#insert-insert-graphic-button').click()
+			cy.get('#insert-insert-graphic-entries #insert-insert-graphic-entry-1').click()
 		})
 		cy.get('.modal-container__content').should('be.visible')
 	})
@@ -137,7 +138,7 @@ describe('Nextcloud integration', function() {
 	it('Smart picker', function() {
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#Insert-tab-label').click()
-			cy.get('#insert-insert-remote-link').click()
+			cy.get('#insert-insert-remote-link-button').click()
 		})
 		cy.get('.reference-picker-modal--content').should('be.visible')
 	})

--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -51,12 +51,11 @@ describe('Open existing office files', function() {
 			cy.waitForViewer()
 			cy.waitForCollabora()
 
-			cy.screenshot('open-file_' + filename)
+			cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 
 			// Share action
 			cy.get('@loleafletframe').within(() => {
 				cy.get('#main-menu #menu-file > a').click()
-				cy.wait(1000)
 				cy.get('#main-menu #menu-shareas > a').should('be.visible').click()
 			})
 

--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -54,6 +54,7 @@ describe('Open existing office files', function() {
 			cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 
 			// Share action
+			cy.wait(2000)
 			cy.get('@loleafletframe').within(() => {
 				cy.get('#main-menu #menu-file > a').click()
 				cy.get('#main-menu #menu-shareas > a').should('be.visible').click()

--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -56,7 +56,8 @@ describe('Open existing office files', function() {
 			// Share action
 			cy.get('@loleafletframe').within(() => {
 				cy.get('#main-menu #menu-file > a').click()
-				cy.get('#main-menu #menu-shareas > a').click()
+				cy.wait(1000)
+				cy.get('#main-menu #menu-shareas > a').should('be.visible').click()
 			})
 
 			cy.get('#app-sidebar-vue')

--- a/cypress/e2e/share-link.js
+++ b/cypress/e2e/share-link.js
@@ -53,15 +53,7 @@ describe('Public sharing of office documents', function() {
 					})
 
 					cy.waitForCollabora()
-					cy.get('@postMessage', { timeout: 20000 }).should(spy => {
-						const calls = spy.getCalls()
-						const findMatchingCall = calls.find(call => call.args[0].indexOf('"MessageId":"App_LoadingStatus"') !== -1)
-						if (!findMatchingCall) {
-							return expect(findMatchingCall).to.not.be.undefined
-						}
-						const object = JSON.parse(findMatchingCall.args[0])
-						expect(object.Values).to.have.property('Status', 'Initialized')
-					})
+					cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 
 					cy.get('@loleafletframe').within(() => {
 						cy.get('#closebutton').click()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -223,7 +223,21 @@ Cypress.Commands.add('waitForCollabora', (wrapped = false) => {
 		.as('loleafletframe')
 	cy.get('@loleafletframe').find('#main-document-content').should('be.visible')
 })
-
+Cypress.Commands.add('waitForPostMessage', (messageId, values = undefined) => {
+	cy.get('@postMessage', { timeout: 20000 }).should(spy => {
+		const calls = spy.getCalls()
+		const findMatchingCall = calls.find(call => call.args[0].indexOf('"MessageId":"' + messageId + '"') !== -1)
+		if (!findMatchingCall) {
+			return expect(findMatchingCall).to.not.be.undefined
+		}
+		if (!values) {
+			const object = JSON.parse(findMatchingCall.args[0])
+			values.forEach(value => {
+				expect(object.Values).to.have.property(value, values[value])
+			})
+		}
+	})
+})
 Cypress.Commands.add('uploadSystemTemplate', () => {
 	cy.login(new User('admin', 'admin'))
 	cy.visit('/settings/admin/richdocuments')

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -435,6 +435,8 @@ export default {
 			case 'UI_ZoteroKeyMissing':
 				this.showZotero = true
 				break
+			// FIXME: Remove once https://github.com/CollaboraOnline/online/pull/8926 is released
+			case 'UI UI_PickLink':
 			case 'UI_PickLink':
 				this.pickLink()
 				break


### PR DESCRIPTION
Let's get main branch back to green with Collabora 24.04 that was recently released and the docker image used by CI was updated

- [x] Check SaveAs feature upstream as when testing locally the button seems to be missing
- [x] https://github.com/CollaboraOnline/online/pull/8926