### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "08f14207f11fabd92b2f8b1f826eec556c547c61"
+                "reference": "e84a723ae9c0d590e3a4deaba9d4fba54bd66184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/08f14207f11fabd92b2f8b1f826eec556c547c61",
-                "reference": "08f14207f11fabd92b2f8b1f826eec556c547c61",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/e84a723ae9c0d590e3a4deaba9d4fba54bd66184",
+                "reference": "e84a723ae9c0d590e3a4deaba9d4fba54bd66184",
                 "shasum": ""
             },
             "require": {
@@ -273,7 +273,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-04-29T06:27:48+00:00"
+            "time": "2024-05-01T00:36:22+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency