### PR TITLE
fix: Avoid loading file actions if app is disabled for users

### DIFF
--- a/lib/Listener/LoadAdditionalListener.php
+++ b/lib/Listener/LoadAdditionalListener.php
@@ -3,6 +3,7 @@
 namespace OCA\Richdocuments\Listener;
 
 use OCA\Richdocuments\AppInfo\Application;
+use OCA\Richdocuments\PermissionManager;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -10,14 +11,18 @@ use OCP\Util;
 
 /** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalListener implements IEventListener {
+	public function __construct(
+		private PermissionManager $permissionManager,
+		private ?string $userId,
+	) {
+	}
+
 	public function handle(Event $event): void {
-		// If not a LoadAdditionalScriptsEvent, we should do nothing
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {
 			return;
 		}
 
-		// If we can add an init script, we add the file-actions script
-		if (method_exists(Util::class, 'addInitScript')) {
+		if ($this->permissionManager->isEnabledForUser() && $this->userId !== null) {
 			Util::addInitScript(Application::APPNAME, 'richdocuments-fileActions');
 		}
 	}


### PR DESCRIPTION
Fix #3670 

This makes sure we do not load the file actions script if the app is disabled for specific user groups in the settings. Otherwise the enabled check of the files app will throw an uncaught error.