### PR TITLE
fix: Do not set user id for guests

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -381,10 +381,6 @@ class DocumentController extends Controller {
 			$share = $shareToken ? $this->shareManager->getShareByToken($shareToken) : null;
 			$file = $shareToken ? $this->getFileForShare($share, $fileId, $path) : $this->getFileForUser($fileId, $path);
 
-			if ($this->userId === null) {
-				$this->userId = $guestName;
-			}
-
 			$wopi = $this->getToken($file, $share);
 
 			return new DataResponse(array_merge(


### PR DESCRIPTION
Should fix #3675 

Aparently I've not catched that during testing as it only happens on file save. We should extend our integration tests for the WOPI endpoints in that regard.

@elzody Do you recall what the line tried to achieve in your recent change?

Edit: This test could have catched this however the /token endpoint is not used in the behat tests. Will see if we can extend that