### PR TITLE
fix: Avoid triggering file list requests during handover to desktop client

### DIFF
--- a/src/mixins/openLocal.js
+++ b/src/mixins/openLocal.js
@@ -95,8 +95,6 @@ export default {
 
 		openLocally() {
 			if (this.openingLocally) {
-				this.openingLocally = false
-
 				axios.post(
 					generateOcsUrl('apps/files/api/v1/openlocaleditor'),
 					{ path: this.filename },
@@ -106,8 +104,13 @@ export default {
 						+ encodePath(this.filename)
 						+ '?token=' + result.data.ocs.data.token
 
-					this.showOpenLocalFinished(url, window.top)
-					this.close()
+					this.showOpenLocalFinished()
+					// Firefox may cancel requests that the files app could send when updating the file meta data
+					// so we need to wait a bit before closing the viewer
+					setTimeout(() => {
+						this.openingLocally = false
+						this.close()
+					}, 1000)
 					window.open(url, '_self')
 				})
 			}

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -469,7 +469,7 @@ export default {
 				this.buttonClicked(args)
 				break
 			case 'Doc_ModifiedStatus':
-				if (args.Modified !== this.modified) {
+				if (args.Modified !== this.modified && !this.openingLocally) {
 					FilesAppIntegration.updateFileInfo(undefined, Date.now())
 				}
 				this.modified = args.Modified


### PR DESCRIPTION
Fixes #3665 

When opening a file locally we let the browser open a custom URL with a protocol handler that triggers the desktop client. Now when we close the viewer we usually trigger an update of the file mtime. Some browsers (e.g. Firefox) cancel ongoing requests which then leads to [an error message in the files app](https://github.com/nextcloud/server/blob/aff8b5620c0b136afba8131762978917f90b6d02/apps/files/src/components/NavigationQuota.vue#L145).

We can avoid this by just deferring the close action a bit as the current page context will continue to be executed after the `nc://` url has been invoked.

On a separate note:
The files app regularly fetches the storage statistics https://github.com/nextcloud/server/blob/aff8b5620c0b136afba8131762978917f90b6d02/apps/files/src/components/NavigationQuota.vue#L108-L114 however the backend caches those for 5 minutes since https://github.com/nextcloud/server/commit/bdfef2dbd1872f1895ec88bd8879a252f4d147b7 so there is also not much use of updating this all the time.