### PR TITLE
[stable29] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "d8c0e1b556b8b2aefe225aa2f9d65ec8d743aa47"
+                "reference": "36698398d842967e052fbd191c133b0828b53f08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/d8c0e1b556b8b2aefe225aa2f9d65ec8d743aa47",
-                "reference": "d8c0e1b556b8b2aefe225aa2f9d65ec8d743aa47",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/36698398d842967e052fbd191c133b0828b53f08",
+                "reference": "36698398d842967e052fbd191c133b0828b53f08",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
             },
-            "time": "2024-05-09T00:34:07+00:00"
+            "time": "2024-06-01T00:37:47+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency