### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "446b922114c1a6d5e0a9a81a207388080f6a94c2"
+                "reference": "cc219f6089f70c20cbea450cf73aa867ddc0df1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/446b922114c1a6d5e0a9a81a207388080f6a94c2",
-                "reference": "446b922114c1a6d5e0a9a81a207388080f6a94c2",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cc219f6089f70c20cbea450cf73aa867ddc0df1f",
+                "reference": "cc219f6089f70c20cbea450cf73aa867ddc0df1f",
                 "shasum": ""
             },
             "require": {
@@ -273,7 +273,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-05-25T00:33:43+00:00"
+            "time": "2024-06-01T00:37:43+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency