### PR TITLE
Always pass is_admin property to userextrainfo

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -198,9 +198,12 @@ class WopiController extends Controller {
 			$response['UserExtraInfo']['avatar'] = $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $wopi->getEditorUid(), 'size' => self::WOPI_AVATAR_SIZE]);
 			if ($this->groupManager->isAdmin($wopi->getEditorUid())) {
 				$response['UserExtraInfo']['is_admin'] = true;
+			} else {
+				$response['UserExtraInfo']['is_admin'] = false;
 			}
 		} else {
 			$response['UserExtraInfo']['avatar'] = $this->urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => urlencode($wopi->getGuestDisplayname()), 'size' => self::WOPI_AVATAR_SIZE]);
+			$response['UserExtraInfo']['is_admin'] = false;
 		}
 
 		if ($isPublic) {


### PR DESCRIPTION
This will be used by COOL for server audit dialog
- which should be shown only for admin users. In case of missing is_admin property - it will be shown too because it means integration don't use that property.

see https://github.com/CollaboraOnline/online/pull/9204