### PR TITLE
Remove legacy Viewer code

### DIFF
--- a/src/viewer.js
+++ b/src/viewer.js
@@ -21,29 +21,3 @@ if (OCA.Viewer) {
 		canCompare: true,
 	})
 }
-
-// TODO: Viewer.openWith introduced with https://github.com/nextcloud/viewer/pull/1273
-//       This check can be replaced with `if(OCA.Viewer)` once NC 24 is EOL.
-if (OCA.Viewer.openWith && OCA?.Files?.fileActions) {
-	const supportedMimes = getCapabilities().richdocuments.mimetypesNoDefaultOpen
-	const actionName = 'Edit with ' + getCapabilities().richdocuments.productName
-	const actionDisplayNameEdit = t('richdocuments', 'Edit with {productName}', { productName: getCapabilities().richdocuments.productName }, undefined, { escape: false })
-	const actionDisplayNameOpen = t('richdocuments', 'Open with {productName}', { productName: getCapabilities().richdocuments.productName }, undefined, { escape: false })
-
-	for (const mime of supportedMimes) {
-		const action = {
-			name: actionName,
-			mime,
-			permissions: OC.PERMISSION_READ,
-			iconClass: 'icon-richdocuments',
-			displayName: mime === 'application/pdf' ? actionDisplayNameOpen : actionDisplayNameEdit,
-			actionHandler: (fileName, context) => {
-				OCA.Viewer.openWith('richdocuments', {
-					path: context.fileInfoModel.getFullPath(),
-				})
-			},
-		}
-
-		OCA.Files.fileActions.registerAction(action)
-	}
-}


### PR DESCRIPTION
* Resolve: #3728 
* Target version: main

### Summary
As a result of #3645, there is still some legacy code in `viewer.js` which is no longer needed since that PR was merged. I think it is safe to be removed from main, stable29, and stable28.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
