### PR TITLE
fix: Avoid requesting remote endpoints during bootstrap

### DIFF
--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -66,6 +66,7 @@ return array(
     'OCA\\Richdocuments\\Preview\\OpenDocument' => $baseDir . '/../lib/Preview/OpenDocument.php',
     'OCA\\Richdocuments\\Preview\\Pdf' => $baseDir . '/../lib/Preview/Pdf.php',
     'OCA\\Richdocuments\\Reference\\OfficeTargetReferenceProvider' => $baseDir . '/../lib/Reference/OfficeTargetReferenceProvider.php',
+    'OCA\\Richdocuments\\Service\\CachedRequestService' => $baseDir . '/../lib/Service/CachedRequestService.php',
     'OCA\\Richdocuments\\Service\\CapabilitiesService' => $baseDir . '/../lib/Service/CapabilitiesService.php',
     'OCA\\Richdocuments\\Service\\ConnectivityService' => $baseDir . '/../lib/Service/ConnectivityService.php',
     'OCA\\Richdocuments\\Service\\DemoService' => $baseDir . '/../lib/Service/DemoService.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -81,6 +81,7 @@ class ComposerStaticInitRichdocuments
         'OCA\\Richdocuments\\Preview\\OpenDocument' => __DIR__ . '/..' . '/../lib/Preview/OpenDocument.php',
         'OCA\\Richdocuments\\Preview\\Pdf' => __DIR__ . '/..' . '/../lib/Preview/Pdf.php',
         'OCA\\Richdocuments\\Reference\\OfficeTargetReferenceProvider' => __DIR__ . '/..' . '/../lib/Reference/OfficeTargetReferenceProvider.php',
+        'OCA\\Richdocuments\\Service\\CachedRequestService' => __DIR__ . '/..' . '/../lib/Service/CachedRequestService.php',
         'OCA\\Richdocuments\\Service\\CapabilitiesService' => __DIR__ . '/..' . '/../lib/Service/CapabilitiesService.php',
         'OCA\\Richdocuments\\Service\\ConnectivityService' => __DIR__ . '/..' . '/../lib/Service/ConnectivityService.php',
         'OCA\\Richdocuments\\Service\\DemoService' => __DIR__ . '/..' . '/../lib/Service/DemoService.php',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -120,12 +120,18 @@ class Application extends App implements IBootstrap {
 			$appConfig->setAppValue('wopi_url', $new_wopi_url);
 			$appConfig->setAppValue('disable_certificate_verification', 'yes');
 
+			/** @var DiscoveryService $discoveryService */
 			$discoveryService = $this->getContainer()->get(DiscoveryService::class);
+			/** @var CapabilitiesService $capabilitiesService */
 			$capabilitiesService = $this->getContainer()->get(CapabilitiesService::class);
 
 			$discoveryService->resetCache();
 			$capabilitiesService->resetCache();
-			$capabilitiesService->fetchFromRemote();
+			try {
+				$capabilitiesService->fetch();
+				$discoveryService->fetch();
+			} catch (\Exception $e) {
+			}
 		}
 	}
 }

--- a/lib/Backgroundjobs/ObtainCapabilities.php
+++ b/lib/Backgroundjobs/ObtainCapabilities.php
@@ -7,21 +7,34 @@
 namespace OCA\Richdocuments\Backgroundjobs;
 
 use OCA\Richdocuments\Service\CapabilitiesService;
+use OCA\Richdocuments\Service\DiscoveryService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
 
 class ObtainCapabilities extends TimedJob {
-	/** @var CapabilitiesService */
-	private $capabilitiesService;
-
-	public function __construct(ITimeFactory $time, CapabilitiesService $capabilitiesService) {
+	public function __construct(
+		ITimeFactory $time,
+		private LoggerInterface $logger,
+		private CapabilitiesService $capabilitiesService,
+		private DiscoveryService $discoveryService,
+	) {
 		parent::__construct($time);
-		$this->capabilitiesService = $capabilitiesService;
 
 		$this->setInterval(60 * 60);
 	}
 
 	protected function run($argument) {
-		$this->capabilitiesService->fetchFromRemote();
+		try {
+			$this->capabilitiesService->fetch();
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to fetch capabilities: ' . $e->getMessage(), ['exception' => $e]);
+		}
+
+		try {
+			$this->discoveryService->fetch();
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to fetch discovery: ' . $e->getMessage(), ['exception' => $e]);
+		}
 	}
 }

--- a/lib/Service/CachedRequestService.php
+++ b/lib/Service/CachedRequestService.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Service;
+
+use OCA\Richdocuments\AppInfo\Application;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\NotFoundException;
+use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
+use OCP\ICacheFactory;
+use Psr\Log\LoggerInterface;
+
+abstract class CachedRequestService {
+
+	public function __construct(
+		private IClientService $clientService,
+		private ICacheFactory $cacheFactory,
+		private IAppDataFactory $appDataFactory,
+		private IAppConfig $appConfig,
+		private LoggerInterface $logger,
+		private string $cacheKey,
+	) {
+	}
+
+	/**
+	 * Method to implement sending a request and returning the result as a string
+	 * @throw \Exception in case the request fails
+	 */
+	abstract protected function sendRequest(IClient $client): string;
+
+	public function get(): ?string {
+		$cache = $this->cacheFactory->createDistributed('richdocuments');
+
+		if ($cached = $cache->get($this->cacheKey)) {
+			return $cached;
+		}
+
+		$folder = $this->getAppDataFolder();
+		if ($folder->fileExists($this->cacheKey)) {
+			$value = $folder->getFile($this->cacheKey)->getContent();
+			$cache->set($this->cacheKey, $value, 3600);
+			return $value;
+		}
+
+		return null;
+	}
+
+	public function getLastUpdate(): ?int {
+		$folder = $this->getAppDataFolder();
+		if (!$folder->fileExists($this->cacheKey)) {
+			return null;
+		}
+		return $folder->getFile($this->cacheKey)->getMTime();
+	}
+
+	/**
+	 * Cached value will be kept if the request fails
+	 *
+	 * @return string
+	 * @throws \Exception
+	 */
+	final public function fetch(): string {
+		$cache = $this->cacheFactory->createDistributed('richdocuments');
+		$client = $this->clientService->newClient();
+
+		$startTime = microtime(true);
+		$response = $this->sendRequest($client);
+		$duration = round(((microtime(true) - $startTime)), 3);
+		$this->logger->info('Fetched remote endpoint from ' . $this->cacheKey . ' in ' . $duration . ' seconds');
+
+		$this->getAppDataFolder()->newFile($this->cacheKey, $response);
+		$cache->set($this->cacheKey, $response);
+		return $response;
+	}
+
+	public function resetCache(): void {
+		$cache = $this->cacheFactory->createDistributed('richdocuments');
+		$cache->remove($this->cacheKey);
+		$folder = $this->getAppDataFolder();
+		if ($folder->fileExists($this->cacheKey)) {
+			$folder->getFile($this->cacheKey)->delete();
+		}
+	}
+
+	protected function getDefaultRequestOptions(): array {
+		$options = [
+			'timeout' => 5,
+			'nextcloud' => [
+				'allow_local_address' => true
+			]
+		];
+
+		if ($this->appConfig->getValueString('richdocuments', 'disable_certificate_verification') === 'yes') {
+			$options['verify'] = false;
+		}
+
+		if ($this->isProxyStarting()) {
+			$options['timeout'] = 180;
+		}
+
+		return $options;
+	}
+
+	private function getAppDataFolder(): ISimpleFolder {
+		$appData = $this->appDataFactory->get(Application::APPNAME);
+		try {
+			$folder = $appData->getFolder('remoteData');
+		} catch (NotFoundException $e) {
+			$folder = $appData->newFolder('remoteData');
+		}
+		return $folder;
+	}
+
+	/**
+	 * @return boolean indicating if proxy.php is in initialize or false otherwise
+	 */
+	private function isProxyStarting(): bool {
+		$url = $this->appConfig->getValueString('richdocuments', 'wopi_url', '');
+		$usesProxy = false;
+		$proxyPos = strrpos($url, 'proxy.php');
+		if ($proxyPos !== false) {
+			$usesProxy = true;
+		}
+
+		if ($usesProxy === true) {
+			$statusUrl = substr($url, 0, $proxyPos);
+			$statusUrl = $statusUrl . 'proxy.php?status';
+
+			$client = $this->clientService->newClient();
+			$options = ['timeout' => 5, 'nextcloud' => ['allow_local_address' => true]];
+
+			if ($this->appConfig->getValueString('richdocuments', 'disable_certificate_verification') === 'yes') {
+				$options['verify'] = false;
+			}
+
+			try {
+				$response = $client->get($statusUrl, $options);
+
+				if ($response->getStatusCode() === 200) {
+					$body = json_decode($response->getBody(), true);
+
+					if ($body['status'] === 'starting'
+						|| $body['status'] === 'stopped'
+						|| $body['status'] === 'restarting') {
+						return true;
+					}
+				}
+			} catch (\Exception $e) {
+				// ignore
+			}
+		}
+
+		return false;
+	}
+}

--- a/lib/Service/ConnectivityService.php
+++ b/lib/Service/ConnectivityService.php
@@ -25,7 +25,7 @@ class ConnectivityService {
 	 */
 	public function testDiscovery(OutputInterface $output): void {
 		$this->discoveryService->resetCache();
-		$this->discoveryService->fetchFromRemote();
+		$this->discoveryService->fetch();
 		$output->writeln('<info>✓ Fetched /hosting/discovery endpoint</info>');
 
 		$this->parser->getUrlSrcValue('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
@@ -38,7 +38,7 @@ class ConnectivityService {
 
 	public function testCapabilities(OutputInterface $output): void {
 		$this->capabilitiesService->resetCache();
-		$this->capabilitiesService->fetchFromRemote(true);
+		$this->capabilitiesService->fetch(true);
 		$output->writeln('<info>✓ Fetched /hosting/capabilities endpoint</info>');
 
 		if ($this->capabilitiesService->getCapabilities() === []) {


### PR DESCRIPTION
This will add some abstraction layer for cached request data as used by
capabilities and discovery endpoints. By default it will always return
the cached data which will never expire (backed by a file in app data in
case the memory cache vanishes).

In short the logic is:
- Fetch the endpoints when configuring Collabora
- Refetch them every hour with the background job
- When trying to get the data we will (in order)
  - Check the memory cache
  - Check the file in appdata (and set the memory cache again)

There is still a use of fetch for richdocumentscode but that needs some more refactoring to work differently. Does not affect instances where richdocumentscode is not enabled.

Also decreasing the timeout to 5 seconds which should be more then enough.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
