### PR TITLE
fix: Avoid background fetch if not configured

### DIFF
--- a/lib/Backgroundjobs/ObtainCapabilities.php
+++ b/lib/Backgroundjobs/ObtainCapabilities.php
@@ -6,6 +6,7 @@
 
 namespace OCA\Richdocuments\Backgroundjobs;
 
+use OCA\Richdocuments\AppConfig;
 use OCA\Richdocuments\Service\CapabilitiesService;
 use OCA\Richdocuments\Service\DiscoveryService;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -18,6 +19,7 @@ class ObtainCapabilities extends TimedJob {
 		private LoggerInterface $logger,
 		private CapabilitiesService $capabilitiesService,
 		private DiscoveryService $discoveryService,
+		private AppConfig $appConfig,
 	) {
 		parent::__construct($time);
 
@@ -25,6 +27,10 @@ class ObtainCapabilities extends TimedJob {
 	}
 
 	protected function run($argument) {
+		if (!$this->appConfig->getCollaboraUrlInternal()) {
+			return;
+		}
+
 		try {
 			$this->capabilitiesService->fetch();
 		} catch (\Exception $e) {

--- a/lib/Service/ConnectivityService.php
+++ b/lib/Service/ConnectivityService.php
@@ -38,7 +38,7 @@ class ConnectivityService {
 
 	public function testCapabilities(OutputInterface $output): void {
 		$this->capabilitiesService->resetCache();
-		$this->capabilitiesService->fetch(true);
+		$this->capabilitiesService->fetch();
 		$output->writeln('<info>✓ Fetched /hosting/capabilities endpoint</info>');
 
 		if ($this->capabilitiesService->getCapabilities() === []) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/richdocuments/issues/3788

Avoid sending requests that fail later on if no URL is configured