### PR TITLE
Fix event name files:node:rename

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -463,7 +463,7 @@ export default {
 		if (node) {
 			if (name) {
 				node.rename(name)
-				emit('files:node:renamed', this.source)
+				emit('files:node:rename', this.source)
 			}
 			if (mtime) {
 				node._data.mtime = new Date(mtime)


### PR DESCRIPTION
From the files action, it does not have an ending `d`: https://vscode.dev/github/nextcloud/server/blob/artonge/fix/update_favorite_navigation/apps/files/src/actions/renameAction.spec.ts#L90
Or maybe it should and the file action is wrong?

Other reference: https://github.com/nextcloud/text/blob/master/src/views/RichWorkspace.vue#L105