### PR TITLE
fix(client): Use shared default options for HTTP client requests

### DIFF
--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -75,6 +75,7 @@ return array(
     'OCA\\Richdocuments\\Service\\FileTargetService' => $baseDir . '/../lib/Service/FileTargetService.php',
     'OCA\\Richdocuments\\Service\\FontService' => $baseDir . '/../lib/Service/FontService.php',
     'OCA\\Richdocuments\\Service\\InitialStateService' => $baseDir . '/../lib/Service/InitialStateService.php',
+    'OCA\\Richdocuments\\Service\\RemoteOptionsService' => $baseDir . '/../lib/Service/RemoteOptionsService.php',
     'OCA\\Richdocuments\\Service\\RemoteService' => $baseDir . '/../lib/Service/RemoteService.php',
     'OCA\\Richdocuments\\Service\\UserScopeService' => $baseDir . '/../lib/Service/UserScopeService.php',
     'OCA\\Richdocuments\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -90,6 +90,7 @@ class ComposerStaticInitRichdocuments
         'OCA\\Richdocuments\\Service\\FileTargetService' => __DIR__ . '/..' . '/../lib/Service/FileTargetService.php',
         'OCA\\Richdocuments\\Service\\FontService' => __DIR__ . '/..' . '/../lib/Service/FontService.php',
         'OCA\\Richdocuments\\Service\\InitialStateService' => __DIR__ . '/..' . '/../lib/Service/InitialStateService.php',
+        'OCA\\Richdocuments\\Service\\RemoteOptionsService' => __DIR__ . '/..' . '/../lib/Service/RemoteOptionsService.php',
         'OCA\\Richdocuments\\Service\\RemoteService' => __DIR__ . '/..' . '/../lib/Service/RemoteService.php',
         'OCA\\Richdocuments\\Service\\UserScopeService' => __DIR__ . '/..' . '/../lib/Service/UserScopeService.php',
         'OCA\\Richdocuments\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',

--- a/lib/Service/CachedRequestService.php
+++ b/lib/Service/CachedRequestService.php
@@ -19,7 +19,6 @@ use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 abstract class CachedRequestService {
-
 	public function __construct(
 		private IClientService $clientService,
 		private ICacheFactory $cacheFactory,
@@ -91,12 +90,7 @@ abstract class CachedRequestService {
 	}
 
 	protected function getDefaultRequestOptions(): array {
-		$options = [
-			'timeout' => 5,
-			'nextcloud' => [
-				'allow_local_address' => true
-			]
-		];
+		$options = RemoteOptionsService::getDefaultOptions();
 
 		if ($this->appConfig->getValueString('richdocuments', 'disable_certificate_verification') === 'yes') {
 			$options['verify'] = false;

--- a/lib/Service/RemoteOptionsService.php
+++ b/lib/Service/RemoteOptionsService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Richdocuments\Service;
+
+class RemoteOptionsService {
+	public const REMOTE_TIMEOUT_DEFAULT = 5;
+
+	public static function getDefaultOptions(int $timeout = self::REMOTE_TIMEOUT_DEFAULT): array {
+		return [
+			'timeout' => $timeout,
+			'nextcloud' => [
+				'allow_local_address' => true,
+			]
+		];
+	}
+
+}

--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -13,9 +13,6 @@ use OCP\Http\Client\IClientService;
 use Psr\Log\LoggerInterface;
 
 class RemoteService {
-
-	public const REMOTE_TIMEOUT_DEFAULT = 25;
-
 	public function __construct(
 		private AppConfig $appConfig,
 		private IClientService $clientService,
@@ -69,12 +66,10 @@ class RemoteService {
 			$stream = $file->fopen('rb');
 		}
 
-		$options = [
-			'timeout' => self::REMOTE_TIMEOUT_DEFAULT,
-			'multipart' => [
-				['name' => $file->getName(), 'contents' => $stream],
-				['name' => 'target', 'contents' => $target]
-			]
+		$options = RemoteOptionsService::getDefaultOptions(25);
+		$options['multipart'] = [
+			['name' => $file->getName(), 'contents' => $stream],
+			['name' => 'target', 'contents' => $target]
 		];
 
 		if ($this->appConfig->getDisableCertificateValidation()) {


### PR DESCRIPTION
Makes sure we always set a sane timeout and `allow_local_address`.

Fixes: #3255
Fixes: #3435
Fixes: nextcloud/server#44190

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
