### PR TITLE
fix: Do not ask for guest name on read only pdfs

### DIFF
--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -20,12 +20,13 @@ const setGuestNameCookie = (username) => {
 	}
 }
 
-const shouldAskForGuestName = () => {
+const shouldAskForGuestName = (mimetype, canWrite) => {
 	const noLoggedInUser = !getLoggedInUser()
 	const noGuestCookie = !cookieAlreadySet('guestUser')
 	const noCurrentUser = !getCurrentUser() || getCurrentUser()?.uid === ''
+	const isReadOnlyPDF = mimetype === 'application/pdf' && !canWrite
 
-	return noLoggedInUser && noGuestCookie && noCurrentUser
+	return noLoggedInUser && noGuestCookie && noCurrentUser && !isReadOnlyPDF
 }
 
 export {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -159,6 +159,14 @@ export default {
 			type: String,
 			default: null,
 		},
+		mime: {
+			type: String,
+			default: null,
+		},
+		permissions: {
+			type: String,
+			default: '',
+		},
 		isEmbedded: {
 			type: Boolean,
 			default: false,
@@ -271,7 +279,7 @@ export default {
 		}
 		this.postMessage.registerPostMessageHandler(this.postMessageHandler)
 
-		if (shouldAskForGuestName()) {
+		if (shouldAskForGuestName(this.mime, this.permissions?.includes('W'))) {
 			const { default: GuestNamePicker } = await import(
 				/* webpackChunkName: 'GuestNamePicker' */
 				'../components/GuestNamePicker.vue')


### PR DESCRIPTION
Avoid asking for the guest name if a read only PDF is opened as there is nothing guests can do then