### PR TITLE
fix: Allow passing css var to change Collabora logo color

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -140,8 +140,14 @@ const generateCSSVarTokens = () => {
 	darkElement.remove()
 	const customLogo = loadState('richdocuments', 'theming-customLogo', false)
 	if (customLogo) {
-		str += ';--nc-custom-logo=' + window.OCA?.Theming?.cacheBuster ?? 0 + ';'
+		str += '--nc-custom-logo=' + window.OCA?.Theming?.cacheBuster ?? 0 + ';'
 	}
+
+	// Get logo background color set via custom css app
+	const rootEl = document.querySelector(':root')
+	const logoBgColor = window.getComputedStyle(rootEl).getPropertyValue('--nc-logo-background')
+	str += '--nc-logo-background=' + logoBgColor + ';'
+
 	return str.replace(/["']/g, '\\\'')
 }
 

--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -143,10 +143,13 @@ const generateCSSVarTokens = () => {
 		str += '--nc-custom-logo=' + window.OCA?.Theming?.cacheBuster ?? 0 + ';'
 	}
 
-	// Get logo background color set via custom css app
 	const rootEl = document.querySelector(':root')
+
 	const logoBgColor = window.getComputedStyle(rootEl).getPropertyValue('--nc-logo-background')
-	str += '--nc-logo-background=' + logoBgColor + ';'
+	str += '--nc-logo-background=' + (logoBgColor === '' ? 'transparent' : logoBgColor) + ';'
+
+	const logoDisplay = window.getComputedStyle(rootEl).getPropertyValue('--nc-logo-display')
+	str += '--nc-logo-display=' + (logoDisplay === '' ? 'block' : logoDisplay) + ';'
 
 	return str.replace(/["']/g, '\\\'')
 }


### PR DESCRIPTION
* Target version: main

### Summary
Allows a user to set custom css values for the logo background color and logo visibility in Collabora.

Example:
```css
:root {
  /* change the background color of the logo */
  --nc-logo-background: cyan;

  /* or hide the logo completely */
  --nc-logo-display: none;
}
```

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
