### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "7610f7fc7b68011fc4cd84ac63abb308fcc7b824"
+                "reference": "c15539c648081c00fa826d734f013f155bff6098"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/7610f7fc7b68011fc4cd84ac63abb308fcc7b824",
-                "reference": "7610f7fc7b68011fc4cd84ac63abb308fcc7b824",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c15539c648081c00fa826d734f013f155bff6098",
+                "reference": "c15539c648081c00fa826d734f013f155bff6098",
                 "shasum": ""
             },
             "require": {
@@ -273,7 +273,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-07-25T12:38:15+00:00"
+            "time": "2024-07-27T00:37:10+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency