### PR TITLE
Fix/guest username

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.5.0-beta.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/auth": "^2.3.0",
+        "@nextcloud/auth": "^2.4.0",
         "@nextcloud/axios": "^2.5.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/dialogs": "^5.3.5",
@@ -2961,11 +2961,12 @@
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
-      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.4.0.tgz",
+      "integrity": "sha512-T5OFltKd0O9Hfj47VrzE7TVjCwqOMHH9JLyjjLUR3pu2MaTY9WL6AjL79sHbFTXUaIkftZgJKu12lHYmqXnL2Q==",
       "dependencies": {
-        "@nextcloud/event-bus": "^3.2.0"
+        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/event-bus": "^3.3.1"
       },
       "engines": {
         "node": "^20.0.0",
@@ -21330,11 +21331,12 @@
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
     },
     "@nextcloud/auth": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.3.0.tgz",
-      "integrity": "sha512-PCkRJbML9sXvBENY43vTIERIZJFk2azu08IK6zYOnOZ7cFkD1QlFJtdTCZTImQLg01IXhIm0j0ExEdatHoqz7g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.4.0.tgz",
+      "integrity": "sha512-T5OFltKd0O9Hfj47VrzE7TVjCwqOMHH9JLyjjLUR3pu2MaTY9WL6AjL79sHbFTXUaIkftZgJKu12lHYmqXnL2Q==",
       "requires": {
-        "@nextcloud/event-bus": "^3.2.0"
+        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/event-bus": "^3.3.1"
       }
     },
     "@nextcloud/axios": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:coverage": "NODE_ENV=test jest --coverage"
   },
   "dependencies": {
-    "@nextcloud/auth": "^2.3.0",
+    "@nextcloud/auth": "^2.4.0",
     "@nextcloud/axios": "^2.5.0",
     "@nextcloud/capabilities": "^1.2.0",
     "@nextcloud/dialogs": "^5.3.5",

--- a/src/components/GuestNamePicker.vue
+++ b/src/components/GuestNamePicker.vue
@@ -43,10 +43,10 @@
 </template>
 
 <script>
+import { setGuestNickname } from '@nextcloud/auth'
 import { NcButton, NcIconSvgWrapper, NcModal, NcTextField } from '@nextcloud/vue'
 import { translate as t } from '@nextcloud/l10n'
 import axios from '@nextcloud/axios'
-import { setGuestNameCookie } from '../helpers/guestName.js'
 
 export default {
 	name: 'GuestNamePicker',
@@ -107,10 +107,10 @@ export default {
 			this.guestName = guestName
 		},
 		async submit() {
-			setGuestNameCookie(this.guestName)
+			setGuestNickname(this.guestName)
 			this.show = false
 
-			await this.onSubmit(this.guestName)
+			await this.onSubmit()
 		},
 	},
 }

--- a/src/helpers/guestName.js
+++ b/src/helpers/guestName.js
@@ -3,33 +3,23 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getCurrentUser } from '@nextcloud/auth'
+import {
+	getCurrentUser,
+	getGuestNickname,
+} from '@nextcloud/auth'
 import getLoggedInUser from '../helpers/getLoggedInUser.js'
 
-const cookieAlreadySet = (cookieName) => {
-	return document.cookie
-		.split(';')
-		.some(cookie => {
-			return cookie.trim().startsWith(`${cookieName}=`)
-		})
-}
-
-const setGuestNameCookie = (username) => {
-	if (username !== '') {
-		document.cookie = 'guestUser=' + encodeURIComponent(username) + '; path=/'
-	}
-}
-
-const shouldAskForGuestName = (mimetype, canWrite) => {
+/**
+ * Determines if the user should be asked to enter a guest name
+ *
+ * @param {string} mimetype - Mimetype of the file
+ * @param {boolean} canWrite - If write access is granted
+ */
+export function shouldAskForGuestName(mimetype, canWrite) {
 	const noLoggedInUser = !getLoggedInUser()
-	const noGuestCookie = !cookieAlreadySet('guestUser')
+	const noGuest = !getGuestNickname()
 	const noCurrentUser = !getCurrentUser() || getCurrentUser()?.uid === ''
 	const isReadOnlyPDF = mimetype === 'application/pdf' && !canWrite
 
-	return noLoggedInUser && noGuestCookie && noCurrentUser && !isReadOnlyPDF
-}
-
-export {
-	setGuestNameCookie,
-	shouldAskForGuestName,
+	return noLoggedInUser && noGuest && noCurrentUser && !isReadOnlyPDF
 }

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -116,7 +116,7 @@ import pickLink from '../mixins/pickLink.js'
 import saveAs from '../mixins/saveAs.js'
 import uiMention from '../mixins/uiMention.js'
 import version from '../mixins/version.js'
-import { getCurrentUser } from '@nextcloud/auth'
+import { getCurrentUser, getGuestNickname } from '@nextcloud/auth'
 import { shouldAskForGuestName } from '../helpers/guestName.js'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
@@ -182,8 +182,6 @@ export default {
 			error: null,
 			errorType: null,
 			loadingMsg: null,
-
-			guestName: null,
 
 			showLinkPicker: false,
 			showZotero: false,
@@ -286,8 +284,7 @@ export default {
 
 			spawnDialog(GuestNamePicker, {
 				fileName: basename(this.filename),
-				onSubmit: async (guestName) => {
-					this.guestName = guestName
+				onSubmit: async () => {
 					await this.load()
 				},
 			})
@@ -307,7 +304,7 @@ export default {
 
 			// Generate WOPI token
 			const { data } = await axios.post(generateUrl('/apps/richdocuments/token'), {
-				fileId: fileid, shareToken: this.shareToken, version, guestName: this.guestName,
+				fileId: fileid, shareToken: this.shareToken, version, guestName: getGuestNickname(),
 			})
 			Config.update('urlsrc', data.urlSrc)
 			Config.update('wopi_callback_url', loadState('richdocuments', 'wopi_callback_url', ''))


### PR DESCRIPTION
* Resolves: #3865 
* Target version: main

### Summary
This PR updates the `@nextcloud/auth` version in use by richdocuments in order to take advantage of the `getGuestnickname` and `setGuestNickname` methods introduced, which use local browser storage rather than a cookie to set the guest nickname.

I think the issue previously was that the cookie with the guest name was set, but it wasn't read again and used, thus only being used on the first time the user is asked. But now it's fixed, and does not use a cookie anymore.

As far as I can tell, it does not require any back-end change.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Tests
- [x] Documentation (manuals or wiki) has been updated or is not required
