### PR TITLE
Fixes #3902 : allow double click in image picker

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -169,7 +169,9 @@ export default {
 			.addButton({
 				label: t('richdocuments', 'Insert image'),
 				callback: (files) => {
-					insertFileFromPath(files[0].path)
+					if (files && files.length) {
+						insertFileFromPath(files[0].path)
+					}
 				},
 			})
 			.build()


### PR DESCRIPTION
Steps to reproduce the behavior:

1. Open any document in Nextcloud Office
2. Insert -> Insert Image... (it shows NC file picker)
3. Double click on any entry (or even anywhere in the dialog?)
4. Click button 'Insert Image'

Result: no image inserted, in the browser console we can see error:
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'path')