### PR TITLE
Cache `extractFields` response from Collabora

### DIFF
--- a/lib/Service/TemplateFieldService.php
+++ b/lib/Service/TemplateFieldService.php
@@ -14,15 +14,20 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Template\Field;
 use OCP\Files\Template\FieldType;
 use OCP\Http\Client\IClientService;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
 
 class TemplateFieldService {
+	private ICache $cache;
+
 	public function __construct(
 		private IClientService $clientService,
 		private CapabilitiesService $capabilitiesService,
 		private AppConfig $appConfig,
 		private IRootFolder $rootFolder,
-		private LoggerInterface $logger
+		private LoggerInterface $logger,
+		private ICacheFactory $cacheFactory
 	) {
 	}
 
@@ -42,6 +47,14 @@ class TemplateFieldService {
 		try {
 			if (!$file) {
 				throw new NotFoundException();
+			}
+
+			$localCache = $this->cacheFactory->createLocal('richdocuments_templates/');
+			$cacheName = $file->getId() . "/" . $file->getEtag();
+			$cachedResponse = $localCache->get($cacheName);
+
+			if ($cachedResponse !== null) {
+				return $cachedResponse;
 			}
 
 			$collaboraUrl = $this->appConfig->getCollaboraUrlInternal();
@@ -81,7 +94,10 @@ class TemplateFieldService {
 				];
 			}
 
-			return array_merge([], ...$fields);
+			$fields = array_merge([], ...$fields);
+			$localCache->set($cacheName, $fields, 3600);
+
+			return $fields;
 		} catch (\Exception $e) {
 			$this->logger->error($e->getMessage());
 			return [];


### PR DESCRIPTION
* Resolves: #3892
* Target version: main

### Summary
I rebased this PR onto #3885 because it includes a fix for an error due to using `getFirstNodeById()` incorrectly.
Thus, should probably wait for #3885 to be merged before merging this one

The response from extracting fields via the Collabora endpoint should be cached as long as the file has not changed, since it prevents an extra hit to Collabora. When the file changes then, it should re-hit the Collabora endpoint for the updated template fields, then cache from there.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
