### PR TITLE
fix(branding): properly send custom logo to collabora

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -140,7 +140,7 @@ const generateCSSVarTokens = () => {
 	darkElement.remove()
 	const customLogo = loadState('richdocuments', 'theming-customLogo', false)
 	if (customLogo) {
-		str += '--nc-custom-logo=' + window.OCA?.Theming?.cacheBuster ?? 0 + ';'
+		str += `--nc-custom-logo=${window.OCA?.Theming?.cacheBuster ?? 0};`
 	}
 
 	const rootEl = document.querySelector(':root')


### PR DESCRIPTION
* Resolves: #3913 
* Target version: main

### Summary
This PR properly formats the string which hands over the css values to the collabora frame. It was previously not accepting a `;` at the end, invalidating the string and collabora couldn't read the `--nc-custom-logo` value properly. It seems to work better with string interpolation.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
