### PR TITLE
fix: Do not set a guest name on actual users

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -185,7 +185,7 @@ class TokenManager {
 		);
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
-		$guestName = $editoruid === null ? $this->prepareGuestName($this->helper->getGuestNameFromCookie()) : $editoruid;
+		$guestName = $editoruid === null ? $this->prepareGuestName($this->helper->getGuestNameFromCookie()) : null;
 		return $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guestName, $hideDownload, $direct, 0, $shareToken);
 	}
 


### PR DESCRIPTION
Should fix using the wrong user for filesystem access as described in https://github.com/nextcloud/server/issues/40090

Before this the node was obtained from the share owner which caused issues getting the relative path later on

Debugger screenshot for my own reference:

![image](https://github.com/user-attachments/assets/c2582b28-a101-4ca6-aaf6-25a260a97c1d)

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
