### PR TITLE
fix: Catch parsing errors or null doc structure

### DIFF
--- a/lib/Service/TemplateFieldService.php
+++ b/lib/Service/TemplateFieldService.php
@@ -87,7 +87,7 @@ class TemplateFieldService {
 				$form
 			);
 
-			$documentStructure = json_decode($response->getBody(), true)['DocStructure'];
+			$documentStructure = json_decode($response->getBody(), true)['DocStructure'] ?? [];
 			$fields = [];
 
 			foreach ($documentStructure as $index => $attr) {


### PR DESCRIPTION
Fixes errors like:

- [PHP] foreach() argument must be of type array|object, null given
- [PHP] Undefined array key "DocStructure"

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
