### PR TITLE
fix: Dispatch event instead of hook for audit logging

### DIFF
--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="lib/AppConfig.php">
     <InvalidArgument>
       <code><![CDATA[[]]]></code>
@@ -89,9 +89,6 @@
     <MissingDependency>
       <code><![CDATA[Image]]></code>
     </MissingDependency>
-    <UndefinedThisPropertyAssignment>
-      <code><![CDATA[$this->capabilitites]]></code>
-    </UndefinedThisPropertyAssignment>
   </file>
   <file src="lib/Service/ConnectivityService.php">
     <UndefinedClass>


### PR DESCRIPTION
With https://github.com/nextcloud/server/pull/47625 i noticed that we actually emit the wrong path (absolute instead of relative to the user directory) for the legacy hook. However since we want this for audit logging we can actually just emit the new node event that also saves some extra effort to get the node first then as we already have it.