### PR TITLE
fix: pressing `Enter` submits guest name input

### DIFF
--- a/src/components/GuestNamePicker.vue
+++ b/src/components/GuestNamePicker.vue
@@ -24,7 +24,8 @@
 			</p>
 
 			<fieldset>
-				<NcTextField :value="guestName"
+				<NcTextField ref="guestNameInput"
+					:value="guestName"
 					data-cy="guestNameInput"
 					:label="t('richdocuments', 'Guest name')"
 					:placeholder="t('richdocuments', 'Anonymous guest')"
@@ -83,6 +84,10 @@ export default {
 	},
 
 	async mounted() {
+		this.$nextTick(() => {
+			this.$refs.guestNameInput.focus()
+		})
+
 		const name = document.getElementById('filename').value
 		const mimeTypeIcon = async () => {
 			const url = document.getElementById('mimetypeIcon').value

--- a/src/components/GuestNamePicker.vue
+++ b/src/components/GuestNamePicker.vue
@@ -7,7 +7,9 @@
 		:out-transition="true"
 		size="small"
 		:show.sync="show">
-		<div class="modal__content" data-cy="guestNameModal">
+		<form class="modal__content"
+			data-cy="guestNameModal"
+			@submit.prevent.stop="submit">
 			<h3>
 				<NcIconSvgWrapper v-if="file.icon !== null"
 					:inline="true"
@@ -21,24 +23,24 @@
                                If you don\'t provide one, the default will be used.`) }}
 			</p>
 
-			<div class="modal__form">
+			<fieldset>
 				<NcTextField :value="guestName"
 					data-cy="guestNameInput"
 					:label="t('richdocuments', 'Guest name')"
 					:placeholder="t('richdocuments', 'Anonymous guest')"
 					type="text"
 					@update:value="setGuestName" />
-			</div>
-		</div>
+			</fieldset>
 
-		<div class="modal__buttons">
-			<NcButton data-cy="guestNameSubmit"
-				:aria-label="t('richdocuments', 'Submit name')"
-				type="primary"
-				@click="submit">
-				{{ t('richdocuments', 'Submit name') }}
-			</NcButton>
-		</div>
+			<div class="modal__buttons">
+				<NcButton data-cy="guestNameSubmit"
+					:aria-label="t('richdocuments', 'Submit name')"
+					type="primary"
+					native-type="submit">
+					{{ t('richdocuments', 'Submit name') }}
+				</NcButton>
+			</div>
+		</form>
 	</NcModal>
 </template>
 
@@ -120,16 +122,22 @@ export default {
 $modal-padding: calc(var(--default-grid-baseline) * 4);
 
 .modal__content {
-	padding: $modal-padding;
+  padding: $modal-padding;
 
-	.modal__form {
-		padding: 15px 0;
-	}
-}
+  h3 {
+    margin: 0;
+    display: flex;
+    align-items: center;
+  }
 
-.modal__buttons {
-	display: flex;
-	justify-content: center;
-	padding: 0 $modal-padding $modal-padding $modal-padding;
+  p, fieldset {
+    margin: 10px 0;
+  }
+
+  .modal__buttons {
+    margin-top: $modal-padding;
+    display: flex;
+    justify-content: end;
+  }
 }
 </style>


### PR DESCRIPTION
* Resolves: #3990 
* Target version: main

### Summary
With this PR the guest name input field is automatically focused, and you can submit it by pressing the `Enter` key. This makes it faster to input the name and get to the document, and follows the behavior users expect.

This is done by moving the dialog content into a `<form>` element, and using the form submit action. It also includes a few styling changes which I think make the dialog look better (but I'm not a designer :D)

### Example
<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/6d9d1735-1b5c-4a34-b517-780168ace11d)
</details>

<details>
<summary>After (video)</summary>

[vokoscreenNG-2024-09-05_14-00-57.webm](https://github.com/user-attachments/assets/92482037-a959-4366-ab61-086a935d8656)
</details>

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required