### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -237,12 +237,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "b6538d7f14472c2ef6182c51df6be34cae033099"
+                "reference": "081cbe36c64e4090f8d7b2858efa7d81c8eb3de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b6538d7f14472c2ef6182c51df6be34cae033099",
-                "reference": "b6538d7f14472c2ef6182c51df6be34cae033099",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/081cbe36c64e4090f8d7b2858efa7d81c8eb3de3",
+                "reference": "081cbe36c64e4090f8d7b2858efa7d81c8eb3de3",
                 "shasum": ""
             },
             "require": {
@@ -274,7 +274,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-08-31T00:39:40+00:00"
+            "time": "2024-09-06T00:40:00+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency