### PR TITLE
fix: failed token generation on public shares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/vue": "^8.18.0",
+        "@nextcloud/sharing": "^0.2.3",
         "vue": "^2.7.16",
         "vue-material-design-icons": "^5.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nextcloud/paths": "^2.2.1",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/vue": "^8.18.0",
+    "@nextcloud/sharing": "^0.2.3",
     "vue": "^2.7.16",
     "vue-material-design-icons": "^5.3.0"
   },

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -4,6 +4,7 @@
  */
 
 import { getRootUrl, generateUrl } from '@nextcloud/router'
+import { getSharingToken } from '@nextcloud/sharing/public'
 import { languageToBCP47 } from './index.js'
 import Config from './../services/config.tsx'
 
@@ -62,7 +63,7 @@ const getDocumentUrlForPublicFile = (fileName, fileId) => {
 	return generateUrl(
 		'apps/richdocuments/public?shareToken={shareToken}&fileName={fileName}&requesttoken={requesttoken}&fileId={fileId}',
 		{
-			shareToken: document.getElementById('sharingToken').value,
+			shareToken: getSharingToken(),
 			fileName,
 			fileId,
 			requesttoken: OC.requestToken,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -5,10 +5,11 @@
 
 import axios from '@nextcloud/axios'
 import { generateOcsUrl, generateFilePath } from '@nextcloud/router'
+import { getSharingToken } from '@nextcloud/sharing/public'
 import { getCurrentDirectory } from '../helpers/filesApp.js'
 
 export const createEmptyFile = async (mimeType, fileName, templateId = null) => {
-	const shareToken = document.getElementById('sharingToken')?.value
+	const shareToken = getSharingToken()
 	const directoryPath = getCurrentDirectory()
 
 	const response = await axios.post(generateOcsUrl('apps/richdocuments/api/v1/file', 2), {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -117,6 +117,7 @@ import saveAs from '../mixins/saveAs.js'
 import uiMention from '../mixins/uiMention.js'
 import version from '../mixins/version.js'
 import { getCurrentUser, getGuestNickname } from '@nextcloud/auth'
+import { getSharingToken } from '@nextcloud/sharing/public'
 import { shouldAskForGuestName } from '../helpers/guestName.js'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
@@ -233,7 +234,7 @@ export default {
 			return document.getElementById('isPublic')?.value === '1'
 		},
 		shareToken() {
-			return document.getElementById('sharingToken')?.value
+			return getSharingToken()
 		},
 		showAdminStorageFailure() {
 			return getCurrentUser()?.isAdmin && this.errorType === 'websocketloadfailed'


### PR DESCRIPTION
* Target version: main

### Summary
This is part of an effort to improve public sharing on the main branch with all the server changes for NC 31.
The issue here was that the sharing token was grabbed from an invisible html element that contained the token, which is no longer present -- the token instead must be gotten via either initial state from files_sharing or via this method using the `@nextcloud/sharing` library which I think is clearer. It also will be helpful for other things relating to public shares

https://nextcloud-libraries.github.io/nextcloud-sharing/modules/public.html

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
