### PR TITLE
fix: Use proper file id for direct editing

### DIFF
--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -19,6 +19,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
@@ -80,7 +81,7 @@ class DirectViewController extends Controller {
 
 		try {
 			$item = $folder->getFirstNodeById($direct->getFileid());
-			if (!($item instanceof Node)) {
+			if (!($item instanceof File)) {
 				throw new \Exception();
 			}
 
@@ -92,8 +93,17 @@ class DirectViewController extends Controller {
 				return $response;
 			}
 
-			$urlSrc = $this->tokenManager->getUrlSrc($item);
-			$wopi = $this->tokenManager->generateWopiToken($item->getId(), null, $direct->getUid(), true);
+			$wopi = null;
+			$template = $direct->getTemplateId() ? $this->templateManager->getTemplateSource($direct->getTemplateId()) : null;
+
+			if ($template !== null) {
+				$wopi = $this->tokenManager->generateWopiTokenForTemplate($template, $direct->getUid(), $item->getId(), true);
+			}
+
+			if ($wopi === null) {
+				$urlSrc = $this->tokenManager->getUrlSrc($item);
+				$wopi = $this->tokenManager->generateWopiToken($item->getId(), null, $direct->getUid(), true);
+			}
 		} catch (\Exception $e) {
 			$this->logger->error('Failed to generate token for existing file on direct editing', ['exception' => $e]);
 			return $this->renderErrorPage('Failed to open the requested file.');

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -278,7 +278,7 @@ class OCSController extends \OCP\AppFramework\OCSController {
 			$name = $folder->getNonExistingName($info['basename']);
 			$file = $folder->newFile($name);
 
-			$direct = $this->directMapper->newDirect($this->userId, $template, $file->getId());
+			$direct = $this->directMapper->newDirect($this->userId, $file->getId(), $template);
 
 			return new DataResponse([
 				'url' => $this->urlGenerator->linkToRouteAbsolute('richdocuments.directView.show', [

--- a/lib/Db/DirectMapper.php
+++ b/lib/Db/DirectMapper.php
@@ -31,13 +31,13 @@ class DirectMapper extends QBMapper {
 	 * @param int $destination
 	 * @return Direct
 	 */
-	public function newDirect($uid, $fileid, $destination = null, $share = null, $initiatorHost = null, $initiatorToken = null) {
+	public function newDirect($uid, $fileid, $template = null, $share = null, $initiatorHost = null, $initiatorToken = null) {
 		$direct = new Direct();
 		$direct->setUid($uid);
 		$direct->setFileid($fileid);
 		$direct->setToken($this->random->generate(64, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_UPPER));
 		$direct->setTimestamp($this->timeFactory->getTime());
-		$direct->setTemplateDestination($destination);
+		$direct->setTemplateId($template);
 		$direct->setShare($share);
 		$direct->setInitiatorHost($initiatorHost);
 		$direct->setInitiatorToken($initiatorToken);


### PR DESCRIPTION
As reported by @marinofaggiana there was an issue creating new files on iOS which I could reproduce with curl.

I assume this broke with some refactoring, but not sure where, requiring a test to avoid future regressions

Still to do:
- [ ] Test with iOS/Android
- [x] I think we should have tests for this, double check or add