### PR TITLE
fix: display proper custom logo in collabora

### DIFF
--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -11,6 +11,7 @@ namespace OCA\Richdocuments\Service;
 use OCA\Richdocuments\AppConfig;
 use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\Db\Wopi;
+use OCA\Theming\ImageManager;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Defaults;
 use OCP\IConfig;
@@ -22,6 +23,7 @@ class InitialStateService {
 	public function __construct(
 		private IInitialState $initialState,
 		private AppConfig $appConfig,
+		private ImageManager $imageManager,
 		private CapabilitiesService $capabilitiesService,
 		private IURLGenerator $urlGenerator,
 		private Defaults $themingDefaults,
@@ -84,15 +86,16 @@ class InitialStateService {
 			'UIMode' => $this->config->getAppValue(Application::APPNAME, 'uiDefaults-UIMode', 'notebookbar')
 		]);
 
-		$logoSet = $this->config->getAppValue('theming', 'logoheaderMime', '') !== '';
+		$logoType = 'logoheader';
+		$logoSet = $this->imageManager->hasImage($logoType);
 		if (!$logoSet) {
-			$logoSet = $this->config->getAppValue('theming', 'logoMime', '') !== '';
+			$logoType = 'logo';
+			$logoSet = $this->imageManager->hasImage($logoType);
 		}
 
-		$this->initialState->provideInitialState('theming-customLogo', ($logoSet ?
-			$this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo())
-			: false));
+		$logo = $logoSet ? $this->imageManager->getImageUrlAbsolute($logoType) : false;
 
+		$this->initialState->provideInitialState('theming-customLogo', $logo);
 		$this->initialState->provideInitialState('open_local_editor', $this->config->getAppValue(Application::APPNAME, 'open_local_editor', 'yes') === 'yes');
 	}
 }

--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -145,9 +145,10 @@ const generateCSSVarTokens = () => {
 	// cleanup theme elements after extracting property values
 	lightElement.remove()
 	darkElement.remove()
+
 	const customLogo = loadState('richdocuments', 'theming-customLogo', false)
 	if (customLogo) {
-		str += `--nc-custom-logo=${window.OCA?.Theming?.cacheBuster ?? 0};`
+		str += `--nc-custom-logo=${encodeURIComponent(customLogo)};`
 	}
 
 	const rootEl = document.querySelector(':root')

--- a/tests/stub.phpstub
+++ b/tests/stub.phpstub
@@ -82,6 +82,35 @@ namespace OCA\Files_Sharing\Event {
 	}
 }
 
+namespace OCA\Theming {
+	use OCA\Theming\Service\BackgroundService;
+	use OCA\Files\IAppData;
+	use OCP\ICacheFactory;
+	use OCP\IConfig;
+	use OCP\ITempManager;
+	use OCP\IURLGenerator;
+	use PSR\Log\LoggerInterface;
+
+	class ImageManager {
+		public function __construct(
+			IConfig $config,
+			IAppData $appData,
+			IURLGenerator $urlGenerator,
+			ICacheFactory $cacheFactory,
+			LoggerInterface $logger,
+			ITempManager $tempManager,
+			BackgroundService $backgroundService
+		) {
+		}
+
+		public function hasImage(string $key): bool {
+		}
+
+		public function getImageUrlAbsolute(string $key): string {
+		}
+	}
+}
+
 class OC_Helper {
 	public static function getFileTemplateManager() {
 	}


### PR DESCRIPTION
* Target version: main

### Summary
this pull request makes it so that if you have a custom logo, it will properly display it within the collabora header bar. if you have only a custom logo, it will use that, but it will first use the custom header logo specifically if you have it set.

it was previously always defaulting to the general custom logo (one used on the login screen) no matter what, so this makes it a bit more dynamic.

### TODO

- [x] merge matching pull request in collabora's online-branding repo [here](https://gitlab.collabora.com/productivity/online-branding/-/merge_requests/339)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
