### PR TITLE
Fix: Fix Admin Settings page when Watermark label selected

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -48,6 +48,11 @@ class AppConfig {
 		'watermark_linkTagsList' => 'array'
 	];
 
+	private const INTEGER_LIST_KEYS = [
+		'watermark_allTagsList' => true,
+		'watermark_linkTagsList' => true,
+	];
+
 	public function __construct(
 		private IConfig $config,
 		private IAppManager $appManager,
@@ -117,7 +122,11 @@ class AppConfig {
 				$value = $value === 'yes' ? true : $value;
 				$result[$key] = $value === 'no' ? false : $value;
 			}
+			if (!empty(self::INTEGER_LIST_KEYS[$key])) {
+				$result[$key] = array_map('intval', $result[$key] ?? []);
+			}
 		}
+
 		return $result;
 	}
 


### PR DESCRIPTION
* Target version: main

### Summary
Reproducer:
1. Open settings
2. Enable watermark that will apply on files with some tags
3. Refresh page

Expected result:
It is possible view and change tag that used for watermark assigning.

Actual result:
There is an error `Error in render: "TypeError: option is undefined"`.
![image](https://github.com/user-attachments/assets/30ec73f0-f208-4267-8f3a-80806a1367a4)


### TODO
- [ ] Backport to stable 29

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
