### PR TITLE
Digitally sign documents via software certificates

### DIFF
--- a/css/admin.scss
+++ b/css/admin.scss
@@ -27,6 +27,14 @@ input#zoteroAPIKeyField {
 	width: 300px;
 }
 
+textarea#documentSigningCertField {
+	width: 600px;
+}
+
+textarea#documentSigningKeyField {
+	width: 600px;
+}
+
 textarea#documentSigningCaField {
 	width: 600px;
 }

--- a/css/admin.scss
+++ b/css/admin.scss
@@ -27,6 +27,10 @@ input#zoteroAPIKeyField {
 	width: 300px;
 }
 
+textarea#documentSigningCaField {
+	width: 600px;
+}
+
 #richdocuments,
 #richdocuments-templates {
 	// inline buttons on section headers

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -237,6 +237,8 @@ class SettingsController extends Controller {
 	 */
 	public function setPersonalSettings($templateFolder,
 		$zoteroAPIKeyInput,
+		$documentSigningCertInput,
+		$documentSigningKeyInput,
 		$documentSigningCaInput) {
 		$message = $this->l10n->t('Saved');
 		$status = 'success';
@@ -258,6 +260,22 @@ class SettingsController extends Controller {
 			}
 		}
 
+		if ($documentSigningCertInput !== null) {
+			try {
+				$this->config->setUserValue($this->userId, 'richdocuments', 'documentSigningCert', $documentSigningCertInput);
+			} catch (PreConditionNotMetException $e) {
+				$message = $this->l10n->t('Error when saving');
+				$status = 'error';
+			}
+		}
+		if ($documentSigningKeyInput !== null) {
+			try {
+				$this->config->setUserValue($this->userId, 'richdocuments', 'documentSigningKey', $documentSigningKeyInput);
+			} catch (PreConditionNotMetException $e) {
+				$message = $this->l10n->t('Error when saving');
+				$status = 'error';
+			}
+		}
 		if ($documentSigningCaInput !== null) {
 			try {
 				$this->config->setUserValue($this->userId, 'richdocuments', 'documentSigningCa', $documentSigningCaInput);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -236,7 +236,8 @@ class SettingsController extends Controller {
 	 * @return JSONResponse
 	 */
 	public function setPersonalSettings($templateFolder,
-		$zoteroAPIKeyInput) {
+		$zoteroAPIKeyInput,
+		$documentSigningCaInput) {
 		$message = $this->l10n->t('Saved');
 		$status = 'success';
 
@@ -252,6 +253,15 @@ class SettingsController extends Controller {
 			try {
 				$this->config->setUserValue($this->userId, 'richdocuments', 'zoteroAPIKey', $zoteroAPIKeyInput);
 			} catch (PreConditionNotMetException) {
+				$message = $this->l10n->t('Error when saving');
+				$status = 'error';
+			}
+		}
+
+		if ($documentSigningCaInput !== null) {
+			try {
+				$this->config->setUserValue($this->userId, 'richdocuments', 'documentSigningCa', $documentSigningCaInput);
+			} catch (PreConditionNotMetException $e) {
 				$message = $this->l10n->t('Error when saving');
 				$status = 'error';
 			}

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -167,6 +167,10 @@ class WopiController extends Controller {
 		}
 		$enableDocumentSigning = $this->config->getAppValue(Application::APPNAME, 'documentSigningEnabled', 'yes') === 'yes';
 		if (!$isPublic && $enableDocumentSigning) {
+			$documentSigningCert = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'documentSigningCert', '');
+			$response['UserPrivateInfo']['SignatureCert'] = $documentSigningCert;
+			$documentSigningKey = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'documentSigningKey', '');
+			$response['UserPrivateInfo']['SignatureKey'] = $documentSigningKey;
 			$documentSigningCa = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'documentSigningCa', '');
 			$response['UserPrivateInfo']['SignatureCa'] = $documentSigningCa;
 		}

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -165,6 +165,11 @@ class WopiController extends Controller {
 			$zoteroAPIKey = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'zoteroAPIKey', '');
 			$response['UserPrivateInfo']['ZoteroAPIKey'] = $zoteroAPIKey;
 		}
+		$enableDocumentSigning = $this->config->getAppValue(Application::APPNAME, 'documentSigningEnabled', 'yes') === 'yes';
+		if (!$isPublic && $enableDocumentSigning) {
+			$documentSigningCa = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'documentSigningCa', '');
+			$response['UserPrivateInfo']['SignatureCa'] = $documentSigningCa;
+		}
 		if ($wopi->hasTemplateId()) {
 			$response['TemplateSource'] = $this->getWopiUrlForTemplate($wopi);
 		}

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -85,6 +85,10 @@ class CapabilitiesService extends CachedRequestService {
 		return $this->getCapabilities()['hasWASMSupport'] ?? false;
 	}
 
+	public function hasDocumentSigningSupport(): bool {
+		return $this->getCapabilities()['hasDocumentSigningSupport'] ?? false;
+	}
+
 	public function hasFormFilling(): bool {
 		return $this->isVersionAtLeast('24.04.5.2');
 	}

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -34,6 +34,8 @@ class Personal implements ISettings {
 			'personal',
 			[
 				'templateFolder' => $this->config->getUserValue($this->userId, 'richdocuments', 'templateFolder', ''),
+				'hasDocumentSigningSupport' => $this->capabilitiesService->hasDocumentSigningSupport(),
+				'documentSigningCa' => $this->config->getUserValue($this->userId, 'richdocuments', 'documentSigningCa', ''),
 				'hasZoteroSupport' => $this->capabilitiesService->hasZoteroSupport(),
 				'zoteroAPIKey' => $this->config->getUserValue($this->userId, 'richdocuments', 'zoteroAPIKey', '')
 			],

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -35,6 +35,8 @@ class Personal implements ISettings {
 			[
 				'templateFolder' => $this->config->getUserValue($this->userId, 'richdocuments', 'templateFolder', ''),
 				'hasDocumentSigningSupport' => $this->capabilitiesService->hasDocumentSigningSupport(),
+				'documentSigningCert' => $this->config->getUserValue($this->userId, 'richdocuments', 'documentSigningCert', ''),
+				'documentSigningKey' => $this->config->getUserValue($this->userId, 'richdocuments', 'documentSigningKey', ''),
 				'documentSigningCa' => $this->config->getUserValue($this->userId, 'richdocuments', 'documentSigningCa', ''),
 				'hasZoteroSupport' => $this->capabilitiesService->hasZoteroSupport(),
 				'zoteroAPIKey' => $this->config->getUserValue($this->userId, 'richdocuments', 'zoteroAPIKey', '')

--- a/src/personal.js
+++ b/src/personal.js
@@ -17,6 +17,12 @@ import { showError } from '@nextcloud/dialogs'
 		this.zoteroAPIKeySaveButton = document.getElementById('zoteroAPIKeySave')
 		this.zoteroAPIKeyRemoveButton = document.getElementById('zoteroAPIKeyRemove')
 
+		this.documentSigningCertInput = document.getElementById('documentSigningCertField')
+		this.documentSigningCertSaveButton = document.getElementById('documentSigningCertSave')
+		this.documentSigningCertRemoveButton = document.getElementById('documentSigningCertRemove')
+		this.documentSigningKeyInput = document.getElementById('documentSigningKeyField')
+		this.documentSigningKeySaveButton = document.getElementById('documentSigningKeySave')
+		this.documentSigningKeyRemoveButton = document.getElementById('documentSigningKeyRemove')
 		this.documentSigningCaInput = document.getElementById('documentSigningCaField')
 		this.documentSigningCaSaveButton = document.getElementById('documentSigningCaSave')
 		this.documentSigningCaRemoveButton = document.getElementById('documentSigningCaRemove')
@@ -36,10 +42,17 @@ import { showError } from '@nextcloud/dialogs'
 
 		this.zoteroAPIKeyRemoveButton.addEventListener('click', this.resetZoteroAPI.bind(this))
 
+		this.documentSigningCertSaveButton.addEventListener('click', function() {
+			self.updateDocumentSigningCert(self.documentSigningCertInput.value)
+		})
+		this.documentSigningCertRemoveButton.addEventListener('click', this.resetDocumentSigningCert.bind(this))
+		this.documentSigningKeySaveButton.addEventListener('click', function() {
+			self.updateDocumentSigningKey(self.documentSigningKeyInput.value)
+		})
+		this.documentSigningKeyRemoveButton.addEventListener('click', this.resetDocumentSigningKey.bind(this))
 		this.documentSigningCaSaveButton.addEventListener('click', function() {
 			self.updateDocumentSigningCa(self.documentSigningCaInput.value)
 		})
-
 		this.documentSigningCaRemoveButton.addEventListener('click', this.resetDocumentSigningCa.bind(this))
 	}
 
@@ -74,6 +87,42 @@ import { showError } from '@nextcloud/dialogs'
 		const self = this
 		this._updateSetting({ zoteroAPIKeyInput: '' }, function() {
 			self.zoteroAPIKeyInput.value = ''
+		}, function() {
+
+		})
+	}
+
+	PersonalSettings.prototype.updateDocumentSigningCert = function(ca) {
+		const self = this
+		this._updateSetting({ documentSigningCertInput: ca }, function() {
+			self.documentSigningCertInput.value = ca
+		}, function() {
+			showError(t('richdocuments', 'Failed to update the document signing CA chain'))
+		})
+	}
+
+	PersonalSettings.prototype.resetDocumentSigningCert = function() {
+		const self = this
+		this._updateSetting({ documentSigningCertInput: '' }, function() {
+			self.documentSigningCertInput.value = ''
+		}, function() {
+
+		})
+	}
+
+	PersonalSettings.prototype.updateDocumentSigningKey = function(ca) {
+		const self = this
+		this._updateSetting({ documentSigningKeyInput: ca }, function() {
+			self.documentSigningKeyInput.value = ca
+		}, function() {
+			showError(t('richdocuments', 'Failed to update the document signing CA chain'))
+		})
+	}
+
+	PersonalSettings.prototype.resetDocumentSigningKey = function() {
+		const self = this
+		this._updateSetting({ documentSigningKeyInput: '' }, function() {
+			self.documentSigningKeyInput.value = ''
 		}, function() {
 
 		})

--- a/src/personal.js
+++ b/src/personal.js
@@ -17,6 +17,10 @@ import { showError } from '@nextcloud/dialogs'
 		this.zoteroAPIKeySaveButton = document.getElementById('zoteroAPIKeySave')
 		this.zoteroAPIKeyRemoveButton = document.getElementById('zoteroAPIKeyRemove')
 
+		this.documentSigningCaInput = document.getElementById('documentSigningCaField')
+		this.documentSigningCaSaveButton = document.getElementById('documentSigningCaSave')
+		this.documentSigningCaRemoveButton = document.getElementById('documentSigningCaRemove')
+
 		const self = this
 		this.templateSelectButton.addEventListener('click', function() {
 			OC.dialogs.filepicker(t('richdocuments', 'Select a personal template folder'), function(datapath, returntype) {
@@ -31,6 +35,12 @@ import { showError } from '@nextcloud/dialogs'
 		})
 
 		this.zoteroAPIKeyRemoveButton.addEventListener('click', this.resetZoteroAPI.bind(this))
+
+		this.documentSigningCaSaveButton.addEventListener('click', function() {
+			self.updateDocumentSigningCa(self.documentSigningCaInput.value)
+		})
+
+		this.documentSigningCaRemoveButton.addEventListener('click', this.resetDocumentSigningCa.bind(this))
 	}
 
 	PersonalSettings.prototype.updateSetting = function(path) {
@@ -64,6 +74,24 @@ import { showError } from '@nextcloud/dialogs'
 		const self = this
 		this._updateSetting({ zoteroAPIKeyInput: '' }, function() {
 			self.zoteroAPIKeyInput.value = ''
+		}, function() {
+
+		})
+	}
+
+	PersonalSettings.prototype.updateDocumentSigningCa = function(ca) {
+		const self = this
+		this._updateSetting({ documentSigningCaInput: ca }, function() {
+			self.documentSigningCaInput.value = ca
+		}, function() {
+			showError(t('richdocuments', 'Failed to update the document signing CA chain'))
+		})
+	}
+
+	PersonalSettings.prototype.resetDocumentSigningCa = function() {
+		const self = this
+		this._updateSetting({ documentSigningCaInput: '' }, function() {
+			self.documentSigningCaInput.value = ''
 		}, function() {
 
 		})

--- a/templates/personal.php
+++ b/templates/personal.php
@@ -33,6 +33,16 @@ script('richdocuments', 'richdocuments-personal');
 	<p><strong><?php p($l->t('Document signing')) ?></strong></p>
 	<?php if ($_['hasDocumentSigningSupport']) { ?>
 		<div class="input-wrapper">
+			<p><label for="documentSigningCertField"><?php p($l->t('Enter document signing cert (in PEM format)')); ?></label><br />
+				<textarea type="text" name="documentSigningCertField" id="documentSigningCertField"><?php p($_['documentSigningCert']); ?></textarea><br />
+				<button id="documentSigningCertSave"><span title="<?php p($l->t('Save document signing cert')); ?>" data-toggle="tooltip">Save</span></button>
+				<button id="documentSigningCertRemove"><span  class="icon-delete" title="<?php p($l->t('Remove document signing cert')); ?>" data-toggle="tooltip"></span></button>
+			</p>
+			<p><label for="documentSigningKeyField"><?php p($l->t('Enter document signing key')); ?></label><br />
+				<textarea type="text" name="documentSigningKeyField" id="documentSigningKeyField"><?php p($_['documentSigningKey']); ?></textarea><br />
+				<button id="documentSigningKeySave"><span title="<?php p($l->t('Save document signing key')); ?>" data-toggle="tooltip">Save</span></button>
+				<button id="documentSigningKeyRemove"><span  class="icon-delete" title="<?php p($l->t('Remove document signing key')); ?>" data-toggle="tooltip"></span></button>
+			</p>
 			<p><label for="documentSigningCaField"><?php p($l->t('Enter document signing CA chain')); ?></label><br />
 				<textarea type="text" name="documentSigningCaField" id="documentSigningCaField"><?php p($_['documentSigningCa']); ?></textarea><br />
 				<button id="documentSigningCaSave"><span title="<?php p($l->t('Save document signing CA chain')); ?>" data-toggle="tooltip">Save</span></button>

--- a/templates/personal.php
+++ b/templates/personal.php
@@ -30,5 +30,18 @@ script('richdocuments', 'richdocuments-personal');
 	<?php } else { ?>
 		<p><em><?php p($l->t('This instance does not support Zotero, because the feature is missing or disabled. Please contact the administration.')); ?></em></p>
 	<?php } ?>
+	<p><strong><?php p($l->t('Document signing')) ?></strong></p>
+	<?php if ($_['hasDocumentSigningSupport']) { ?>
+		<div class="input-wrapper">
+			<p><label for="documentSigningCaField"><?php p($l->t('Enter document signing CA chain')); ?></label><br />
+				<textarea type="text" name="documentSigningCaField" id="documentSigningCaField"><?php p($_['documentSigningCa']); ?></textarea><br />
+				<button id="documentSigningCaSave"><span title="<?php p($l->t('Save document signing CA chain')); ?>" data-toggle="tooltip">Save</span></button>
+				<button id="documentSigningCaRemove"><span  class="icon-delete" title="<?php p($l->t('Remove document signing CA chain')); ?>" data-toggle="tooltip"></span></button>
+			</p>
+			<p><em><?php p($l->t('To use document signing, specify your signing certificate, key and CA chain here.')); ?></em></p>
+		</div>
+	<?php } else { ?>
+		<p><em><?php p($l->t('This instance does not support document signing, because the feature is missing or disabled. Please contact the administrator.')); ?></em></p>
+	<?php } ?>
 	</div>
 </div>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4123
* Target version: main

### Summary

This implements step 1 of digital signature signing, where the keystore is in richdocuments and the signing is performed in Collabora Online, not via some external signing service. This supports ODF, OOXML and PDF formats.

### Checklist

- [x] Code is properly formatted: `npm run stylelint` passes
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required: this is not done in this PR, maybe we should link to the Collabora Online SDK to explain how to generate signing keys?

### How to test

1) Make sure to have a new enough COOL snapshot, so its /hosting/capabilities reports hasDocumentSigningSupport=true. This is true for online.git master as of >= 2024-11-09.

1) Go to /settings/user/richdocuments

2) Fill in the 3 new signing settings. For testing, you can generate the certificates with a script described at https://github.com/CollaboraOnline/online/issues/9992#issuecomment-2396115427 or just use these:

- cert: [test.odt.cert.pem.txt](https://github.com/user-attachments/files/17391222/test.odt.cert.pem.txt)
- key: [test.odt.cert.key.txt](https://github.com/user-attachments/files/17391229/test.odt.cert.key.txt)
- ca: [test.odt.cert.ca.txt](https://github.com/user-attachments/files/17391232/test.odt.cert.ca.txt)

3) Load e.g. an ODT file in Nextcloud Office. Go to the File tab, press the Signature button to open the Signatures dialog. Press the Sign Document button, select the detected certificate, press the Sign button: "the signatures in this document are valid" text appears.

Let me know if you would like any tweaks. Thanks.