### PR TITLE
Fix asset download checks

### DIFF
--- a/lib/Controller/AssetsController.php
+++ b/lib/Controller/AssetsController.php
@@ -6,6 +6,7 @@
 
 namespace OCA\Richdocuments\Controller;
 
+use OCA\Files_Sharing\SharedStorage;
 use OCA\Richdocuments\Controller\Attribute\RestrictToWopiServer;
 use OCA\Richdocuments\Db\AssetMapper;
 use OCA\Richdocuments\Service\UserScopeService;
@@ -18,6 +19,7 @@ use OCP\AppFramework\Http\StreamResponse;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 
@@ -46,8 +48,24 @@ class AssetsController extends Controller {
 
 		try {
 			$node = $userFolder->get($path);
+
+			if (!($node instanceof File)) {
+				return new JSONResponse([], Http::STATUS_NOT_FOUND);
+			}
+
+			$storage = $node->getStorage();
+			if ($storage->instanceOfStorage(SharedStorage::class)) {
+				/** @var SharedStorage $storage */
+				$share = $storage->getShare();
+				$attributes = $share->getAttributes();
+				if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
+					throw new NotPermittedException();
+				}
+			}
 		} catch (NotFoundException) {
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		} catch (NotPermittedException) {
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
 		$asset = $this->assetMapper->newAsset($this->userId, $node->getId());

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -165,6 +165,11 @@ export default {
 
 		getFilePickerBuilder(t('richdocuments', 'Insert image from {name}', { name: OC.theme.name }))
 			.setMimeTypeFilter(['image/png', 'image/gif', 'image/jpeg', 'image/svg'])
+			.setFilter((node) => {
+				const downloadShareAttribute = JSON.parse(node.attributes['share-attributes']).find((shareAttribute) => shareAttribute.key === 'download')
+				const downloadPermissions = downloadShareAttribute !== undefined ? (downloadShareAttribute.enabled || downloadShareAttribute.value) : true
+				return (node.permissions & OC.PERMISSION_READ) && downloadPermissions
+			})
 			.addButton({
 				label: t('richdocuments', 'Insert image'),
 				callback: (files) => {


### PR DESCRIPTION
- **fix: Skip disabled download files when requesting assets**
- **fix: Filter out non-downloadable files in image picker**


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
