### PR TITLE
fix: get user by display name

### DIFF
--- a/lib/Controller/MentionController.php
+++ b/lib/Controller/MentionController.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
+use OCP\IUserManager;
 use OCP\Notification\IManager;
 
 class MentionController extends Controller {
@@ -25,6 +26,7 @@ class MentionController extends Controller {
 		private IRootFolder $rootFolder,
 		private IManager $manager,
 		private ITimeFactory $timeFactory,
+		private IUserManager $userManager,
 		private ?string $userId,
 	) {
 		parent::__construct($appName, $request);
@@ -39,14 +41,22 @@ class MentionController extends Controller {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
-		$userFolder = $this->rootFolder->getUserFolder($mention);
+		// Reverse the array of users to pop off the first user later
+		$userResults = array_reverse($this->userManager->searchDisplayName($mention, 1));
+		if (count($userResults) < 1) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
+		// Get the first user returned in the array
+		$user = array_pop($userResults);
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 		$file = $userFolder->getFirstNodeById($fileId);
 		if ($file === null) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		$notification = $this->manager->createNotification();
-		$notification->setUser($mention)
+		$notification->setUser($user->getUID())
 			->setApp(Application::APPNAME)
 			->setSubject(Notifier::TYPE_MENTIONED, [
 				Notifier::SUBJECT_MENTIONED_SOURCE_USER => $this->userId,
@@ -58,7 +68,6 @@ class MentionController extends Controller {
 			$notification->setDateTime(\DateTime::createFromImmutable($this->timeFactory->now()));
 			$this->manager->notify($notification);
 			return new DataResponse([], Http::STATUS_OK);
-
 		}
 
 		return new DataResponse([], Http::STATUS_NOT_FOUND);


### PR DESCRIPTION
* Resolves: #4169
* Target version: main

### Summary
When mentioning a user within a document from Collabora, it seems to search by the user's display name. Thus, if the display name has any whitespace, it will fail to mention the user. The problem is that the backend tries to use the mentioned user string (display name in this case) as the UID, which is not the same. The solution is to first search by the display name to get the proper user object, then use the UID from that to generate the notification and send it to the user.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
