### PR TITLE
fix(share): link share of federated share

### DIFF
--- a/cypress/e2e/share-federated.spec.js
+++ b/cypress/e2e/share-federated.spec.js
@@ -16,6 +16,7 @@ describe('Federated sharing of office documents', function() {
 		cy.createUser(shareOwner)
 
 		cy.uploadFile(shareOwner, 'document.odt', 'application/vnd.oasis.opendocument.text', '/document.odt')
+		cy.uploadFile(shareOwner, 'document.odt', 'application/vnd.oasis.opendocument.text', '/document-reshare.odt')
 	})
 
 	it('Open a remotely shared file', function() {
@@ -35,6 +36,25 @@ describe('Federated sharing of office documents', function() {
 		cy.waitForCollabora(true, true).within(() => {
 			cy.get('#closebutton').click()
 			cy.get('#viewer', { timeout: 5000 }).should('not.exist')
+		})
+	})
+
+	it('Open a remotely shared file as a link', function() {
+		cy.login(shareOwner)
+		cy.shareFileToRemoteUser(shareOwner, '/document-reshare.odt', shareRecipient)
+
+		cy.login(shareRecipient)
+		cy.visit('/apps/files')
+
+		cy.shareLink(shareRecipient, '/document-reshare.odt', { permissions: 1 }).then((token) => {
+			cy.logout()
+			cy.visit(`/s/${token}`, {
+				onBeforeLoad(win) {
+					cy.spy(win, 'postMessage').as('postMessage')
+				},
+			})
+			cy.waitForViewer()
+			cy.waitForCollabora(true, true)
 		})
 	})
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -118,6 +118,7 @@ Cypress.Commands.add('shareFileToRemoteUser', (user, path, targetUser, shareData
 		body: {
 			path,
 			shareType: 6,
+			permission: 31,
 			shareWith: federatedId,
 			...shareData,
 		},

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -387,7 +387,7 @@ class DocumentController extends Controller {
 			$share = $shareToken ? $this->shareManager->getShareByToken($shareToken) : null;
 			$file = $shareToken ? $this->getFileForShare($share, $fileId, $path) : $this->getFileForUser($fileId, $path);
 
-			$federatedUrl = $this->federationService->getRemoteRedirectURL($file);
+			$federatedUrl = $this->federationService->getRemoteRedirectURL($file, null, $share);
 			if ($federatedUrl) {
 				return new DataResponse([
 					'federatedUrl' => $federatedUrl,


### PR DESCRIPTION
* Target version: main

### Summary

Fix opening link shares to federated shares.

I know that's complicated so let me explain:
* Alice@one.example shares a file with Bob@two.example via federated sharing.
* Bob creates a public link share to that file.
* When a guest visits that share it should open nicely.

### TODO

- [ ] Add cypress test.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation is not needed.
