### PR TITLE
fix(headers): only add Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy on richdocuments

### DIFF
--- a/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/lib/Listener/BeforeTemplateRenderedListener.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 namespace OCA\Richdocuments\Listener;
 
+use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\Service\CapabilitiesService;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\EventDispatcher\Event;
@@ -24,7 +25,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			return;
 		}
 
-		if ($this->capabilitiesService->hasWASMSupport()) {
+		if ($this->capabilitiesService->hasWASMSupport() && $event->getResponse()->getApp() === Application::APPNAME) {
 			$event->getResponse()->addHeader('Cross-Origin-Opener-Policy', 'same-origin');
 			$event->getResponse()->addHeader('Cross-Origin-Embedder-Policy', 'require-corp');
 		}


### PR DESCRIPTION

* Resolves: #4103
* Target version: main

### Summary
Otherwise it's being added to absolutely all requests, creating issues in other apps.

However, since I don't know how to test this and why these headers are required, I'm not sure if this still works for public sharing pages for instance.

Ref. https://github.com/nextcloud/richdocuments/issues/3258#issuecomment-2398139667

### TODO

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
