### PR TITLE
Autofix: fix(headers): only add Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy on richdocuments

### DIFF
--- a/lib/Listener/AddContentSecurityPolicyListener.php
+++ b/lib/Listener/AddContentSecurityPolicyListener.php
@@ -24,6 +24,10 @@ class AddContentSecurityPolicyListener implements IEventListener {
 	) {
 	}
 
+		if (!$this->isPageLoad()) {
+			return;
+		}
+
 	public function handle(Event $event): void {
 		if (!$event instanceof AddContentSecurityPolicyEvent) {
 			return;

--- a/lib/Listener/AddFeaturePolicyListener.php
+++ b/lib/Listener/AddFeaturePolicyListener.php
@@ -22,6 +22,10 @@ class AddFeaturePolicyListener implements IEventListener {
 	) {
 	}
 
+		if (!$this->isPageLoad()) {
+			return;
+		}
+
 	public function handle(Event $event): void {
 		if (!$event instanceof AddFeaturePolicyEvent) {
 			return;
@@ -38,6 +42,12 @@ class AddFeaturePolicyListener implements IEventListener {
 		}
 
 		$event->addPolicy($policy);
+	}
+
+	private function isPageLoad(): bool {
+		$scriptNameParts = explode('/', $this->request->getScriptName());
+		return end($scriptNameParts) === 'index.php';
+	}
 	}
 
 	private function isPageLoad(): bool {


### PR DESCRIPTION
This change adds a page load check to both AddContentSecurityPolicyListener and AddFeaturePolicyListener to ensure that the policies are only added on full page loads. This should resolve the issue of the headers being added to all requests, which was causing problems in other apps. The change maintains functionality for public sharing pages by keeping the existing logic intact. 
    > [!CAUTION]
    > Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
    >
    > The fix provided by Latta AI might not be complete and it can serve as an inspiration.

    ---
    This bug was fixed for free by Latta AI - https://latta.ai/ourmission

    If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    