### PR TITLE
feat: use autocomplete api for mentions

### DIFF
--- a/src/mixins/uiMention.js
+++ b/src/mixins/uiMention.js
@@ -27,7 +27,8 @@ export default {
 				const list = users.map((user) => {
 					const profile = window.location.protocol + '//' + getNextcloudUrl() + '/index.php/u/' + user.id
 					return {
-						username: user.label,
+						label: user.label,
+						username: user.id,
 						profile,
 					}
 				})


### PR DESCRIPTION
* Target version: main

### Summary
Try to use the autocomplete API to search for the user by display name instead so that the instance sharing settings regarding autocompletion are respected.

⚠️ **We probably want to wait for [CollaboraOnline/online#10556](https://github.com/CollaboraOnline/online/pull/10556) to be merged**

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
