### PR TITLE
fix: use new db types constants

### DIFF
--- a/lib/Db/Asset.php
+++ b/lib/Db/Asset.php
@@ -7,6 +7,7 @@
 namespace OCA\Richdocuments\Db;
 
 use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
 
 /**
  * @method void setUid(string $uid)
@@ -32,9 +33,9 @@ class Asset extends Entity {
 	protected $timestamp;
 
 	public function __construct() {
-		$this->addType('uid', 'string');
-		$this->addType('fileid', 'int');
-		$this->addType('token', 'string');
-		$this->addType('timestamp', 'int');
+		$this->addType('uid', Types::STRING);
+		$this->addType('fileid', Types::INTEGER);
+		$this->addType('token', Types::STRING);
+		$this->addType('timestamp', Types::INTEGER);
 	}
 }

--- a/lib/Db/Direct.php
+++ b/lib/Db/Direct.php
@@ -7,6 +7,7 @@
 namespace OCA\Richdocuments\Db;
 
 use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
 
 /**
  * @method void setToken(string $token)
@@ -51,14 +52,14 @@ class Direct extends Entity {
 	protected $initiatorToken;
 
 	public function __construct() {
-		$this->addType('token', 'string');
-		$this->addType('uid', 'string');
-		$this->addType('fileid', 'int');
-		$this->addType('timestamp', 'int');
-		$this->addType('templateDestination', 'int');
-		$this->addType('templateId', 'int');
-		$this->addType('share', 'string');
-		$this->addType('initiatorHost', 'string');
-		$this->addType('initiatorToken', 'string');
+		$this->addType('token', Types::STRING);
+		$this->addType('uid', Types::STRING);
+		$this->addType('fileid', Types::INTEGER);
+		$this->addType('timestamp', Types::INTEGER);
+		$this->addType('templateDestination', Types::INTEGER);
+		$this->addType('templateId', Types::INTEGER);
+		$this->addType('share', Types::STRING);
+		$this->addType('initiatorHost', Types::STRING);
+		$this->addType('initiatorToken', Types::STRING);
 	}
 }

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -6,6 +6,7 @@
 namespace OCA\Richdocuments\Db;
 
 use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
 
 /**
  * @package OCA\Richdocuments\Db
@@ -119,20 +120,20 @@ class Wopi extends Entity implements \JsonSerializable {
 	protected $tokenType = 0;
 
 	public function __construct() {
-		$this->addType('ownerUid', 'string');
-		$this->addType('editorUid', 'string');
-		$this->addType('fileid', 'int');
-		$this->addType('version', 'int');
-		$this->addType('canwrite', 'bool');
-		$this->addType('serverHost', 'string');
-		$this->addType('token', 'string');
-		$this->addType('expiry', 'int');
-		$this->addType('guestDisplayname', 'string');
-		$this->addType('templateDestination', 'int');
-		$this->addType('templateId', 'int');
-		$this->addType('hideDownload', 'bool');
-		$this->addType('direct', 'bool');
-		$this->addType('tokenType', 'int');
+		$this->addType('ownerUid', Types::STRING);
+		$this->addType('editorUid', Types::STRING);
+		$this->addType('fileid', Types::INTEGER);
+		$this->addType('version', Types::INTEGER);
+		$this->addType('canwrite', Types::BOOLEAN);
+		$this->addType('serverHost', Types::STRING);
+		$this->addType('token', Types::STRING);
+		$this->addType('expiry', Types::INTEGER);
+		$this->addType('guestDisplayname', Types::STRING);
+		$this->addType('templateDestination', Types::INTEGER);
+		$this->addType('templateId', Types::INTEGER);
+		$this->addType('hideDownload', Types::BOOLEAN);
+		$this->addType('direct', Types::BOOLEAN);
+		$this->addType('tokenType', Types::INTEGER);
 	}
 
 	public function hasTemplateId() {


### PR DESCRIPTION
* Target version: main

### Summary
psalm was throwing errors because as of nextcloud 31.0.0 you must use the new `Types` constants when adding types to a database entity. so, we migrate them here

you can see it here: https://nextcloud-server.netlify.app/classes/ocp-appframework-db-entity#method_addType

![image](https://github.com/user-attachments/assets/bb1371a8-ae1e-448b-87f6-e547523ea709)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
