### PR TITLE
fix: Limit open with Collabora action to pdf files

### DIFF
--- a/src/file-actions.js
+++ b/src/file-actions.js
@@ -23,10 +23,15 @@ const openPdf = new FileAction({
 			{ productName: getCapabilities().productName })
 	},
 
-	enabled: () => {
+	enabled: (files) => {
+		if (files.length !== 1) {
+			return false
+		}
+
+		const isPdf = files[0].mime === 'application/pdf'
 		// Only enable the file action when files_pdfviewer is enabled
 		const optionalMimetypes = getCapabilities().mimetypesNoDefaultOpen
-		return optionalMimetypes.includes('application/pdf')
+		return isPdf && optionalMimetypes.includes('application/pdf')
 	},
 
 	exec: (file) => {


### PR DESCRIPTION
### Summary

Before the "Open with Nextcloud Office" file action was always displayed (e.g. also on folders), we rather intend to only show it on pdf files.

| Before | After |
|---|---|
| <img width="430" alt="Screenshot 2024-11-15 at 08 56 34" src="https://github.com/user-attachments/assets/f6d05605-d449-4858-af97-822a592bc011"> | <img width="437" alt="Screenshot 2024-11-15 at 08 56 02" src="https://github.com/user-attachments/assets/87530223-58c1-401b-bfb8-9c645a226f83"> | 

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
