### PR TITLE
Implement support for insertion of multimedia from Nextcloud assets

### DIFF
--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -100,6 +100,10 @@ The following handlers are currently supported:
 - insertGraphic: will be called when an image from the Nextcloud storage should be inserted
   - Arguments
     - insertFileFromPath(path): Callback to trigger the actual inserting of the graphic from an absolute file path
+- insertFile: will be called when a file (e.g., multimedia) from the Nextcloud storage should be inserted (generalized insertGraphic)
+  - Arguments
+    - mimeTypeFilter: array of MIME types (strings) to filter in the UI
+    - insertFileFromPath(path): Callback to trigger the actual inserting of the file from an absolute file path
 
 In addition, the following handlers can be used to overwrite the handling of file actions that are rendered in the Nextcloud header bar:
 - actionDetails

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -145,6 +145,7 @@ class WopiController extends Controller {
 			'SupportsRename' => !$isVersion && !$wopi->isRemoteToken(),
 			'UserCanRename' => !$isPublic && !$isVersion && !$wopi->isRemoteToken(),
 			'EnableInsertRemoteImage' => !$isPublic,
+			'EnableInsertRemoteFile' => !$isPublic,
 			'EnableShare' => $file->isShareable() && !$isVersion && !$isPublic,
 			'HideUserList' => '',
 			'EnableOwnerTermination' => $wopi->getCanwrite() && !$isPublic,

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -430,6 +430,14 @@ export default {
 					})
 				})
 				break
+			case 'UI_InsertFile':
+				FilesAppIntegration.insertFile(args.mimeTypeFilter, (filename, url) => {
+					this.postMessage.sendWOPIPostMessage(FRAME_DOCUMENT, args.callback, {
+						filename,
+						url,
+					})
+				})
+				break
 			case 'UI_Mention':
 				this.uiMention(parsed.args)
 				break


### PR DESCRIPTION
This change adds ability to insert multimedia files from Nextcloud to Impress
documents. It advertises EnableInsertRemoteFile capability, so that Office
activates the feature (requires Office including commit 60d9a9c20bf69b3f1d8591b2d8400c4a453970ab;
older builds won't show the respective button).