### PR TITLE
Fix errors when extracting content controls

### DIFF
--- a/lib/Service/TemplateFieldService.php
+++ b/lib/Service/TemplateFieldService.php
@@ -94,7 +94,7 @@ class TemplateFieldService {
 			$fields = [];
 
 			foreach ($documentStructure as $index => $attr) {
-				$fieldType = FieldType::tryFrom($attr['type']) ?? null;
+				$fieldType = FieldType::tryFrom($attr['type'] ?? '') ?? null;
 				if ($fieldType === null) {
 					continue;
 				}

--- a/lib/Service/TemplateFieldService.php
+++ b/lib/Service/TemplateFieldService.php
@@ -78,7 +78,7 @@ class TemplateFieldService {
 			$httpClient = $this->clientService->newClient();
 
 			$form = RemoteOptionsService::getDefaultOptions();
-			$form['query'] = ['limit' => 'content-control'];
+			$form['query'] = ['filter' => 'contentcontrol'];
 			$form['multipart'] = [[
 				'name' => 'data',
 				'contents' => $file->getStorage()->fopen($file->getInternalPath(), 'r'),


### PR DESCRIPTION
- **fix: properly filter for content controls**
  - This commit fixes the filtering that has been in place but was likely not working anymore due to an upstream change 
- **fix: Catch unexpected results with no type**
  - Safeguard the results to not fail hard on unexpected result sets

Fix https://github.com/nextcloud/richdocuments/issues/4228