### PR TITLE
fix: remove deprecated `title` parameter

### DIFF
--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -29,7 +29,7 @@ const getWopiSrc = (fileId) => {
 	return wopiurl
 }
 
-const getWopiUrl = ({ fileId, title, readOnly, closeButton, revisionHistory, target = undefined, startPresentation = false }) => {
+const getWopiUrl = ({ fileId, readOnly, closeButton, revisionHistory, target = undefined, startPresentation = false }) => {
 	// Only set the revision history parameter if the versions app is enabled
 	revisionHistory = revisionHistory && window?.oc_appswebroots?.files_versions
 
@@ -39,7 +39,6 @@ const getWopiUrl = ({ fileId, title, readOnly, closeButton, revisionHistory, tar
 	//   https://<loolwsd-server>:9980/hosting/discovery
 	return Config.get('urlsrc')
 		+ 'WOPISrc=' + encodeURIComponent(getWopiSrc(fileId))
-		+ '&title=' + encodeURIComponent(title)
 		+ '&lang=' + languageToBCP47()
 		+ (closeButton ? '&closebutton=1' : '')
 		+ (revisionHistory ? '&revisionhistory=1' : '')

--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -149,6 +149,9 @@ export default {
 	},
 
 	/**
+	 * @param mimeTypeFilter
+	 * @param insertFileProc
+	 * @param insertHandler
 	 * @private
 	 */
 	insertFile_impl(mimeTypeFilter, insertFileProc, insertHandler) {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -324,7 +324,6 @@ export default {
 			// Generate form and submit to the iframe
 			const action = getWopiUrl({
 				fileId: fileid + '_' + loadState('richdocuments', 'instanceId', 'instanceid') + (version > 0 ? '_' + version : ''),
-				title: this.filename,
 				readOnly: forceReadOnly || version > 0,
 				revisionHistory: !this.isPublic,
 				closeButton: !Config.get('hideCloseButton') && !this.isEmbedded,


### PR DESCRIPTION
* Target version: main

### Summary
This resolves an issue of being unable to open a document if the file name has a `%` in it. This parameter is also not used anymore; therefore consider this another legacy cleanup of sorts :)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
