### PR TITLE
Clarify the remote font config setting a bit

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -513,7 +513,7 @@ export default {
 			return this.hostErrors.some(x => x)
 		},
 		fontHint() {
-			return t('richdocuments', 'Make sure to set this URL: {url} in the coolwsd.xml file of your Collabora Online server to ensure the added fonts get loaded automatically.',
+			return t('richdocuments', 'Make sure to set this URL: {url} in the coolwsd.xml file of your Collabora Online server to ensure the added fonts get loaded automatically. Please note that http:// will only work for debug builds of Collabora Online. In production you must use https:// for remote font config.',
 				{ url: this.fontHintUrl },
 			)
 		},


### PR DESCRIPTION
Some people test Nextcloud and Collabora Online without setting up SSL. For security reasons, Collabora Online production builds refuse to load remote configuration via http://. It is possible to use http:// only with debug builds, that users build for themselves. The feature simply does not work, when someone tries http:// with a production build, only logs will tell "Remote config url should only use HTTPS protocol"