### PR TITLE
fix: Apply viewer wrapper as we do it in text

### DIFF
--- a/src/components/Modal/ZoteroHint.vue
+++ b/src/components/Modal/ZoteroHint.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcModal :show="show" @close="close" :name="t('richdocument', 'Link to your Zotero library')">
+	<NcModal :show="show" :name="t('richdocument', 'Link to your Zotero library')" @close="close">
 		<div class="zotero-hint">
 			<h2>{{ t('richdocument', 'Link to your Zotero library') }}</h2>
 			<BookOpenPageVariantOutline :size="96" />

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -367,7 +367,7 @@ export default {
 				FilesAppIntegration.updateFileInfo(undefined, Date.now())
 			}
 			disableScrollLock()
-			this.$parent.close()
+			this.$emit('close')
 		},
 		reload() {
 			this.loading = LOADING_STATE.LOADING

--- a/src/view/Viewer.vue
+++ b/src/view/Viewer.vue
@@ -1,0 +1,64 @@
+<!--
+  - SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<!--
+  - This component is a wrapper around the Office component to be used in the viewer
+  - We currently need this to isolate the vue instances
+-->
+<template>
+	<Office :filename="filename"
+		:fileid="fileid"
+		:has-preview="hasPreview"
+		:source="source"
+		:mime="mime"
+		:permissions="permissions"
+		:is-embedded="isEmbedded"
+		@close="$parent.close()"
+		@update:loaded="$emit('update:loaded', $event)" />
+</template>
+<script>
+import Vue from 'vue'
+import Office from './Office.vue'
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+
+export default {
+	name: 'Viewer',
+	components: {
+		Office: Vue.extend(Office),
+	},
+	props: {
+		filename: {
+			type: String,
+			default: null,
+		},
+		fileid: {
+			type: Number,
+			default: null,
+		},
+		hasPreview: {
+			type: Boolean,
+			required: false,
+			default: () => false,
+		},
+		source: {
+			type: String,
+			default: null,
+		},
+		mime: {
+			type: String,
+			default: null,
+		},
+		permissions: {
+			type: String,
+			default: '',
+		},
+		isEmbedded: {
+			type: Boolean,
+			default: false,
+		},
+	},
+}
+</script>

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -6,10 +6,9 @@
 import './init-shared.js'
 import '../css/filetypes.scss'
 
-import Vue from 'vue'
-import Office from './view/Office.vue'
 import { getCapabilities } from './services/capabilities.ts'
 import { autoSetupBuiltInCodeServerIfNeeded } from './services/builtInCode.ts'
+import Viewer from './view/Viewer.vue'
 
 const supportedMimes = getCapabilities().mimetypes
 
@@ -18,7 +17,7 @@ if (OCA.Viewer) {
 		id: 'richdocuments',
 		group: null,
 		mimes: supportedMimes,
-		component: Vue.extend(Office),
+		component: Viewer,
 		theme: 'default',
 		canCompare: true,
 	})


### PR DESCRIPTION
Follow up to https://github.com/nextcloud/richdocuments/pull/4259 to address the issues that come with different vue instances (https://github.com/nextcloud-libraries/nextcloud-vue/issues/6280)

This PR introduces a similar pattern as we do it in text where we have a simple Viewer component that just wraps our main Office component. The main goal is to extend our main Office component from our own vue instance to avoid issues further down the compoent tree (e.g. when initializing NcTextField within a component that is rendered by spawnDialog).

Take it with care, it is mostly replicating what worked on text, but seems to work and not log errors in the console anymore.

Ideally viewer would not leak its vue instance in apps that register a handler https://github.com/nextcloud/viewer/issues/2395#issuecomment-2324646410