### PR TITLE
ci: Attempt to make cypress tests more stable with a unified wait for close

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   cypress:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/cypress/e2e/integration.spec.js
+++ b/cypress/e2e/integration.spec.js
@@ -79,8 +79,8 @@ describe('Nextcloud integration', function() {
 
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#closebutton').click()
+			cy.waitForViewerClose()
 		})
-		cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 
 		// FIXME: We should not need to reload
 		cy.get('.breadcrumb__crumbs a').eq(0).click({ force: true })

--- a/cypress/e2e/new.spec.js
+++ b/cypress/e2e/new.spec.js
@@ -62,8 +62,8 @@ describe.skip('Create new office files', function() {
 
 			cy.get('@loleafletframe').within(() => {
 				cy.get('#closebutton').click()
+				cy.waitForViewerClose()
 			})
-			cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 		})
 	})
 })

--- a/cypress/e2e/share-federated.spec.js
+++ b/cypress/e2e/share-federated.spec.js
@@ -35,7 +35,7 @@ describe('Federated sharing of office documents', function() {
 		cy.waitForViewer()
 		cy.waitForCollabora(true, true).within(() => {
 			cy.get('#closebutton').click()
-			cy.get('#viewer', { timeout: 5000 }).should('not.exist')
+			cy.waitForViewerClose()
 		})
 	})
 

--- a/cypress/e2e/share-internal.spec.js
+++ b/cypress/e2e/share-internal.spec.js
@@ -38,8 +38,8 @@ describe('File sharing of office documents', function() {
 		// Validate closing
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#closebutton').click()
+			cy.waitForViewerClose()
 		})
-		cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 	})
 
 	it('Open a shared file as readonly', function() {
@@ -61,7 +61,7 @@ describe('File sharing of office documents', function() {
 		// Validate closing
 		cy.get('@loleafletframe').within(() => {
 			cy.get('#closebutton').click()
+			cy.waitForViewerClose()
 		})
-		cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 	})
 })

--- a/cypress/e2e/share-link.js
+++ b/cypress/e2e/share-link.js
@@ -114,7 +114,6 @@ function waitForCollabora() {
 
 	cy.get('@loleafletframe').within(() => {
 		cy.get('#closebutton').click()
+		cy.waitForViewerClose()
 	})
-
-	cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -229,6 +229,11 @@ Cypress.Commands.add('waitForViewer', () => {
 		.and('not.have.class', 'icon-loading')
 })
 
+Cypress.Commands.add('waitForViewerClose', () => {
+	cy.get('#viewer', { timeout: 30000 })
+		.should('not.exist')
+})
+
 Cypress.Commands.add('waitForCollabora', (wrapped = false, federated = false) => {
 	const wrappedFrameIdentifier = federated ? 'coolframe' : 'documentframe'
 	if (wrapped) {


### PR DESCRIPTION
Hopefully fix #4284 

It seems close sometimes takes a bit longer until the viewer frame is actually removed (especially on CI). Move the logic to a cypress command.