### PR TITLE
fix: use storage free space

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -444,7 +444,7 @@ class WopiController extends Controller {
 
 			$content = fopen('php://input', 'rb');
 
-			$freespace = $file->getParent()->getFreeSpace();
+			$freespace = (int)$file->getStorage()->free_space($file->getInternalPath());
 			$contentLength = (int)$this->request->getHeader('Content-Length');
 
 			try {


### PR DESCRIPTION
* Resolves: #4229 
* Target version: main

### Summary
Using `getStorage()` will allow us to get the storage of the share owner, which means guest users (or other users with zero quota) will still be able to edit documents which are shared to them. The previous method of using `getParent()->getFreeSpace()` caused it to retrieve the editing user's free storage space instead, which results in the unintended behavior described by the issue.

### TODO

- [ ] Write tests

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
