### PR TITLE
ci: Try running oci on all runners

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -275,7 +275,7 @@ jobs:
         run: cd tests && bash run-integration.sh features/${{ matrix.scenarios }}.feature
 
   oci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     needs: changes
     if: needs.changes.outputs.src != 'false'

--- a/composer/composer/InstalledVersions.php
+++ b/composer/composer/InstalledVersions.php
@@ -322,6 +322,7 @@ class InstalledVersions
         }
 
         $installed = array();
+        $copiedLocalDir = false;
 
         if (self::$canGetVendors) {
             foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $loader) {
@@ -330,9 +331,11 @@ class InstalledVersions
                 } elseif (is_file($vendorDir.'/composer/installed.php')) {
                     /** @var array{root: array{name: string, pretty_version: string, version: string, reference: string|null, type: string, install_path: string, aliases: string[], dev: bool}, versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}>} $required */
                     $required = require $vendorDir.'/composer/installed.php';
-                    $installed[] = self::$installedByVendor[$vendorDir] = $required;
-                    if (null === self::$installed && strtr($vendorDir.'/composer', '\\', '/') === strtr(__DIR__, '\\', '/')) {
-                        self::$installed = $installed[count($installed) - 1];
+                    self::$installedByVendor[$vendorDir] = $required;
+                    $installed[] = $required;
+                    if (strtr($vendorDir.'/composer', '\\', '/') === strtr(__DIR__, '\\', '/')) {
+                        self::$installed = $required;
+                        $copiedLocalDir = true;
                     }
                 }
             }
@@ -350,7 +353,7 @@ class InstalledVersions
             }
         }
 
-        if (self::$installed !== array()) {
+        if (self::$installed !== array() && !$copiedLocalDir) {
             $installed[] = self::$installed;
         }
 

--- a/composer/composer/installed.php
+++ b/composer/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '88eb9d7b4bbe5f42df84e9ed12183e91554e0a1d',
+        'reference' => 'a020a8fa3bc95f7b2107173c1e1caa634a7c6671',
         'type' => 'library',
         'install_path' => __DIR__ . '/../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '88eb9d7b4bbe5f42df84e9ed12183e91554e0a1d',
+            'reference' => 'a020a8fa3bc95f7b2107173c1e1caa634a7c6671',
             'type' => 'library',
             'install_path' => __DIR__ . '/../',
             'aliases' => array(),

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -97,12 +97,12 @@ class DirectViewController extends Controller {
 			$template = $direct->getTemplateId() ? $this->templateManager->getTemplateSource($direct->getTemplateId()) : null;
 
 			if ($template !== null) {
-				$wopi = $this->tokenManager->generateWopiTokenForTemplate($template, $direct->getUid(), $item->getId(), true);
+				$wopi = $this->tokenManager->generateWopiTokenForTemplate($template, $item->getId(), $direct->getUid(), false, true);
 			}
 
 			if ($wopi === null) {
 				$urlSrc = $this->tokenManager->getUrlSrc($item);
-				$wopi = $this->tokenManager->generateWopiToken($item->getId(), null, $direct->getUid(), true);
+				$wopi = $this->tokenManager->generateWopiToken((string)$item->getId(), null, $direct->getUid(), true);
 			}
 		} catch (\Exception $e) {
 			$this->logger->error('Failed to generate token for existing file on direct editing', ['exception' => $e]);


### PR DESCRIPTION
Let's go back to passing CI

- Move oci to run on all ci runners (issues with selfhosted were resolved)
- Fix method usage due to merge of https://github.com/nextcloud/richdocuments/pull/4101 and https://github.com/nextcloud/richdocuments/pull/4306 which had introduced a new usage of that method
- Update committed composer files