### PR TITLE
feat: electronic signing, add settings for eIDEasy

### DIFF
--- a/docs/app_settings.md
+++ b/docs/app_settings.md
@@ -24,3 +24,9 @@ token. These credentials then can be used by the 3rd party application to make c
 
 ### Canonical webroot
 Canonical webroot, in case there are multiple, for Collabora Online to use. Provide the one with least restrictions. E.g.: Use non-shibbolized webroot if this instance is accessed by both shibbolized and non-shibbolized webroots. You can ignore this setting if only one webroot is used to access this instance.
+
+### Electronic signature
+From a shell running in the Nextcloud root directory, run the following `occ`
+command to configure a non-default base URL for eID Easy. For example:
+
+	./occ config:app:set --value https://test.eideasy.com richdocuments esignature_base_url

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -110,6 +110,9 @@ class SettingsController extends Controller {
 			'product_name' => $this->capabilitiesService->getServerProductName(),
 			'product_version' => $this->capabilitiesService->getProductVersion(),
 			'product_hash' => $this->capabilitiesService->getProductHash(),
+			'esignature_base_url' => $this->appConfig->getAppValue('esignature_base_url'),
+			'esignature_client_id' => $this->appConfig->getAppValue('esignature_client_id'),
+			'esignature_secret' => $this->appConfig->getAppValue('esignature_secret'),
 		];
 	}
 
@@ -122,6 +125,9 @@ class SettingsController extends Controller {
 		?string $doc_format,
 		?string $external_apps,
 		?string $canonical_webroot,
+		?string $esignature_base_url,
+		?string $esignature_client_id,
+		?string $esignature_secret,
 	): JSONResponse {
 		if ($wopi_url !== null) {
 			$this->appConfig->setAppValue('wopi_url', $wopi_url);
@@ -156,6 +162,18 @@ class SettingsController extends Controller {
 
 		if ($canonical_webroot !== null) {
 			$this->appConfig->setAppValue('canonical_webroot', $canonical_webroot);
+		}
+
+		if ($esignature_base_url !== null) {
+			$this->appConfig->setAppValue('esignature_base_url', $esignature_base_url);
+		}
+
+		if ($esignature_client_id !== null) {
+			$this->appConfig->setAppValue('esignature_client_id', $esignature_client_id);
+		}
+
+		if ($esignature_secret !== null) {
+			$this->appConfig->setAppValue('esignature_secret', $esignature_secret);
 		}
 
 		try {

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -159,6 +159,7 @@ class WopiController extends Controller {
 			'IsUserLocked' => $this->permissionManager->userIsFeatureLocked($wopi->getEditorUid()),
 			'EnableRemoteLinkPicker' => (bool)$wopi->getCanwrite() && !$isPublic && !$wopi->getDirect(),
 			'HasContentRange' => true,
+			'ServerPrivateInfo' => [],
 		];
 
 		$enableZotero = $this->config->getAppValue(Application::APPNAME, 'zoteroEnabled', 'yes') === 'yes';
@@ -174,6 +175,23 @@ class WopiController extends Controller {
 			$response['UserPrivateInfo']['SignatureKey'] = $documentSigningKey;
 			$documentSigningCa = $this->config->getUserValue($wopi->getEditorUid(), 'richdocuments', 'documentSigningCa', '');
 			$response['UserPrivateInfo']['SignatureCa'] = $documentSigningCa;
+
+			$eSignatureBaseUrl = $this->config->getAppValue(Application::APPNAME, 'esignature_base_url');
+			$eSignatureClientId = $this->config->getAppValue(Application::APPNAME, 'esignature_client_id');
+			$eSignatureSecret = $this->config->getAppValue(Application::APPNAME, 'esignature_secret');
+			if ($eSignatureBaseUrl === '' && $eSignatureClientId !== '' && $eSignatureSecret !== '') {
+				// If the client ID & secret is set, then assume a production base URL.
+				$eSignatureBaseUrl = 'https://id.eideasy.com';
+			}
+			if ($eSignatureBaseUrl !== '') {
+				$response['ServerPrivateInfo']['ESignatureBaseUrl'] = $eSignatureBaseUrl;
+			}
+			if ($eSignatureClientId !== '') {
+				$response['ServerPrivateInfo']['ESignatureClientId'] = $eSignatureClientId;
+			}
+			if ($eSignatureSecret !== '') {
+				$response['ServerPrivateInfo']['ESignatureSecret'] = $eSignatureSecret;
+			}
 		}
 		if ($wopi->hasTemplateId()) {
 			$response['TemplateSource'] = $this->getWopiUrlForTemplate($wopi);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -53,6 +53,9 @@ class Admin implements ISettings {
 					'os_family' => PHP_VERSION_ID >= 70200 ? PHP_OS_FAMILY : PHP_OS,
 					'platform' => php_uname('m'),
 					'fonts' => $this->fontService->getFontFileNames(),
+					'esignature_base_url' => $this->config->getAppValue('richdocuments', 'esignature_base_url'),
+					'esignature_client_id' => $this->config->getAppValue('richdocuments', 'esignature_client_id'),
+					'esignature_secret' => $this->config->getAppValue('richdocuments', 'esignature_secret'),
 				],
 			],
 			'blank'

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -391,6 +391,20 @@
 			</div>
 		</div>
 
+		<div v-if="isSetup" id="esignature-settings" class="section">
+			<h2>{{ t('richdocuments', 'Electronic signature settings') }}</h2>
+			<SettingsInputText v-model="settings.esignature_client_id"
+				:label="t('richdocuments', 'Client ID for the electronic signature API')"
+				:hint="t('richdocuments', 'Fill in the registration form at https://eideasy.com/signup to obtain a client ID and secret.')"
+				:disabled="updating"
+				@update="updateESignatureClientId" />
+			<SettingsInputText v-model="settings.esignature_secret"
+				:label="t('richdocuments', 'Secret for the electronic signature API')"
+				:hint="t('richdocuments', 'The secret may be downloadable via WOPI requests if WOPI allow list is not correctly configured.')"
+				:disabled="updating"
+				@update="updateESignatureSecret" />
+		</div>
+
 		<GlobalTemplates v-if="isSetup" />
 	</div>
 </template>
@@ -686,6 +700,16 @@ export default {
 		async updateWopiAllowlist(allowlist) {
 			await this.updateSettings({
 				wopi_allowlist: allowlist,
+			})
+		},
+		async updateESignatureClientId(id) {
+			await this.updateSettings({
+				esignature_client_id: id,
+			})
+		},
+		async updateESignatureSecret(secret) {
+			await this.updateSettings({
+				esignature_secret: secret,
 			})
 		},
 		async updateOoxml(enabled) {


### PR DESCRIPTION
* Resolves:  #4311
* Target version: main

### Summary

Electronic signing needs to store settings as richdocuments settings. This involves the API URL, a client ID visible to the browser and a secret, which is only used during server-side requests.

The WOPI CheckFileInfo reply sends this information to the COOL server, similar to how it's done for digital signing (via PEM files).

Add the settings as admin settings, otherwise normal users would be able to use eIDEasy services outside richdocuments.

<https://github.com/CollaboraOnline/online/issues/10630#issuecomment-2510923379> has instructions on what test data to use to try out the service in a test environment. Additionally, if the test CA is configured to be trusted as a user setting, then the green stamp icon will show up in the status bar.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required