### PR TITLE
feat: insert text and images generated with nextcloud assistant

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -42,6 +42,7 @@ return [
 
 		// Direct Editing: Assets
 		['name' => 'assets#create', 'url' => 'assets', 'verb' => 'POST'],
+		['name' => 'assets#createFromTask', 'url' => 'assets/tasks', 'verb' => 'POST'],
 		['name' => 'assets#get', 'url' => 'assets/{token}', 'verb' => 'GET'],
 
 		// templates

--- a/composer/composer/autoload_classmap.php
+++ b/composer/composer/autoload_classmap.php
@@ -87,6 +87,7 @@ return array(
     'OCA\\Richdocuments\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',
     'OCA\\Richdocuments\\Settings\\Personal' => $baseDir . '/../lib/Settings/Personal.php',
     'OCA\\Richdocuments\\Settings\\Section' => $baseDir . '/../lib/Settings/Section.php',
+    'OCA\\Richdocuments\\TaskProcessingManager' => $baseDir . '/../lib/TaskProcessingManager.php',
     'OCA\\Richdocuments\\TemplateManager' => $baseDir . '/../lib/TemplateManager.php',
     'OCA\\Richdocuments\\Template\\CollaboraTemplateProvider' => $baseDir . '/../lib/Template/CollaboraTemplateProvider.php',
     'OCA\\Richdocuments\\TokenManager' => $baseDir . '/../lib/TokenManager.php',

--- a/composer/composer/autoload_static.php
+++ b/composer/composer/autoload_static.php
@@ -120,6 +120,7 @@ class ComposerStaticInitRichdocuments
         'OCA\\Richdocuments\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',
         'OCA\\Richdocuments\\Settings\\Personal' => __DIR__ . '/..' . '/../lib/Settings/Personal.php',
         'OCA\\Richdocuments\\Settings\\Section' => __DIR__ . '/..' . '/../lib/Settings/Section.php',
+        'OCA\\Richdocuments\\TaskProcessingManager' => __DIR__ . '/..' . '/../lib/TaskProcessingManager.php',
         'OCA\\Richdocuments\\TemplateManager' => __DIR__ . '/..' . '/../lib/TemplateManager.php',
         'OCA\\Richdocuments\\Template\\CollaboraTemplateProvider' => __DIR__ . '/..' . '/../lib/Template/CollaboraTemplateProvider.php',
         'OCA\\Richdocuments\\TokenManager' => __DIR__ . '/..' . '/../lib/TokenManager.php',

--- a/lib/TaskProcessingManager.php
+++ b/lib/TaskProcessingManager.php
@@ -8,16 +8,20 @@ declare(strict_types=1);
 
 namespace OCA\Richdocuments;
 
+use OCP\App\IAppManager;
+use OCP\IUserSession;
 use OCP\TaskProcessing\IManager;
 
 class TaskProcessingManager {
-	public const array SUPPORTED_TASK_TYPES = [
+	public const SUPPORTED_TASK_TYPES = [
 		'core:text2text',
 		'core:text2image',
 	];
 
 	public function __construct(
 		private IManager $taskProcessing,
+		private IAppManager $appManager,
+		private IUserSession $userSession,
 	) {
 	}
 
@@ -29,6 +33,9 @@ class TaskProcessingManager {
 			array_flip(self::SUPPORTED_TASK_TYPES)
 		);
 
-		return !empty($availableTaskTypes);
+		// Check if the Assistant is actually enabled for the user
+		$isAssistantEnabled = $this->appManager->isEnabledForUser('assistant', $this->userSession->getUser());
+
+		return !empty($availableTaskTypes) && $isAssistantEnabled;
 	}
 }

--- a/lib/TaskProcessingManager.php
+++ b/lib/TaskProcessingManager.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\Richdocuments;
+
+use OCP\TaskProcessing\IManager;
+
+class TaskProcessingManager {
+	public const array SUPPORTED_TASK_TYPES = [
+		'core:text2text',
+		'core:text2image',
+	];
+
+	public function __construct(
+		private IManager $taskProcessing,
+	) {
+	}
+
+	public function isTaskProcessingEnabled(): bool {
+		// Check if task processing should be considered enabled
+		// if any of our supported task types are available
+		$availableTaskTypes = array_intersect_key(
+			$this->taskProcessing->getAvailableTaskTypes(),
+			array_flip(self::SUPPORTED_TASK_TYPES)
+		);
+
+		return !empty($availableTaskTypes);
+	}
+}

--- a/src/mixins/assistant.js
+++ b/src/mixins/assistant.js
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
+import axios from '@nextcloud/axios'
+
+const SupportedTaskTypes = {
+	Text: 'core:text2text',
+	Image: 'core:text2image',
+}
+
+export default {
+	data() {
+		return {
+			task: null,
+		}
+	},
+	methods: {
+		async openAssistant() {
+			this.task = await window.OCA.Assistant.openAssistantForm({
+				appId: 'richdocuments',
+				customId: 'richdocuments:' + this.fileid,
+				isInsideViewer: true,
+				actionButtons: [
+					{
+						label: t('richdocuments', 'Insert into document'),
+						title: t('richdocuments', 'Insert into document'),
+						onClick: () => this.handleTask(this.task),
+					},
+				],
+			})
+		},
+		handleTask(task) {
+			switch (task.type) {
+
+			case SupportedTaskTypes.Text:
+				this.insertAIText(task.output.output)
+				break
+
+			case SupportedTaskTypes.Image:
+				this.insertAIImages(task.output.images)
+				break
+
+			default:
+				break
+			}
+		},
+		insertAIText(text) {
+			this.sendPostMessage('Action_Paste', {
+				Mimetype: 'text/plain;charset=utf-8',
+				Data: text,
+			})
+		},
+		async insertAIImages(images) {
+			const assets = await axios({
+				method: 'post',
+				url: generateUrl('apps/richdocuments/assets/tasks'),
+				data: {
+					taskId: this.task.id,
+					fileIds: [images[0]],
+				},
+			})
+
+			// For now, we only insert the first generated image
+			const firstImage = assets.data[0]
+
+			this.sendPostMessage('Action_InsertGraphic', {
+				filename: firstImage.filename,
+				url: firstImage.url,
+			})
+		},
+	},
+}

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -114,6 +114,7 @@ import Config from '../services/config.tsx'
 import autoLogout from '../mixins/autoLogout.js'
 import openLocal from '../mixins/openLocal.js'
 import pickLink from '../mixins/pickLink.js'
+import assistant from '../mixins/assistant.js'
 import saveAs from '../mixins/saveAs.js'
 import uiMention from '../mixins/uiMention.js'
 import version from '../mixins/version.js'
@@ -140,7 +141,7 @@ export default {
 		ZoteroHint,
 	},
 	mixins: [
-		autoLogout, openLocal, pickLink, saveAs, uiMention, version,
+		autoLogout, openLocal, pickLink, saveAs, uiMention, version, assistant,
 	],
 	props: {
 		filename: {
@@ -466,6 +467,9 @@ export default {
 			case 'UI UI_PickLink':
 			case 'UI_PickLink':
 				this.pickLink()
+				break
+			case 'UI_InsertAIContent':
+				this.openAssistant()
 				break
 			case 'Action_GetLinkPreview':
 				this.resolveLink(args.url)


### PR DESCRIPTION
* Part of: https://github.com/nextcloud/richdocuments/issues/3934
* Target version: main

### Summary
This PR introduces some work toward integrating the Nextcloud Assistant into Nextcloud Office. With this integration, you can generate and insert both text and images into an office document without leaving the editor.

In order to test this feature, you need to also have the matching additions from the related pull request on Collabora: https://github.com/CollaboraOnline/online/pull/10730

### TODO

- [ ] Write the necessary Cypress tests (separate PR)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
