### PR TITLE
fix: Properly get empty template for direct editing

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -121,8 +121,13 @@ describe('Direct editing (legacy)', function() {
 				createNewFileDirectEditingLink(randUser, 'mynewfile.odt', emptyTemplate.id)
 					.then((token) => {
 						cy.logout()
-						cy.visit(token)
+						cy.visit(token, {
+							onBeforeLoad(win) {
+								cy.spy(win, 'postMessage').as('postMessage')
+							},
+						})
 						cy.waitForCollabora(false)
+						cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 						cy.screenshot('direct-new')
 					})
 			})

--- a/lib/Controller/DirectViewController.php
+++ b/lib/Controller/DirectViewController.php
@@ -94,16 +94,17 @@ class DirectViewController extends Controller {
 			}
 
 			$wopi = null;
-			$template = $direct->getTemplateId() ? $this->templateManager->getTemplateSource($direct->getTemplateId()) : null;
+			$template = $direct->getTemplateId() ? $this->templateManager->get($direct->getTemplateId()) : null;
 
 			if ($template !== null) {
 				$wopi = $this->tokenManager->generateWopiTokenForTemplate($template, $item->getId(), $direct->getUid(), false, true);
 			}
 
 			if ($wopi === null) {
-				$urlSrc = $this->tokenManager->getUrlSrc($item);
 				$wopi = $this->tokenManager->generateWopiToken((string)$item->getId(), null, $direct->getUid(), true);
 			}
+
+			$urlSrc = $this->tokenManager->getUrlSrc($item);
 		} catch (\Exception $e) {
 			$this->logger->error('Failed to generate token for existing file on direct editing', ['exception' => $e]);
 			return $this->renderErrorPage('Failed to open the requested file.');


### PR DESCRIPTION
Fix https://github.com/nextcloud/richdocuments/issues/4313

Follow up to #4101 as my cypress test did not assert that the document was loaded, when doing so the test was still failing. It turned out that i used the wrong method to get the template file which would work when I manually tested with user defined templates but not with the default empty template files.