### PR TITLE
Add Template and pages/numbers/keynote mimetypes

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -32,6 +32,9 @@ class Capabilities implements ICapability {
 		'application/vnd.oasis.opendocument.spreadsheet-template',
 		'application/vnd.oasis.opendocument.presentation-template',
 		'text/rtf',
+		'application/x-iwork-pages-sffpages',
+		'application/x-iwork-numbers-sffnumbers',
+		'application/x-iwork-keynote-sffkey',
 	];
 
 	public const MIMETYPES_MSOFFICE = [

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -28,6 +28,9 @@ class Capabilities implements ICapability {
 		'application/vnd.ms-visio.drawing',
 		'application/vnd.wordperfect',
 		'application/rtf',
+		'application/vnd.oasis.opendocument.text-template',
+		'application/vnd.oasis.opendocument.spreadsheet-template',
+		'application/vnd.oasis.opendocument.presentation-template',
 		'text/rtf',
 	];
 


### PR DESCRIPTION
- **feat: Add template mimetypes** 
  - They are read only in Collabora for now, contributes to https://github.com/nextcloud/richdocuments/issues/2315
- **feat: Add apple pages/numbers/keynote mimetypes** 
  - Rendering is not as good as with other office formats, 
  - @jospoortvliet Since you mention it works in Libreoffice, would you say it is good enough to enable by default? Otherwise I'd probably make this a config option as experimental support
