### PR TITLE
fix(notifications): Notifier::prepare() threw \InvalidArgumentExcepti…

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace OCA\Richdocuments\Notification;
 
-use InvalidArgumentException;
 use OC\User\NoUserException;
 use OCA\Richdocuments\AppInfo\Application;
 use OCP\Files\IRootFolder;
@@ -16,8 +15,10 @@ use OCP\Files\NotPermittedException;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	public const TYPE_MENTIONED = 'mentioned';
@@ -42,7 +43,7 @@ class Notifier implements INotifier {
 
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APPNAME) {
-			throw new InvalidArgumentException('Application should be text instead of ' . $notification->getApp());
+			throw new UnknownNotificationException('Application should be text instead of ' . $notification->getApp());
 		}
 
 		$l = $this->factory->get(Application::APPNAME, $languageCode);
@@ -56,18 +57,18 @@ class Notifier implements INotifier {
 				$fileId = (int)$notification->getObjectId();
 
 				if ($sourceUserDisplayName === null) {
-					throw new InvalidArgumentException();
+					throw new UnknownNotificationException();
 				}
 
 				try {
 					$userFolder = $this->rootFolder->getUserFolder($targetUser);
 				} catch (NotPermittedException|NoUserException $e) {
-					throw new InvalidArgumentException();
+					throw new UnknownNotificationException();
 				}
 				$node = $userFolder->getFirstNodeById($fileId);
 
 				if ($node === null) {
-					throw new InvalidArgumentException();
+					throw new AlreadyProcessedException();
 				}
 
 				$fileLink = $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $node->getId()]);
@@ -88,7 +89,7 @@ class Notifier implements INotifier {
 				]);
 				break;
 			default:
-				throw new InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 		$notification->setIcon($this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('text', 'app-dark.svg')));
 		$notification->setLink($fileLink);


### PR DESCRIPTION
…on which is deprecated

If a user has any notifications this log is generated all the time:

> OCA\Richdocuments\Notification\Notifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
