### PR TITLE
fix: Apply proper default timezone for watermarks

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -205,9 +205,13 @@ class WopiController extends Controller {
 		$share = $this->getShareForWopiToken($wopi);
 		if ($this->permissionManager->shouldWatermark($file, $wopi->getEditorUid(), $share)) {
 			$email = $user !== null && !$isPublic ? $user->getEMailAddress() : '';
+			$currentDateTime = new \DateTime(
+				'now',
+				new \DateTimeZone($this->config->getSystemValueString('default_timezone', 'UTC'))
+			);
 			$replacements = [
 				'userId' => $wopi->getEditorUid(),
-				'date' => (new \DateTime())->format('Y-m-d H:i:s'),
+				'date' => $currentDateTime->format('Y-m-d H:i:s'),
 				'themingName' => \OC::$server->getThemingDefaults()->getName(),
 				'userDisplayName' => $userDisplayName,
 				'email' => $email,


### PR DESCRIPTION
Nextcloud server overwrites the default php timezone in https://github.com/nextcloud/server/blob/7c59119c03c491f3534021b7011adfebf6e27b19/lib/base.php#L618

It might be historic reasons, this PR makes sure to pick up the `default_timezone` setting from Nextclouds config.php and set that when generating the date time for watermarking.