### PR TITLE
fix: Add another option for otf font mimetypes

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -436,6 +436,7 @@ const SERVER_STATE_BROWSER_CONNECTION_ERROR = 4
 
 const fontMimes = [
 	'font/ttf',
+	'font/otf',
 	'application/font-sfnt',
 	'font/opentype',
 	'application/vnd.oasis.opendocument.formula-template',


### PR DESCRIPTION
Depending on the operating system or browser the mimetype detected in JS might be different.