### PR TITLE
fix(sharing): use correct save path when renaming

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -571,8 +571,7 @@ class WopiController extends Controller {
 				$suggested = $this->request->getHeader('X-WOPI-RequestedName');
 				$suggested = mb_convert_encoding($suggested, 'utf-8', 'utf-7') . '.' . $file->getExtension();
 
-				$parent = $isPublic ? dirname($file->getPath()) : $userFolder->getPath();
-				$path = $this->normalizePath($suggested, $parent);
+				$path = $this->normalizePath($suggested, dirname($file->getPath()));
 
 				if ($path === '') {
 					return new JSONResponse([

--- a/tests/features/bootstrap/RichDocumentsContext.php
+++ b/tests/features/bootstrap/RichDocumentsContext.php
@@ -235,4 +235,17 @@ class RichDocumentsContext implements Context {
 			'guestName' => $displayName,
 		], [ 'auth' => null ]);
 	}
+
+	/**
+	 * @Given /^as "([^"]*)" rename "([^"]*)" to "([^"]*)"$/
+	 */
+	public function renameFileTo($user, $file, $newName) {
+		$this->serverContext->usingWebAsUser($user);
+		$davClient = $this->filesContext->getSabreClient($user);
+		$path = $this->filesContext->makeSabrePath($user, $file);
+		$result = $davClient->propFind($path, ['{http://owncloud.org/ns}fileid']);
+		$fileId = $result['{http://owncloud.org/ns}fileid'];
+
+		$this->wopiContext->collaboraRenamesTo($fileId, $newName);
+	}
 }

--- a/tests/features/bootstrap/WopiContext.php
+++ b/tests/features/bootstrap/WopiContext.php
@@ -298,4 +298,21 @@ class WopiContext implements Context {
 			$this->response = $e->getResponse();
 		}
 	}
+
+	public function collaboraRenamesTo($fileId, $newName) {
+		$client = new Client();
+		$options = [
+			'headers' => [
+				'X-LOOL-WOPI-Timestamp' => $this->checkFileInfoResult['LastModifiedTime'],
+				'X-WOPI-RequestedName' => $newName,
+				'X-WOPI-Override' => 'RENAME_FILE',
+			],
+		];
+
+		try {
+			$this->response = $client->post($this->getWopiEndpointBaseUrl() . 'index.php/apps/richdocuments/wopi/files/' . $fileId . '?access_token=' . $this->wopiToken, $options);
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
+			$this->response = $e->getResponse();
+		}
+	}
 }

--- a/tests/features/wopi.feature
+++ b/tests/features/wopi.feature
@@ -358,3 +358,21 @@ Feature: WOPI
     And Collabora saves the content of "./../emptyTemplates/template.ods" as "/saved-as-guest-document.odt"
     And as "user1" the file "/SharedFolder/saved-as-guest-document.odt" exists
     And as "user1" the file "/saved-as-guest-document.odt" does not exist
+
+  Scenario: Rename file on share link
+    Given as user "user1"
+
+    And User "user1" creates a folder "/SharedFolder"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/SharedFolder/file.odt"
+    And as "user1" create a share with
+      | path        | /SharedFolder |
+      | shareType   | 3             |
+    And Updating last share with
+      | permissions | 31 |
+    And User "user1" opens the file "file.odt" of the shared link
+    And Collabora fetches checkFileInfo
+
+    And as "user1" rename "/SharedFolder/file.odt" to "renamed_file"
+    And as "user1" the file "/SharedFolder/renamed_file.odt" exists
+    And as "user1" the file "/SharedFolder/file.odt" does not exist
+    And as "user1" the file "/renamed_file.odt" does not exist


### PR DESCRIPTION
* Resolves: #4370 
* Target version: main

### Summary
When accessing a publicly shared folder as a logged-in user with edit permissions and attempting to rename a file from within Collabora, the file would seemingly disappear upon a page refresh. It was actually being saved to the owner's root folder (so not entirely disappearing, just being moved out of the shared folder).

It seems to have been caused by a previous pull request which introduced logic to determine the proper save path for a file. We instead just use the file path now if it is a request for a name change, instead of doing some unneeded checks for public shares, etc.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
