### PR TITLE
fix: Generate preview with proper aspect ratio for templates

### DIFF
--- a/lib/Template/CollaboraTemplateProvider.php
+++ b/lib/Template/CollaboraTemplateProvider.php
@@ -46,7 +46,7 @@ class CollaboraTemplateProvider implements ICustomTemplateProvider {
 
 		return array_map(function (File $file) {
 			$template = new Template(CollaboraTemplateProvider::class, (string)$file->getId(), $file);
-			$template->setCustomPreviewUrl($this->urlGenerator->linkToRouteAbsolute('richdocuments.templates.getPreview', ['fileId' => $file->getId()]));
+			$template->setCustomPreviewUrl($this->urlGenerator->linkToRouteAbsolute('richdocuments.templates.getPreview', ['fileId' => $file->getId(), 'a' => true]));
 			return $template;
 		}, $collaboraTemplates);
 	}


### PR DESCRIPTION
Steps to reproduce:

- Select a user template folder in richdocuments settings
- Add a template
- Open the template picker

Before this change we injected a square preview that looked odd in the tempalte picker with others coming from the server template directory having the aspect ratio of the document.