### PR TITLE
fix(Controller): incomplete return type list

### DIFF
--- a/composer/composer/installed.php
+++ b/composer/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'a020a8fa3bc95f7b2107173c1e1caa634a7c6671',
+        'reference' => 'cfd48c8ab8986bf0b444fede00b5c3f70c0f703a',
         'type' => 'library',
         'install_path' => __DIR__ . '/../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'a020a8fa3bc95f7b2107173c1e1caa634a7c6671',
+            'reference' => 'cfd48c8ab8986bf0b444fede00b5c3f70c0f703a',
             'type' => 'library',
             'install_path' => __DIR__ . '/../',
             'aliases' => array(),

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -305,7 +305,7 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'GET', url: 'wopi/files/{fileId}/contents')]
-	public function getFile(string $fileId, string $access_token): JSONResponse|StreamResponse {
+	public function getFile(string $fileId, string $access_token): JSONResponse|StreamResponse|Http\Response {
 		[$fileId, , $version] = Helper::parseFileId($fileId);
 
 		try {


### PR DESCRIPTION
- a plain response is instantiated in two places
- solves a PHP Error


Cf. lines 336 and 342 for the instantiation.

This prevents me opening documents for editing on 31.

<details><summary>Uncaught error: OCA\\Richdocuments\\Controller\\WopiController::getFile(): Return value must be of type OCP\\AppFramework\\Http\\JSONResponse|OCP\\AppFramework\\Http\\StreamResponse, OCP\\AppFramework\\Http\\Response returned in file '/path/to/nextcloud/apps/richdocuments/lib/Controller/WopiController.php' line 374</summary>

```
{
  "reqId": "SDJcMq8QHM71UZdi9KYd",
  "level": 3,
  "time": "2025-01-21T19:28:49+00:00",
  "remoteAddr": "127.0.0.1",
  "user": false,
  "app": "richdocuments",
  "method": "GET",
  "url": "/master/index.php/apps/richdocuments/wopi/files/1005358_oc1aiufaw3gw/contents?access_token=larf2GHV7ApYlYKHmaXU713jocMSZlz7&access_token_ttl=0",
  "message": "Uncaught error: OCA\\Richdocuments\\Controller\\WopiController::getFile(): Return value must be of type OCP\\AppFramework\\Http\\JSONResponse|OCP\\AppFramework\\Http\\StreamResponse, OCP\\AppFramework\\Http\\Response returned in file '/path/to/nextcloud/apps/richdocuments/lib/Controller/WopiController.php' line 374",
  "userAgent": "COOLWSD HTTP Agent 24.04.7.1",
  "version": "31.0.0.9",
  "exception": {
    "Exception": "Exception",
    "Message": "OCA\\Richdocuments\\Controller\\WopiController::getFile(): Return value must be of type OCP\\AppFramework\\Http\\JSONResponse|OCP\\AppFramework\\Http\\StreamResponse, OCP\\AppFramework\\Http\\Response returned in file '/path/to/nextcloud/apps/richdocuments/lib/Controller/WopiController.php' line 374",
    "Code": 0,
    "Trace": [
      {
        "file": "/path/to/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Richdocuments\\Controller\\WopiController"
          },
          "getFile"
        ]
      },
      {
        "file": "/path/to/nextcloud/lib/private/Route/Router.php",
        "line": 306,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Richdocuments\\Controller\\WopiController",
          "getFile",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "fileId": "1005358_oc1aiufaw3gw",
            "_route": "richdocuments.wopi.getfile"
          }
        ]
      },
      {
        "file": "/path/to/nextcloud/lib/base.php",
        "line": 1019,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/apps/richdocuments/wopi/files/1005358_oc1aiufaw3gw/contents"
        ]
      },
      {
        "file": "/path/to/nextcloud/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "/path/to/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
    "Line": 146,
    "Previous": {
      "Exception": "TypeError",
      "Message": "OCA\\Richdocuments\\Controller\\WopiController::getFile(): Return value must be of type OCP\\AppFramework\\Http\\JSONResponse|OCP\\AppFramework\\Http\\StreamResponse, OCP\\AppFramework\\Http\\Response returned",
      "Code": 0,
      "Trace": [
        {
          "file": "/path/to/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 200,
          "function": "getFile",
          "class": "OCA\\Richdocuments\\Controller\\WopiController",
          "type": "->",
          "args": [
            "1005358",
            "larf2GHV7ApYlYKHmaXU713jocMSZlz7"
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 114,
          "function": "executeController",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Richdocuments\\Controller\\WopiController"
            },
            "getFile"
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/private/AppFramework/App.php",
          "line": 161,
          "function": "dispatch",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->",
          "args": [
            {
              "__class__": "OCA\\Richdocuments\\Controller\\WopiController"
            },
            "getFile"
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/private/Route/Router.php",
          "line": 306,
          "function": "main",
          "class": "OC\\AppFramework\\App",
          "type": "::",
          "args": [
            "OCA\\Richdocuments\\Controller\\WopiController",
            "getFile",
            {
              "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
            },
            {
              "fileId": "1005358_oc1aiufaw3gw",
              "_route": "richdocuments.wopi.getfile"
            }
          ]
        },
        {
          "file": "/path/to/nextcloud/lib/base.php",
          "line": 1019,
          "function": "match",
          "class": "OC\\Route\\Router",
          "type": "->",
          "args": [
            "/apps/richdocuments/wopi/files/1005358_oc1aiufaw3gw/contents"
          ]
        },
        {
          "file": "/path/to/nextcloud/index.php",
          "line": 24,
          "function": "handleRequest",
          "class": "OC",
          "type": "::",
          "args": []
        }
      ],
      "File": "/path/to/nextcloud/apps/richdocuments/lib/Controller/WopiController.php",
      "Line": 374
    },
    "message": "Uncaught error: OCA\\Richdocuments\\Controller\\WopiController::getFile(): Return value must be of type OCP\\AppFramework\\Http\\JSONResponse|OCP\\AppFramework\\Http\\StreamResponse, OCP\\AppFramework\\Http\\Response returned in file '/path/to/nextcloud/apps/richdocuments/lib/Controller/WopiController.php' line 374",
    "exception": {},
    "CustomMessage": "Uncaught error: OCA\\Richdocuments\\Controller\\WopiController::getFile(): Return value must be of type OCP\\AppFramework\\Http\\JSONResponse|OCP\\AppFramework\\Http\\StreamResponse, OCP\\AppFramework\\Http\\Response returned in file '/path/to/nextcloud/apps/richdocuments/lib/Controller/WopiController.php' line 374"
  }
}

```

</details>