### PR TITLE
chore: update composer files for composer v2.3.5

### DIFF
--- a/composer/composer/installed.json.license
+++ b/composer/composer/installed.json.license
@@ -1,2 +1,0 @@
-SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
-SPDX-License-Identifier: AGPL-3.0-or-later

--- a/composer/composer/installed.php
+++ b/composer/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => '__root__',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'cfd48c8ab8986bf0b444fede00b5c3f70c0f703a',
+        'reference' => '8c21f5edd732074493f83a7e9c84b825ab8aab25',
         'type' => 'library',
         'install_path' => __DIR__ . '/../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         '__root__' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'cfd48c8ab8986bf0b444fede00b5c3f70c0f703a',
+            'reference' => '8c21f5edd732074493f83a7e9c84b825ab8aab25',
             'type' => 'library',
             'install_path' => __DIR__ . '/../',
             'aliases' => array(),


### PR DESCRIPTION
Fixes an issue with the autoload tests failing due to an update to composer. I used [this PR](https://github.com/nextcloud/text/pull/6767) as a reference