### PR TITLE
fix(Db): Allow guest displaynames with a length of up to 255 chars

### DIFF
--- a/lib/Migration/Version2060Date20200302131958.php
+++ b/lib/Migration/Version2060Date20200302131958.php
@@ -44,7 +44,7 @@ class Version2060Date20200302131958 extends SimpleMigrationStep {
 			]);
 			$table->addColumn('guest_displayname', 'string', [
 				'notnull' => false,
-				'length' => 64,
+				'length' => 255,
 			]);
 			$table->addColumn('fileid', 'bigint', [
 				'notnull' => true,

--- a/lib/Migration/Version9000Date20250128212050.php
+++ b/lib/Migration/Version9000Date20250128212050.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version9000Date20250128212050 extends SimpleMigrationStep {
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('richdocuments_wopi')) {
+			return null;
+		}
+
+		$table = $schema->getTable('richdocuments_wopi');
+		if (!$table->hasColumn('guest_displayname')) {
+			return null;
+		}
+
+		$column = $table->getColumn('guest_displayname');
+		if ($column->getLength() === 255) {
+			return null;
+		}
+
+		$column->setLength(255);
+		return $schema;
+	}
+}


### PR DESCRIPTION
* Resolves: #4389
* Target version: main

### Summary

Changes DB field for guest displaynames from 64 to 255 bytes. Useful in federated setups.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Documentation (manuals or wiki) has been updated or is not required
