### PR TITLE
fix: Read from local file stream to avoid locking during preview generation

### DIFF
--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -58,13 +58,8 @@ class RemoteService {
 	 * @return resource|string
 	 */
 	public function convertFileTo(File $file, string $format) {
-		$useTempFile = $file->isEncrypted() || !$file->getStorage()->isLocal();
-		if ($useTempFile) {
-			$fileName = $file->getStorage()->getLocalFile($file->getInternalPath());
-			$stream = fopen($fileName, 'r');
-		} else {
-			$stream = $file->fopen('r');
-		}
+		$fileName = $file->getStorage()->getLocalFile($file->getInternalPath());
+		$stream = fopen($fileName, 'rb');
 
 		if ($stream === false) {
 			throw new Exception('Failed to open stream');
@@ -98,16 +93,11 @@ class RemoteService {
 	}
 
 	private function getRequestOptionsForFile(File $file, ?string $target = null): array {
-		$useTempFile = $file->isEncrypted() || !$file->getStorage()->isLocal();
-		if ($useTempFile) {
-			$localFile = $file->getStorage()->getLocalFile($file->getInternalPath());
-			if (!is_string($localFile)) {
-				throw new NotFoundException('Could not get local file');
-			}
-			$stream = fopen($localFile, 'rb');
-		} else {
-			$stream = $file->fopen('rb');
+		$localFile = $file->getStorage()->getLocalFile($file->getInternalPath());
+		if (!is_string($localFile)) {
+			throw new NotFoundException('Could not get local file');
 		}
+		$stream = fopen($localFile, 'rb');
 
 		$options = RemoteOptionsService::getDefaultOptions(25);
 		$options['multipart'] = [


### PR DESCRIPTION
Should resolve https://github.com/nextcloud/richdocuments/issues/2092

We can always use the local file, it may be temporary or the file itself in the data directory, but we can read without locking.