### PR TITLE
fix: portable document format --> pdf

### DIFF
--- a/lib/Conversion/ConversionProvider.php
+++ b/lib/Conversion/ConversionProvider.php
@@ -141,7 +141,7 @@ class ConversionProvider implements IConversionProvider {
 				[$targetMimeType]
 			));
 		}
-		
+
 		return $this->remoteService->convertFileTo($file, $targetFileExtension);
 	}
 
@@ -196,7 +196,7 @@ class ConversionProvider implements IConversionProvider {
 		return [
 			'application/pdf' => [
 				'extension' => 'pdf',
-				'displayName' => $this->l10n->t('Portable Document Format (.pdf)'),
+				'displayName' => $this->l10n->t('PDF (.pdf)'),
 			],
 			'image/png' => [
 				'extension' => 'png',


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4441
* Target version: main

### Summary
Change `Save as Portable Document Format (.pdf)` to `Save as PDF (.pdf)` which is less verbose and more in line with how most users refer to the format.

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/04748486-f5ac-4c55-8846-a46992a12227)
</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/f972c56b-736e-4c88-846a-6b4980d12fa3)
</details>

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
