### PR TITLE
fix: Skip early if font file path is not existing

### DIFF
--- a/lib/Service/FontService.php
+++ b/lib/Service/FontService.php
@@ -183,6 +183,9 @@ class FontService {
 			// but just a file path
 			$tmpFontFile = tmpfile();
 			$tmpFontFilePath = stream_get_meta_data($tmpFontFile)['uri'];
+			if (!file_exists($tmpFontFilePath)) {
+				return;
+			}
 			fwrite($tmpFontFile, $fontFile->getContent());
 			fflush($tmpFontFile);
 


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
