### PR TITLE
fix(url): correct WOPI settings URL to prevent duplicate `nextcloud`

### DIFF
--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -82,7 +82,7 @@ const getDocumentUrlForFile = (fileDir, fileId) => {
 }
 
 export const getConfigFileUrl = () => {
-	return getCallbackBaseUrl() + generateUrl('apps/richdocuments/wopi/settings')
+	return generateUrl('apps/richdocuments/wopi/settings', null, { baseURL: getCallbackBaseUrl() })
 }
 
 const getNextcloudUrl = () => {


### PR DESCRIPTION
Replaced `getCallbackBaseUrl()` with `window.location.protocol + '//' + window.location.host` to ensure the correct WOPI settings URL. This prevents the issue where `/nextcloud` appears twice in the generated URL.

prev URL : http://localhost/nextcloud/nextcloud/index.php/apps/richdocuments/wopi/settings
now it should be: http://localhost/nextcloud/index.php/apps/richdocuments/wopi/settings