### PR TITLE
templates: better support cross-format templates

### DIFF
--- a/lib/Listener/FileCreatedFromTemplateListener.php
+++ b/lib/Listener/FileCreatedFromTemplateListener.php
@@ -54,17 +54,17 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			return;
 		}
 
-		if ($this->templateManager->isSupportedTemplateSource($templateFile->getExtension())) {
-			// Only use TemplateSource if supported filetype
-			$this->templateManager->setTemplateSource($event->getTarget()->getId(), $templateFile->getId());
-		}
-
 		if ($this->capabilitiesService->hasFormFilling()) {
 			try {
-				$filledTemplate = $this->templateFieldService->fillFields($templateFile, $event->getTemplateFields());
+				$filledTemplate = $this->templateFieldService->fillFields($templateFile, $event->getTemplateFields(), null, $event->getTarget()->getExtension());
 				$event->getTarget()->putContent($filledTemplate);
 			} catch (\Exception $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
+			}
+		} else {
+			if ($this->templateManager->isSupportedTemplateSource($templateFile->getExtension())) {
+				// Only use TemplateSource if supported filetype
+				$this->templateManager->setTemplateSource($event->getTarget()->getId(), $templateFile->getId());
 			}
 		}
 

--- a/lib/Service/TemplateFieldService.php
+++ b/lib/Service/TemplateFieldService.php
@@ -177,7 +177,7 @@ class TemplateFieldService {
 
 		$formFormat = [
 			'name' => 'format',
-			'contents' => $file->getExtension(),
+			'contents' => $format === null ? $file->getExtension() : $format,
 		];
 
 		$form = RemoteOptionsService::getDefaultOptions();
@@ -190,13 +190,6 @@ class TemplateFieldService {
 			);
 
 			$content = $response->getBody();
-
-			if ($format !== null) {
-				$tmp = $this->tempManager->getTemporaryFile();
-				file_put_contents($tmp, $content);
-				$fp = fopen($tmp, 'rb');
-				$content = $this->remoteService->convertTo($file->getName(), $fp, $format);
-			}
 
 			if ($destination !== null) {
 				$this->writeToDestination($destination, $content);


### PR DESCRIPTION
If form filling was used to create a file, do not add a template source. Otherwise Collabora Online creates the file again from the template.

Use the format option in 'transform-document-structure' to avoid an intermediate save in the template format, which might not be supported as a save format.
