### PR TITLE
fix: send etag for settings URLs and update etag on file changes

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -177,7 +177,6 @@ class WopiController extends Controller {
 		];
 
 		if ($this->capabilitiesService->hasSettingIframeSupport()) {
-
 			if (!$isPublic) {
 				$response['UserSettings'] = $this->generateSettings($userId, 'userconfig');
 			}
@@ -993,9 +992,10 @@ class WopiController extends Controller {
 	private function generateSettings(string $userId, string $type): array {
 		$nextcloudUrl = $this->appConfig->getNextcloudUrl() ?: trim($this->urlGenerator->getAbsoluteURL(''), '/');
 		$uri = $nextcloudUrl . '/index.php/apps/richdocuments/wopi/settings' . '?type=' . $type . '&access_token=' . $this->generateSettingToken($userId) . '&fileId=' . '-1';
+		$etag = $this->settingsService->getFolderEtag($type);
 		return [
 			'uri' => $uri,
-			'stamp' => time()
+			'stamp' => $etag
 		];
 	}
 }

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -242,7 +242,12 @@ class SettingsService {
 			throw new NotFoundException('Instance ID not found');
 		}
 		$rootFolder = $this->rootFolder;
-		$folder = $rootFolder->get('appdata_' . $instanceId . '/richdocuments' . '/' . $type);
+		try {
+			$folder = $rootFolder->get('appdata_' . $instanceId . '/richdocuments' . '/' . $type);
+		} catch (NotFoundException $e) {
+			$baseFolder = $this->appData->newFolder($type);
+			$folder = $rootFolder->get('appdata_' . $instanceId . '/richdocuments' . '/' . $type);
+		}
 		return $folder;
 	}
 

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -97,6 +97,7 @@ class SettingsService {
 		$fileName = $settingsUrl->getFileName();
 		$newFile = $categoryFolder->newFile($fileName, $fileData);
 		$fileUri = $this->generateFileUri($settingsUrl->getType(), $settingsUrl->getCategory(), $fileName, $userId);
+		$this->refreshFolderEtag($settingsUrl->getType());
 
 		return [
 			'stamp' => $newFile->getETag(),
@@ -154,6 +155,15 @@ class SettingsService {
 			throw $e;
 		}
 	}
+
+	/**
+	 *
+	 * @param string $type
+	 * @return string
+	 */
+	public function getFolderEtag($type) : string {
+		return $this->getTypeFolder($type)->getEtag();
+	}
 	
 	/**
 	 * generate setting config
@@ -210,12 +220,7 @@ class SettingsService {
 	 */
 	private function getCategoryDirFolderList(string $type) : array {
 		try {
-			$instanceId = $this->config->getSystemValue('instanceid', null);
-			if ($instanceId === null) {
-				throw new NotFoundException('Instance ID not found');
-			}
-			$rootFolder = $this->rootFolder;
-			$folder = $rootFolder->get('appdata_' . $instanceId . '/richdocuments' . '/' . $type);
+			$folder = $this->getTypeFolder($type);
 			if (!$folder instanceof Folder) {
 				return [];
 			}
@@ -223,6 +228,31 @@ class SettingsService {
 		} catch (NotFoundException $e) {
 			return [];
 		}
+	}
+
+	/**
+	 * extract folder of $type
+	 *
+	 * @param string $type
+	 * @return Folder
+	 */
+	private function getTypeFolder($type) {
+		$instanceId = $this->config->getSystemValue('instanceid', null);
+		if ($instanceId === null) {
+			throw new NotFoundException('Instance ID not found');
+		}
+		$rootFolder = $this->rootFolder;
+		$folder = $rootFolder->get('appdata_' . $instanceId . '/richdocuments' . '/' . $type);
+		return $folder;
+	}
+
+	/**
+	 *
+	 * @param string $type
+	 */
+	private function refreshFolderEtag($type) {
+		$folder = $this->getTypeFolder($type);
+		$folder->getStorage()->getCache()->update($folder->getId(), [ 'etag' => uniqid() ]);
 	}
 
 	/**
@@ -314,6 +344,7 @@ class SettingsService {
 				throw new NotFoundException("File '{$name}' not found in category '{$category}' for type '{$type}'.");
 			}
 			$categoryFolder->getFile($name)->delete();
+			$this->refreshFolderEtag($type);
 		} catch (NotFoundException $e) {
 			throw $e;
 		} catch (NotPermittedException $e) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
fix: send etag for settings URLs and update etag on file changes

- Replace timestamp with the folder etag in settings generation.
- Update the folder etag when files are created or deleted.
- Refactor folder retrieval logic into helper methods for consistency.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
