### PR TITLE
[stable27] fix: get storage from file instead of parent

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -517,7 +517,7 @@ class WopiController extends Controller {
 
 			$content = fopen('php://input', 'rb');
 
-			$freespace = $file->getParent()->getFreeSpace();
+			$freespace = (int)$file->getStorage()->free_space($file->getInternalPath());
 			$contentLength = (int)$this->request->getHeader('Content-Length');
 
 			try {


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/richdocuments/pull/4301