### PR TITLE
[stable29] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -236,12 +236,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "5ee6a24cf01fbfd0ca32a4e568279de6eadd68f7"
+                "reference": "45023f648cfcc3942baf4e9a5d465a545fa06bfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/5ee6a24cf01fbfd0ca32a4e568279de6eadd68f7",
-                "reference": "5ee6a24cf01fbfd0ca32a4e568279de6eadd68f7",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/45023f648cfcc3942baf4e9a5d465a545fa06bfb",
+                "reference": "45023f648cfcc3942baf4e9a5d465a545fa06bfb",
                 "shasum": ""
             },
             "require": {
@@ -272,7 +272,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable29"
             },
-            "time": "2025-02-04T00:42:54+00:00"
+            "time": "2025-02-15T00:42:50+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency