### PR TITLE
chore: remove `vendor/` from `.nextcloudignore`

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -32,5 +32,4 @@ screenshots
 src
 tests
 tsconfig.json
-vendor
 webpack.*


### PR DESCRIPTION
Fixes broken dependencies in packaging.