### PR TITLE
Properly handle editor user id for direct editing links

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -190,7 +190,7 @@ jobs:
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: failure()
         with:
-          name: Upload screenshots
+          name: screenshots-${{ matrix.code-image }}-${{ matrix.containers }}
           path: apps/${{ env.APP_NAME }}/cypress/screenshots/
           retention-days: 5
 
@@ -198,7 +198,7 @@ jobs:
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         if: failure()
         with:
-          name: Upload nextcloud log
+          name: nextcloud-log-${{ matrix.code-image }}-${{ matrix.containers }}
           path: data/nextcloud.log
           retention-days: 5
 

--- a/composer.lock
+++ b/composer.lock
@@ -481,12 +481,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f5322bc3a4faaaa33a722cc22c8ee08f9da3e387"
+                "reference": "dc5473e3895d859535de45eab15d2095cb8eafe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f5322bc3a4faaaa33a722cc22c8ee08f9da3e387",
-                "reference": "f5322bc3a4faaaa33a722cc22c8ee08f9da3e387",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/dc5473e3895d859535de45eab15d2095cb8eafe4",
+                "reference": "dc5473e3895d859535de45eab15d2095cb8eafe4",
                 "shasum": ""
             },
             "require": {
@@ -522,7 +522,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-02-28T00:44:44+00:00"
+            "time": "2025-03-11T00:46:19+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -485,7 +485,7 @@ class DocumentController extends Controller {
 		if ($templateFile) {
 			$owneruid = $share?->getShareOwner() ?? $file->getOwner()->getUID();
 
-			return $this->tokenManager->generateWopiTokenForTemplate(
+			$wopiToken = $this->tokenManager->generateWopiTokenForTemplate(
 				$templateFile,
 				$file->getId(),
 				$owneruid,
@@ -493,7 +493,10 @@ class DocumentController extends Controller {
 				false,
 				$share?->getPermissions()
 			);
+			$this->tokenManager->setShareToken($wopiToken, $share?->getToken());
+			return $wopiToken;
 		}
+
 
 		return $this->tokenManager->generateWopiToken($this->getWopiFileId($file->getId(), $version), $share?->getToken(), $this->userId);
 	}

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -760,7 +760,7 @@ class WopiController extends Controller {
 
 			// generate a token for the new file (the user still has to be
 			// logged in)
-			$wopi = $this->tokenManager->generateWopiToken((string)$file->getId(), null, $wopi->getEditorUid(), $wopi->getDirect());
+			$wopi = $this->tokenManager->generateWopiToken((string)$file->getId(), $wopi->getShare(), $wopi->getEditorUid(), $wopi->getDirect());
 
 			return new JSONResponse(['Name' => $file->getName(), 'Url' => $this->getWopiUrlForFile($wopi, $file)], Http::STATUS_OK);
 		} catch (NotFoundException $e) {

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -258,6 +258,11 @@ class TokenManager {
 		$this->wopiMapper->update($wopi);
 	}
 
+	public function setShareToken(Wopi $wopi, ?string $shareToken): Wopi {
+		$wopi->setShare($shareToken);
+		return $this->wopiMapper->update($wopi);
+	}
+
 	public function setGuestName(Wopi $wopi, ?string $guestName = null): Wopi {
 		if ($wopi->getTokenType() !== Wopi::TOKEN_TYPE_GUEST && $wopi->getTokenType() !== Wopi::TOKEN_TYPE_REMOTE_GUEST) {
 			return $wopi;

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -51,7 +51,6 @@ class TokenManager {
 		[$fileId, , $version] = Helper::parseFileId($fileId);
 		$owneruid = null;
 		$hideDownload = false;
-		$rootFolder = $this->rootFolder;
 
 		// if the user is not logged-in do use the sharers storage
 		if ($shareToken !== null) {
@@ -66,66 +65,43 @@ class TokenManager {
 			$updatable = (bool)($share->getPermissions() & \OCP\Constants::PERMISSION_UPDATE);
 			$updatable = $updatable && $this->permissionManager->userCanEdit($owneruid);
 			$hideDownload = $share->getHideDownload();
-			$rootFolder = $this->rootFolder->getUserFolder($owneruid);
-		} elseif ($this->userId !== null) {
-			try {
-				$editoruid = $this->userId;
-				$rootFolder = $this->rootFolder->getUserFolder($editoruid);
+			$userFolder = $this->rootFolder->getUserFolder($owneruid);
+		} else {
+			$editoruid = $this->userId ?? $editoruid;
+			$userFolder = $this->rootFolder->getUserFolder($editoruid);
 
-				$files = $rootFolder->getById((int)$fileId);
-				$updatable = false;
-				foreach ($files as $file) {
-					if ($file->isUpdateable()) {
-						$updatable = true;
+			$files = $userFolder->getById((int)$fileId);
+			$updatable = false;
+			foreach ($files as $file) {
+				if ($file->isUpdateable()) {
+					$updatable = true;
+					break;
+				}
+			}
+
+			$updatable = $updatable && $this->permissionManager->userCanEdit($editoruid);
+
+			// disable download if at least one shared access has it disabled
+			foreach ($files as $file) {
+				$storage = $file->getStorage();
+				// using string as we have no guarantee that "files_sharing" app is loaded
+				if ($storage->instanceOfStorage(SharedStorage::class)) {
+					if (!method_exists(IShare::class, 'getAttributes')) {
 						break;
 					}
-				}
-
-				$updatable = $updatable && $this->permissionManager->userCanEdit($editoruid);
-
-				// disable download if at least one shared access has it disabled
-				foreach ($files as $file) {
-					$storage = $file->getStorage();
-					// using string as we have no guarantee that "files_sharing" app is loaded
-					if ($storage->instanceOfStorage(SharedStorage::class)) {
-						if (!method_exists(IShare::class, 'getAttributes')) {
-							break;
-						}
-						/** @var SharedStorage $storage */
-						$share = $storage->getShare();
-						$attributes = $share->getAttributes();
-						if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
-							$hideDownload = true;
-							break;
-						}
-					}
-				}
-			} catch (Exception $e) {
-				throw $e;
-			}
-		} else {
-			// no active user login while generating the token
-			// this is required during WopiPutRelativeFile
-			if (is_null($editoruid)) {
-				$this->logger->warning('Generating token for SaveAs without editoruid');
-				$updatable = true;
-			} else {
-				// Make sure we use the user folder if available since fetching all files by id from the root might be expensive
-				$rootFolder = $this->rootFolder->getUserFolder($editoruid);
-
-				$updatable = false;
-				$files = $rootFolder->getById($fileId);
-
-				foreach ($files as $file) {
-					if ($file->isUpdateable()) {
-						$updatable = true;
+					/** @var SharedStorage $storage */
+					$share = $storage->getShare();
+					$attributes = $share->getAttributes();
+					if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
+						$hideDownload = true;
 						break;
 					}
 				}
 			}
 		}
+
 		/** @var File $file */
-		$file = $rootFolder->getFirstNodeById($fileId);
+		$file = $userFolder->getFirstNodeById($fileId);
 
 		// Check node readability (for storage wrapper overwrites like terms of services)
 		if ($file === null || !$file->isReadable()) {

--- a/tests/features/direct.feature
+++ b/tests/features/direct.feature
@@ -38,6 +38,22 @@ Feature: Direct editing
     And Collabora can not save the file with the content of "./../emptyTemplates/template.odt"
     Then Collabora downloads the file and it is equal to "./../emptyTemplates/template.ods"
 
+  Scenario: Open a shared file share attributes for download set to false
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/document-shared-no-download.odt"
+    And as "user1" create a share with
+      | path        | /document-shared-no-download.odt |
+      | shareType   | 0                                |
+      | shareWith   | user2                            |
+      | permissions | 1                                |
+      | attributes  | [{"scope":"permissions","key":"download","value":false}] |
+    When User "user2" opens "/document-shared-no-download.odt" through direct editing
+    And Collabora fetches checkFileInfo
+    Then checkFileInfo "BaseFileName" is "document-shared-no-download.odt"
+    And checkFileInfo "DisableExport" is true
+
+
   Scenario: Open a reshared file through direct editing
     Given on instance "serverA"
     And as user "user1"


### PR DESCRIPTION
Otherwise the user id may be wrongly assumed as null if the request is not authenticated as it is with direct editing links.

Mostly unifying into one code path and changing indents, best to be reviewed as https://github.com/nextcloud/richdocuments/pull/4567/files?w=1