### PR TITLE
chore: update actions/cache

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -142,7 +142,7 @@ jobs:
           cat data/nextcloud.log
 
       - name: Cache node modules
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
Updates actions/cache workflow as it is now deprecated and throws errors in the workflow
https://github.com/actions/cache/discussions/1510

⚠️  **Needed so https://github.com/nextcloud/richdocuments/pull/4568 can pass**