### PR TITLE
Ensure we have a clean db schema when migrating

### DIFF
--- a/lib/Migration/Version2060Date20200302131958.php
+++ b/lib/Migration/Version2060Date20200302131958.php
@@ -9,6 +9,7 @@ namespace OCA\Richdocuments\Migration;
 
 use Closure;
 use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
@@ -16,6 +17,23 @@ use OCP\Migration\SimpleMigrationStep;
  * Auto-generated migration step: Please modify to your needs!
  */
 class Version2060Date20200302131958 extends SimpleMigrationStep {
+
+	public function __construct(
+		private IDBConnection $connection,
+	) {
+	}
+
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('richdocuments_wopi')) {
+			$qb = $this->connection->getQueryBuilder();
+			$qb->delete('richdocuments_wopi');
+			$qb->executeStatement();
+		}
+	}
+
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
@@ -25,6 +43,10 @@ class Version2060Date20200302131958 extends SimpleMigrationStep {
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
+
+		if ($schema->hasTable('richdocuments_wopi')) {
+			$schema->dropTable('richdocuments_wopi');
+		}
 
 		if (!$schema->hasTable('richdocuments_wopi')) {
 			$table = $schema->createTable('richdocuments_wopi');


### PR DESCRIPTION
The content of the oc_richdocuments_wopi table is just temporary tokens, so in oder to ensure that the db schema matches if we install from old ownCloud versions, we can just drop and recreate the table.

This may be an issue because we did introduce new columns in the old database.xml file that was not properly covered in migration from the old project. 

Note the migration/doctrine abstractions will actually not drop but change the schema as one step.

Can be tested also by dropping some tables and running `occ migrations:execute richdocuments 2060Date20200302131958` manually.