### PR TITLE
preset: fix: adding/removing global template not reflected in sidebar

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -996,7 +996,7 @@ class WopiController extends Controller {
 	private function generateSettings(string $userId, string $type): array {
 		$nextcloudUrl = $this->appConfig->getNextcloudUrl() ?: trim($this->urlGenerator->getAbsoluteURL(''), '/');
 		$uri = $nextcloudUrl . '/index.php/apps/richdocuments/wopi/settings' . '?type=' . $type . '&access_token=' . $this->generateSettingToken($userId) . '&fileId=' . '-1';
-		$etag = $this->settingsService->getFolderEtag($type);
+		$etag = $this->settingsService->getFolderEtag($type) . $this->settingsService->getPresentationFolderEtag($type, $userId);
 		return [
 			'uri' => $uri,
 			'stamp' => $etag

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -167,6 +167,20 @@ class SettingsService {
 		return $this->getTypeFolder($type)->getEtag();
 	}
 
+	/**
+	 *
+	 * @param string $type
+	 * @param string $userId
+	 * @return string
+	 */
+	public function getPresentationFolderEtag(string $type, string $userId) : string {
+		if ($type === 'systemconfig') {
+			return $this->templateManager->getSystemTemplateDir()->getEtag();
+		}
+		$this->templateManager->setUserId($userId);
+		return $this->templateManager->getUserTemplateDir()->getEtag();
+	}
+
 	public const SUPPORTED_PRESENTATION_MIMES = [
 		'application/vnd.oasis.opendocument.presentation',
 		'application/vnd.oasis.opendocument.presentation-template',

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -316,7 +316,7 @@ class TemplateManager {
 			$template = $folder->newFile($templateName);
 		}
 		$template->putContent($templateFile);
-
+		$folder->getStorage()->getCache()->update($folder->getId(), [ 'etag' => uniqid() ]);
 		return $this->formatNodeReturn($this->get($template->getId()));
 	}
 
@@ -327,11 +327,13 @@ class TemplateManager {
 	 * @return boolean
 	 * @throws NotFoundException
 	 */
-	public function delete($fileId) {
-		$files = $this->getSystemTemplateDir()->getDirectoryListing();
+	public function delete($fileId): bool {
+		$folder = $this->getSystemTemplateDir();
+		$files = $folder->getDirectoryListing();
 		foreach ($files as $file) {
 			if ($file->getId() === $fileId) {
 				$file->delete();
+				$folder->getStorage()->getCache()->update($folder->getId(), [ 'etag' => uniqid() ]);
 				return true;
 			}
 		}
@@ -389,7 +391,7 @@ class TemplateManager {
 	/**
 	 * @return Folder
 	 */
-	private function getSystemTemplateDir() {
+	public function getSystemTemplateDir() {
 		$this->ensureAppDataFolders();
 		$path = 'appdata_' . $this->config->getSystemValue('instanceid', null) . '/richdocuments/templates';
 		return $this->rootFolder->get($path);


### PR DESCRIPTION
- this patch appends the presentation template folder etag to shared setting etag so that COOL can detect changes
- this patch also update the etag of global templates folder when template is added or removed by admin


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
