### PR TITLE
fix(settings): send ui_theme input to cool settings iframe

### DIFF
--- a/src/components/CoolFrame.vue
+++ b/src/components/CoolFrame.vue
@@ -13,6 +13,7 @@
 			<input type="hidden" name="wopi_setting_base_url" :value="wopiSettingBaseUrl">
 			<input type="hidden" name="iframe_type" :value="iframeType">
 			<input type="hidden" name="css_variables" :value="cssVariables">
+			<input type="hidden" name="ui_theme" :value="uiTheme">
 		</form>
 		<iframe :id="iframeName"
 			:name="iframeName"
@@ -25,7 +26,7 @@
 
 <script>
 
-import { generateCSSVarTokens } from '../helpers/coolParameters.js'
+import { generateCSSVarTokens, getUITheme } from '../helpers/coolParameters.js'
 
 export default {
 	name: 'CoolFrame',
@@ -57,6 +58,7 @@ export default {
 			formAction: '',
 			cssVariables: generateCSSVarTokens(),
 			isIframeLoaded: false,
+			uiTheme: getUITheme(),
 		}
 	},
 	mounted() {

--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -168,4 +168,5 @@ export {
 	getUIDefaults,
 	getCollaboraTheme,
 	generateCSSVarTokens,
+	getUITheme,
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Collabora needs `ui_theme` to identify the theme mode for the settings iframe.


