### PR TITLE
[stable30] fix: trim trailing slash before validating trusted remotes

### DIFF
--- a/lib/Service/FederationService.php
+++ b/lib/Service/FederationService.php
@@ -106,6 +106,7 @@ class FederationService {
 	}
 
 	public function isTrustedRemote($domainWithPort) {
+		$domainWithPort = rtrim($domainWithPort, '/');
 		if (strpos($domainWithPort, 'http://') === 0 || strpos($domainWithPort, 'https://') === 0) {
 			$port = parse_url($domainWithPort, PHP_URL_PORT);
 			$domainWithPort = parse_url($domainWithPort, PHP_URL_HOST) . ($port ? ':' . $port : '');


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
