### PR TITLE
feat: add composer install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ Collaborative editing of federated documents requires richdocuments version 3.4 
 
 ## Development setup
 
-Just clone this repo into your apps directory ([Nextcloud server](https://github.com/nextcloud/server#running-master-checkouts) installation needed). Additionally, [npm](https://www.npmjs.com/) and [Node.js](https://nodejs.org/en/download/package-manager/) are needed for installing JavaScript dependencies and building the frontend code.
+Just clone this repo into your apps directory ([Nextcloud server](https://github.com/nextcloud/server#running-master-checkouts) installation needed). Additionally, [npm](https://www.npmjs.com/), [Node.js](https://nodejs.org/en/download/package-manager/), and [Composer](https://getcomposer.org/) are needed for installing JavaScript dependencies and building the frontend code.
 
-Once npm and Node.js are installed, this can be done by running:
+Once npm, Node.js, and Composer are installed, this can be done by running:
 ```bash
+composer install
 npm ci
 npm run dev
 ```


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4628
* Target version: main

### Summary
When we modified the autoloader settings we never mentioned anywhere that you also need to run `composer install` in your setup. If I remember correctly the runtime dependencies at least were already in the repository.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
