### PR TITLE
fix(setting): userId undefined issue for template

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -489,8 +489,8 @@ class SettingsController extends Controller {
 	public function getSettingsFile(string $type, string $token, string $category, string $name) {
 		try {
 			$wopi = $this->wopiMapper->getWopiForToken($token);
+			$userId = $wopi->getEditorUid() ?: $wopi->getOwnerUid();
 			if ($type === 'userconfig') {
-				$userId = $wopi->getEditorUid() ?: $wopi->getOwnerUid();
 				$type = $type . '/' . $userId;
 			}
 


### PR DESCRIPTION
* Resolves: #4636 
* Target version: main

### Summary

Now, we're generating the userId earlier, which prevents the issue of it being undefined.