### PR TITLE
fix: load `wopi_callback_url` from initial state into config service

### DIFF
--- a/src/services/config.tsx
+++ b/src/services/config.tsx
@@ -9,7 +9,10 @@ class ConfigService {
 	private values: {[name: string]: any}
 
 	constructor() {
-		this.values = loadState('richdocuments', 'document', {})
+		this.values = {
+			wopi_callback_url: loadState('richdocuments', 'wopi_callback_url', ''),
+			...loadState('richdocuments', 'document', {}),
+		}
 	}
 
 	update(key: string, value: any) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4670
* Target version: main

### Summary
We need to tell Collabora the correct URL to use to connect back to Nextcloud for uploading the settings, and to do that we need to make sure we always have the `wopi_callback_url` available to us via the config service. We check if it is provided by initial state, and if not, we default to the current host and port of the browser.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
