### PR TITLE
fix: accepted global templates file types

### DIFF
--- a/src/components/AdminSettings/GlobalTemplates.vue
+++ b/src/components/AdminSettings/GlobalTemplates.vue
@@ -5,7 +5,8 @@
 
 <template>
 	<NcSettingsSection v-if="templatesAvailable"
-		:name="t('richdocuments', 'Global Templates')">
+		:name="t('richdocuments', 'Global Templates')"
+		:description="description">
 		<input ref="newTemplateInput"
 			type="file"
 			class="hidden-visually"
@@ -76,6 +77,26 @@ export default {
 		}
 	},
 
+	computed: {
+		acceptedFileExtensions() {
+			return this.templateExtensions.join(', ')
+		},
+		description() {
+			return t(
+				'richdocuments',
+				'Accepted file types: {accepts}',
+				{
+					/*
+					 * TRANSLATORS
+					 * The file extensions will be displayed as
+					 *  .ott, .otg, .otp, .ots, and so on
+					 */
+					accepts: this.acceptedFileExtensions,
+				},
+			)
+		},
+	},
+
 	mounted() {
 		// Later maybe we can retrieve these settings from AdminSettings.vue`
 		// and pass them in as props (once AdminSettings is cleaned up)
@@ -85,12 +106,6 @@ export default {
 		this.existingTemplates = settings.templates?.filter((template) => {
 			return template.name !== 'Empty'
 		})
-	},
-
-	computed: {
-		acceptedFileExtensions() {
-			return this.templateExtensions.join(', ')
-		}
 	},
 
 	methods: {

--- a/src/components/AdminSettings/GlobalTemplates.vue
+++ b/src/components/AdminSettings/GlobalTemplates.vue
@@ -9,6 +9,7 @@
 		<input ref="newTemplateInput"
 			type="file"
 			class="hidden-visually"
+			:accept="acceptedFileExtensions"
 			@change="selectFile">
 
 		<div class="template-buttons">
@@ -66,6 +67,12 @@ export default {
 		return {
 			existingTemplates: [],
 			templatesAvailable: false,
+			templateExtensions: [
+				'.ott', '.otg', '.otp', '.ots',
+				'.dot', '.dotx',
+				'.xlt', '.xltx',
+				'.pot', '.potx',
+			],
 		}
 	},
 
@@ -78,6 +85,12 @@ export default {
 		this.existingTemplates = settings.templates?.filter((template) => {
 			return template.name !== 'Empty'
 		})
+	},
+
+	computed: {
+		acceptedFileExtensions() {
+			return this.templateExtensions.join(', ')
+		}
 	},
 
 	methods: {

--- a/src/components/AdminSettings/GlobalTemplates.vue
+++ b/src/components/AdminSettings/GlobalTemplates.vue
@@ -166,6 +166,10 @@ $padding: calc(var(--default-grid-baseline) * 3);
 	display: grid;
 	gap: calc(var(--default-grid-baseline) * 4);
 	grid-template-columns: repeat(auto-fit, 175px);
+
+	button {
+		padding: 0 !important;
+	}
 }
 
 .template-btn {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4627
* Contributes to: https://github.com/nextcloud/richdocuments/issues/4351
* Target version: main

### Summary
Add filter to local file picker and add short description of accepted file types

### Screenshot
<details>
<summary>Global Templates</summary>

![image](https://github.com/user-attachments/assets/1a3f84e6-cc68-4f40-998b-b93a9a480a2e)
</details>

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
