### PR TITLE
[stable30] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3482,9 +3482,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.24.0.tgz",
-      "integrity": "sha512-eMwV6verEW8j5XrHXDHz/gm+nnfUDKzXccCQFNvlu32fsxInyWVqe/6b2Fn1SkQmuZsa9YY0ejhzmFHjMZ1/1g==",
+      "version": "8.25.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.25.1.tgz",
+      "integrity": "sha512-tePbb9xiM94fkRGqbJXSVuSSseHOem8MS8ulRpmMIWB/g0BqROtigb7VHaVLKAsxgywPN/TqeMeyKFC8cQjptw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -22650,9 +22650,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.24.0.tgz",
-      "integrity": "sha512-eMwV6verEW8j5XrHXDHz/gm+nnfUDKzXccCQFNvlu32fsxInyWVqe/6b2Fn1SkQmuZsa9YY0ejhzmFHjMZ1/1g==",
+      "version": "8.25.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.25.1.tgz",
+      "integrity": "sha512-tePbb9xiM94fkRGqbJXSVuSSseHOem8MS8ulRpmMIWB/g0BqROtigb7VHaVLKAsxgywPN/TqeMeyKFC8cQjptw==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",


### PR DESCRIPTION
# Audit report

This audit fix resolves 10 of the total 17 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=4.2.0-beta.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.0 - 3.1.0
* Package usage:
  * `node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`