### PR TITLE
fix: Ensure edit permissions are checked before template file token generation

### DIFF
--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -185,7 +185,7 @@ class TokenManager {
 			$updatable = $updatable && $shareUpdatable;
 		}
 
-		$updatable = $updatable && $this->permissionManager->userCanEdit($editoruid);
+		$updatable = $updatable && $this->permissionManager->userCanEdit($owneruid);
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -185,6 +185,8 @@ class TokenManager {
 			$updatable = $updatable && $shareUpdatable;
 		}
 
+		$updatable = $updatable && $this->permissionManager->userCanEdit($editoruid);
+
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 
 		return $this->wopiMapper->generateFileToken(


### PR DESCRIPTION
### Summary
This PR ensures that edit permissions are properly checked before generating template file tokens. Without this check, files created from templates can be edited by users with read-only permissions.


## Problem
Currently, users without edit permissions can edit documents created via the "new template document" feature. This behavior violates the intended permission restrictions.


## Proposed Fix
The fix ensures that edit permissions are validated before token generation, preventing unauthorized edits. This approach is similar to the fix implemented in commit 3b3c31f0.


## Observed Behavior (Before Fix)
Users without edit permissions can edit documents created from templates.

https://github.com/user-attachments/assets/c191b46d-0bf0-43e8-8976-0a38b3c7ff7a


### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
