### PR TITLE
fix(Wopi): fall back to super share if share token is not available

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -92,6 +92,7 @@ class WopiController extends Controller {
 		private TaskProcessingManager $taskProcessingManager,
 		private SettingsService $settingsService,
 		private CapabilitiesService $capabilitiesService,
+		private Helper $helper,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -219,7 +220,7 @@ class WopiController extends Controller {
 			$response['TemplateSource'] = $this->getWopiUrlForTemplate($wopi);
 		}
 
-		$share = $this->getShareForWopiToken($wopi);
+		$share = $this->getShareForWopiToken($wopi, $file);
 		if ($this->permissionManager->shouldWatermark($file, $wopi->getEditorUid(), $share)) {
 			$email = $user !== null && !$isPublic ? $user->getEMailAddress() : '';
 			$currentDateTime = new \DateTime(
@@ -925,9 +926,13 @@ class WopiController extends Controller {
 		return array_shift($files);
 	}
 
-	private function getShareForWopiToken(Wopi $wopi): ?IShare {
+	private function getShareForWopiToken(Wopi $wopi, File $file): ?IShare {
 		try {
-			return $wopi->getShare() ? $this->shareManager->getShareByToken($wopi->getShare()) : null;
+			$shareToken = $wopi->getShare();
+			if ($shareToken) {
+				return $this->shareManager->getShareByToken($shareToken);
+			}
+			return $this->helper->getShareFromNode($file);
 		} catch (ShareNotFound) {
 		}
 

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -7,7 +7,11 @@ namespace OCA\Richdocuments;
 
 use DateTime;
 use DateTimeZone;
+use OCA\Files_Sharing\SharedStorage;
 use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\Share\IShare;
 
 class Helper {
 	/**
@@ -81,5 +85,18 @@ class Helper {
 			return null;
 		}
 		return $_COOKIE['guestUser'];
+	}
+
+	public function getShareFromNode(Node $node): ?IShare {
+		try {
+			$storage = $node->getStorage();
+		} catch (NotFoundException) {
+			return null;
+		}
+		if ($storage->instanceOfStorage(SharedStorage::class)) {
+			/** @var SharedStorage $storage */
+			return $storage->getShare();
+		}
+		return null;
 	}
 }

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -7,7 +7,6 @@
 namespace OCA\Richdocuments;
 
 use Exception;
-use OCA\Files_Sharing\SharedStorage;
 use OCA\Richdocuments\Db\Direct;
 use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\Db\WopiMapper;
@@ -24,7 +23,6 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
-use OCP\Share\IShare;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -83,19 +81,13 @@ class TokenManager {
 
 			// disable download if at least one shared access has it disabled
 			foreach ($files as $file) {
-				$storage = $file->getStorage();
-				// using string as we have no guarantee that "files_sharing" app is loaded
-				if ($storage->instanceOfStorage(SharedStorage::class)) {
-					if (!method_exists(IShare::class, 'getAttributes')) {
-						break;
-					}
-					/** @var SharedStorage $storage */
-					$share = $storage->getShare();
-					$attributes = $share->getAttributes();
-					if ($attributes !== null && $attributes->getAttribute('permissions', 'download') === false) {
-						$hideDownload = true;
-						break;
-					}
+				$share = $this->helper->getShareFromNode($file);
+				$attributes = $share?->getAttributes();
+				if ($attributes !== null
+					&& $attributes->getAttribute('permissions', 'download') === false
+				) {
+					$hideDownload = true;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
* Target version: main

### Summary

On internal shares the controller is called without the share token. But necessary information, like share attributes, might be necessary to know and are available from the super share of the SharedMount in that case.

This can be testes as following:

1. In Admin settings → Office enable Secure view 
2. and there tick *Show watermark for shares without download permission* (but no other if its options!)
3. Share a document with an internal user as **read-only** and **without download-privileges**
4. As this user, open the document

It is expected that the document is opened with the watermark, but it does not. This is because we do not store (for we do not know) the share token of the document in `DocumentController::token()`. Hence we try now in the WopiController whether the share token is present and otherwise fall back to the super share.

The super share combines any relevant present share. While some field stay empty (shareWith, shareToken, as they cannot be combined) the share attributes are.  So if there would be another share of this document with the user, that does have download permissions, then the watermarking would not happen, as expected.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Documentation (manuals or wiki) has been updated or is not required
