### PR TITLE
fix: check if template fields should be extracted

### DIFF
--- a/lib/Listener/BeforeGetTemplatesListener.php
+++ b/lib/Listener/BeforeGetTemplatesListener.php
@@ -24,6 +24,7 @@ class BeforeGetTemplatesListener implements IEventListener {
 			return;
 		}
 
+		/** @psalm-suppress RedundantCondition */
 		if (method_exists($event, 'shouldGetFields') && !$event->shouldGetFields()) {
 			return;
 		}

--- a/lib/Listener/BeforeGetTemplatesListener.php
+++ b/lib/Listener/BeforeGetTemplatesListener.php
@@ -24,10 +24,14 @@ class BeforeGetTemplatesListener implements IEventListener {
 			return;
 		}
 
+		if (method_exists($event, 'shouldGetFields') && !$event->shouldGetFields()) {
+			return;
+		}
+
 		foreach ($event->getTemplates() as $template) {
-			$templateFileId = $template->jsonSerialize()['fileid'];
-			$fields = $this->templateFieldService->extractFields($templateFileId);
-			
+			$templateId = $template->jsonSerialize()['fileid'];
+			$fields = $this->templateFieldService->extractFields($templateId);
+
 			$template->setFields($fields);
 		}
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4402
* Target version: main
* Requires: https://github.com/nextcloud/server/pull/52514

### Summary
With the new server changes, we need to check if the event tells us to fetch the fields or not. If the fields should be extracted, then we do that. On the server side, this will only be triggered once the user makes a template selection, and only that template will be sent.

The documentation has been updated for the server pull request, and the `templates.spec.js` tests have been expanded a bit in this pull request to verify that no template fields are extracted at first.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
