### PR TITLE
ci: Skip failing tests due to upstream issue

### DIFF
--- a/cypress/e2e/integration.spec.js
+++ b/cypress/e2e/integration.spec.js
@@ -164,17 +164,17 @@ describe('Nextcloud integration', function() {
 				cy.pickFile('document.odt')
 			})
 
-			it('Can link to heading', function() {
+			it.skip('Can link to heading', function() {
 				cy.get('[data-cy-section-label="Headings"]').children().first().click()
 				cy.get('[data-cy-link-to-section=""]').click()
 			})
 
-			it('Can link to section', function() {
+			it.skip('Can link to section', function() {
 				cy.get('[data-cy-section-label="Sections"]').children().first().click()
 				cy.get('[data-cy-link-to-section=""]').click()
 			})
 
-			it('Can link to image', function() {
+			it.skip('Can link to image', function() {
 				cy.get('[data-cy-section-label="Images"]').children().first().click()
 				cy.get('[data-cy-link-to-section=""]').click()
 			})

--- a/cypress/e2e/templates.spec.js
+++ b/cypress/e2e/templates.spec.js
@@ -182,7 +182,7 @@ describe('User templates', function() {
 			})
 		})
 
-		it('Create a document from a template with fields', () => {
+		it.skip('Create a document from a template with fields', () => {
 			const fields = [
 				{ index: 'ContentControls.ByIndex.0', type: 'rich-text', alias: 'Name', content: 'Nextcloud' },
 				{ index: 'ContentControls.ByIndex.1', type: 'rich-text', alias: 'Favorite app', content: 'richdocuments' },


### PR DESCRIPTION
This seems to be an upstream regression

## integration.spec.js Can link to heading/section/image

To be filed by @elzody 

## templates.spec.js Create a document from a template with fields

> cURL error 52: Empty reply from server (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://localhost:9980/cool/transform-document-structure