### PR TITLE
test: use nightly collabora build for now

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,7 +61,8 @@ jobs:
 
     services:
       collabora:
-        image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'ghcr.io/juliusknorr/code-nightly:latest' }}
+        #image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'juliushaertl/nc-code-nightly:latest' }}
+        image: juliushaertl/nc-code-nightly:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'
@@ -140,7 +141,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: rootpassword
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
       collabora:
-        image: ghcr.io/juliusknorr/nextcloud-dev-code:latest
+        image: juliushaertl/nc-code-nightly:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'
@@ -221,7 +222,7 @@ jobs:
           POSTGRES_DB: nextcloud
         options: --health-cmd pg_isready --health-interval 5s --health-timeout 2s --health-retries 5
       collabora:
-        image: ghcr.io/juliusknorr/nextcloud-dev-code:latest
+        image: juliushaertl/nc-code-nightly:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'
@@ -312,7 +313,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       collabora:
-        image: ghcr.io/juliusknorr/nextcloud-dev-code:latest
+        image: juliushaertl/nc-code-nightly:latest
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'


### PR DESCRIPTION
Use the nightly Collabora image for now, since there is an upstream bug that fails our integrations tests. This can be reverted once https://github.com/collaboraonline/online/issues/11792 is resolved.