### PR TITLE
add an initial state for 'browser_setting' variable.

### DIFF
--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -14,6 +14,7 @@ use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\TemplateManager;
 use OCA\Theming\ImageManager;
 use OCP\AppFramework\Services\IInitialState;
+use OCA\Richdocuments\Service\SettingsService;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IURLGenerator;
@@ -31,6 +32,7 @@ class InitialStateService {
 		private Defaults $themingDefaults,
 		private IConfig $config,
 		private ?string $userId,
+		private SettingsService $settingsService,
 	) {
 	}
 
@@ -110,5 +112,12 @@ class InitialStateService {
 
 		$this->initialState->provideInitialState('theming-customLogo', $logo);
 		$this->initialState->provideInitialState('open_local_editor', $this->config->getAppValue(Application::APPNAME, 'open_local_editor', 'yes') === 'yes');
+		$fileName = $this->config->getUserValue($this->userId, Application::APPNAME, 'browsersetting');
+		if ($fileName) {
+			$browserSetting = $this->settingsService->getSettingsFile('userconfig/' . $this->userId,
+				'browsersetting',
+				$fileName);
+			$this->initialState->provideInitialState('browsersetting', $browserSetting->getContent());
+		}
 	}
 }

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -102,6 +102,9 @@ class SettingsService {
 		$fileUri = $this->generateFileUri($settingsUrl->getType(), $settingsUrl->getCategory(), $fileName, $token['token']);
 		$this->refreshFolderEtag($settingsUrl->getType());
 
+		if ($settingsUrl->getType() === 'userconfig' && $settingsUrl->getCategory() === 'browsersetting') {
+			$this->config->setUserValue($userId, 'richdocuments', 'browsersetting', $fileName);
+		}
 		return [
 			'stamp' => $newFile->getETag(),
 			'uri' => $fileUri,

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -55,6 +55,7 @@
 			<input name="theme" :value="formData.theme" type="hidden">
 			<input name="buy_product" value="https://nextcloud.com/pricing" type="hidden">
 			<input name="host_session_id" :value="formData.hostSessionID" type="hidden">
+			<input name="browser_setting" :value="formData.browserSetting" type="hidden">
 		</form>
 		<iframe :id="iframeId"
 			ref="documentFrame"
@@ -198,6 +199,7 @@ export default {
 				cssVariables: generateCSSVarTokens(),
 				theme: getCollaboraTheme(),
 				hostSessionID: 'nextcloud ' + OC.config.version + ' - richdocuments ' + getCapabilities().version,
+				browserSetting: loadState('richdocuments', 'browsersetting', ''),
 			},
 		}
 	},


### PR DESCRIPTION
After the file browsersettings.json is uploaded, it’s necessary to create an initial state for the user’s browser preference settings. This enables the Collabora iframe to include the POST variable and serve preprocessed HTML with accessibility features enabled, for example.

