### PR TITLE
Fix save as on mobile with direct editing

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -161,4 +161,41 @@ describe('Direct editing (legacy)', function() {
 		})
 	})
 
+	it('Save as', function() {
+		createDirectEditingLink(randUser, fileId)
+			.then((token) => {
+				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'tabbed')
+				cy.logout()
+				cy.visit(token)
+				cy.waitForCollabora(false)
+
+				cy.get('@loleafletframe').within(() => {
+					cy.get('.notebookbar-tabs-container', { timeout: 30_000 })
+						.should('be.visible')
+
+					cy.get('button[aria-label="File"]').click()
+					cy.get('button[aria-label="Save As"]').click()
+
+					cy.get('#saveas-entries #saveas-entry-1').click()
+				})
+
+				cy.get('.saveas-dialog')
+					.should('be.visible')
+				cy.get('.saveas-dialog input[type=text]')
+					.should('be.visible')
+					.should('have.value', 'document.odt')
+
+				cy.get('.saveas-dialog input[type=text]')
+					.clear()
+				cy.get('.saveas-dialog input[type=text]')
+					.type('/document.rtf')
+
+				cy.get('.saveas-dialog button.button-vue--vue-primary').click()
+
+				cy.get('@loleafletframe').within(() => {
+					cy.verifyOpen('document.rtf')
+				})
+			})
+	})
+
 })

--- a/src/document.js
+++ b/src/document.js
@@ -473,7 +473,7 @@ const documentsMain = {
 						spawnDialog(
 							SaveAs,
 							{
-								path: documentsMain.filename,
+								path: documentsMain.fileName,
 								format: args.Format,
 							},
 							(value) => value && this.sendPostMessage('Action_SaveAs', { Filename: value, Notify: true }),

--- a/src/document.js
+++ b/src/document.js
@@ -476,7 +476,7 @@ const documentsMain = {
 								path: documentsMain.fileName,
 								format: args.Format,
 							},
-							(value) => value && this.sendPostMessage('Action_SaveAs', { Filename: value, Notify: true }),
+							(value) => value && PostMessages.sendWOPIPostMessage('loolframe', 'Action_SaveAs', { Filename: value, Notify: true }),
 						)
 					} else if (msgId === 'Action_Save_Resp') {
 						if (args.success && args.fileName) {


### PR DESCRIPTION
- **fix(direct-editing): Use proper path in the save as dialog**
- **fix(direct-editing): Use correct method to pass the Action_SaveAs post message**

### Summary

When using "Save as" through direct editing in the mobile apps the wrong method call was introduced in https://github.com/nextcloud/richdocuments/commit/c6306bb4a367f12701a43aa138ce570148a41d5f#diff-d6043d5e8ee25405786521e86514439eeb1b9d1cc02a7b744cea3084a13b41f0R509 causing the modal to not work.

Steps to reproduce:

- Create a file
- Generate a direct editing token and url for richdocuments with with the curl below
- Open the URL in a private browser window and try to use the save as function

```
`curl --request POST \
  --url 'http://nextcloud.local/ocs/v2.php/apps/richdocuments/api/v1/document?format=json' -u admin:admin \
  --header 'Content-Type: multipart/form-data' \
  --header 'OCS-Apirequest: true' \
  --form fileId=302`
```

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
