### PR TITLE
[stable30] fix: for shares allow document creation only for users that ca…

### DIFF
--- a/src/public.js
+++ b/src/public.js
@@ -10,6 +10,7 @@ import {
 	isDownloadHidden,
 } from './helpers/index.js'
 import { getCapabilities } from './services/capabilities.ts'
+import { getCurrentUser } from '@nextcloud/auth'
 import NewFileMenu from './view/NewFileMenu.js'
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -17,7 +18,12 @@ document.addEventListener('DOMContentLoaded', () => {
 		return
 	}
 
-	if (OCA.Files && OCA.Files.fileActions) {
+	const userGroups = getCurrentUser()?.groups || []
+	const editGroups = getCapabilities().config.edit_groups || []
+	const editGroupsArray = Array.isArray(editGroups) ? editGroups : [editGroups]
+	const userInEditGroups = editGroupsArray.some(group => userGroups.includes(group))
+
+	if (OCA.Files && OCA.Files.fileActions && userInEditGroups) {
 		OC.Plugins.register('OCA.Files.NewFileMenu', NewFileMenu)
 	}
 


### PR DESCRIPTION
### Summary

This fix assures files creation from templates in public share is not possible for users with read-only permissions.
Users with read-only permissions should not have option to create new document from diagram, document, presentation or spreadsheet template, see attached screenshot.

This is a fix for nextcloud v30.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
![shares-add-new-files-with-doc-creation](https://github.com/user-attachments/assets/5f903f9b-5417-4817-a889-520a91de29de)
