### PR TITLE
[stable29] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,9 +4549,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
-      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.27.0.tgz",
+      "integrity": "sha512-v9aTv5G5zVKN8PJVAP/WTcTspDXr6yxZtgGyQ4El5pZzMWk2+3wANT+VU4mdNCIpiJ2xyYorLs/Gg0Z9y73Anw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -4587,6 +4587,7 @@
         "remark-breaks": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.0.0",
+        "remark-unlink-protocols": "^1.0.0",
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
@@ -16679,6 +16680,20 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -19820,6 +19835,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-unlink-protocols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
+      "integrity": "sha512-5j/F28jhFmxeyz8nuJYYIWdR4nNpKWZ8A+tVwnK/0pq7Rjue33CINEYSckSq2PZvedhKUwbn08qyiuGoPLBung==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "node_modules/request-progress": {
@@ -27167,9 +27193,9 @@
       }
     },
     "@nextcloud/vue": {
-      "version": "8.26.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.1.tgz",
-      "integrity": "sha512-kaTtiNeaiE2nT4mLe1X3oIbuNZbIYOQknPTa9gF6yCCn8gMwMTfg/JL/7Kr1a+UsLYNLLCizGZoCjEzR2DDpYA==",
+      "version": "8.27.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.27.0.tgz",
+      "integrity": "sha512-v9aTv5G5zVKN8PJVAP/WTcTspDXr6yxZtgGyQ4El5pZzMWk2+3wANT+VU4mdNCIpiJ2xyYorLs/Gg0Z9y73Anw==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",
@@ -27204,6 +27230,7 @@
         "remark-breaks": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.0.0",
+        "remark-unlink-protocols": "^1.0.0",
         "splitpanes": "^2.4.1",
         "string-length": "^5.0.1",
         "striptags": "^3.2.0",
@@ -36184,6 +36211,15 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "mdast-squeeze-paragraphs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-squeeze-paragraphs/-/mdast-squeeze-paragraphs-6.0.0.tgz",
+      "integrity": "sha512-6NDbJPTg0M0Ye+TlYwX1KJ1LFbp515P2immRJyJQhc9Na9cetHzSoHNYIQcXpANEAP1sm9yd/CTZU2uHqR5A+w==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-visit": "^5.0.0"
+      }
+    },
     "mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -38367,6 +38403,16 @@
             "unist-util-stringify-position": "^4.0.0"
           }
         }
+      }
+    },
+    "remark-unlink-protocols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/remark-unlink-protocols/-/remark-unlink-protocols-1.0.0.tgz",
+      "integrity": "sha512-5j/F28jhFmxeyz8nuJYYIWdR4nNpKWZ8A+tVwnK/0pq7Rjue33CINEYSckSq2PZvedhKUwbn08qyiuGoPLBung==",
+      "requires": {
+        "@types/mdast": "^4.0.0",
+        "mdast-squeeze-paragraphs": "^6.0.0",
+        "unist-util-visit": "^5.0.0"
       }
     },
     "request-progress": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 9 of the total 16 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: 4.2.0-beta.1 - 6.3.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.0 - 3.1.0
* Package usage:
  * `node_modules/@nextcloud/l10n`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`