### PR TITLE
fix(tests): use `autoload.php` for unit tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,17 +1,24 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2014-2015 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
-require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
+
+Server::get(IAppManager::class)->loadApp('richdocuments');
 
 if (!class_exists(\PHPUnit\Framework\TestCase::class)) {
 	require_once('PHPUnit/Autoload.php');
 }
-\OC_App::loadApp('richdocuments');
-OC_Hook::clear();


### PR DESCRIPTION
The tests in the server repository switched to providing an `autoload.php` file for app tests to use, so it was breaking some of the unit tests here. This takes inspiration from the fix for it in Tables, so maybe this will work.

Server change: https://github.com/nextcloud/server/pull/52951
Tables change: https://github.com/nextcloud/tables/pull/1806