### PR TITLE
fix(shares): guest users inherit edit_group

### DIFF
--- a/lib/Listener/ShareLinkListener.php
+++ b/lib/Listener/ShareLinkListener.php
@@ -42,8 +42,11 @@ class ShareLinkListener implements \OCP\EventDispatcher\IEventListener {
 		$loggedInUser = $this->permissionManager->loggedInUser();
 
 		if ($this->permissionManager->isEnabledForUser($owner)) {
+			$updatable = (bool)($share->getPermissions() & \OCP\Constants::PERMISSION_UPDATE);
+			$updatable = $updatable && $this->permissionManager->userCanEdit($owner);
+			
 			$this->initialStateService->prepareParams(['userId' => $loggedInUser]);
-			$this->initialStateService->provideCapabilities();
+			$this->initialStateService->providePublicShare($updatable);
 
 			Util::addScript('richdocuments', 'richdocuments-viewer', 'viewer');
 			Util::addScript('richdocuments', 'richdocuments-public', 'viewer');

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -58,6 +58,11 @@ class InitialStateService {
 		$this->provideOptions();
 	}
 
+	public function providePublicShare(?bool $userInEditGroups = true): void {
+		$this->initialState->provideInitialState('userInEditGroups', $userInEditGroups);
+		$this->provideCapabilities();
+	}
+
 	public function prepareParams(array $params): array {
 		$defaults = [
 			'instanceId' => $this->config->getSystemValue('instanceid'),

--- a/src/public.js
+++ b/src/public.js
@@ -10,18 +10,15 @@ import {
 	isDownloadHidden,
 } from './helpers/index.js'
 import { getCapabilities } from './services/capabilities.ts'
-import { getCurrentUser } from '@nextcloud/auth'
 import NewFileMenu from './view/NewFileMenu.js'
+import { loadState } from '@nextcloud/initial-state'
 
 document.addEventListener('DOMContentLoaded', () => {
 	if (!isPublic() || !OCA.Viewer) {
 		return
 	}
 
-	const userGroups = getCurrentUser()?.groups || []
-	const editGroups = getCapabilities().config.edit_groups || []
-	const editGroupsArray = Array.isArray(editGroups) ? editGroups : [editGroups]
-	const userInEditGroups = editGroupsArray.some(group => userGroups.includes(group))
+	const userInEditGroups = loadState('richdocuments', 'userInEditGroups', true)
 
 	if (OCA.Files && OCA.Files.fileActions && userInEditGroups) {
 		OC.Plugins.register('OCA.Files.NewFileMenu', NewFileMenu)


### PR DESCRIPTION
* Follow up to: https://github.com/nextcloud/richdocuments/pull/4809
* Target version: stable30

### Summary
With the merging of https://github.com/nextcloud/richdocuments/pull/4809, I realized that it somewhat broke being able to create new documents in a public share by a guest user. This is being the guest user is not a real user, and the `edit_groups` could not be determined. In the back end, we have a way to do this, so it is injected as an initial state that we get from the front end. It is inherited from the share owner.

Example:
- Share owner that is not in a group with edit permissions creates a *public share with editing permissions*
- A guest user accesses the public share
- The guest user can not create new documents in the public share, and also can not edit documents, as it inherits the group permissions

It is mostly the same as before, except now the *New file* menu should reflect the proper permissions.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
