### PR TITLE
chore: remove reviewers from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,6 @@ updates:
   labels:
     - "3. to review"
     - "dependencies"
-  reviewers:
-    - juliusknorr
-    - elzody
 
 - package-ecosystem: composer
   directory: "/"
@@ -29,9 +26,6 @@ updates:
   labels:
     - "3. to review"
     - "dependencies"
-  reviewers:
-    - juliusknorr
-    - elzody
 
 - package-ecosystem: composer
   directory: "/tests"
@@ -43,9 +37,6 @@ updates:
   labels:
     - "3. to review"
     - "dependencies"
-  reviewers:
-    - juliusknorr
-    - elzody
   open-pull-requests-limit: 10
 
 - package-ecosystem: npm
@@ -59,9 +50,6 @@ updates:
   labels:
     - "3. to review"
     - "dependencies"
-  reviewers:
-    - juliusknorr
-    - elzody
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -79,9 +67,6 @@ updates:
   labels:
     - "3. to review"
     - "dependencies"
-  reviewers:
-    - juliusknorr
-    - elzody
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
@@ -99,9 +84,6 @@ updates:
   labels:
     - "3. to review"
     - "dependencies"
-  reviewers:
-    - juliusknorr
-    - elzody
   ignore:
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
* Target version: main

### Summary
The reviewers field in `dependabot.yml` is no longer being used. From now on, it uses the defined code owners to determine who to request reviews from. We already have code owners set up for this repository so we're good to go. It will also get rid of the extra comments from dependabot about this on automated PRs.

Source: [Dependabot reviewers configuration option being replaced by code owners](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
