### PR TITLE
feat(ai): spreadsheet conversion input filters

### DIFF
--- a/lib/Service/DocumentGenerationService.php
+++ b/lib/Service/DocumentGenerationService.php
@@ -48,7 +48,7 @@ EOF;
 		$converter = new GithubFlavoredMarkdownConverter();
 		$htmlContent = $converter->convert($markdownContent)->getContent();
 		$htmlStream = $this->stringToStream($htmlContent);
-		$docxContent = $this->remoteService->convertTo('document.html', $htmlStream, $targetFormat, true);
+		$docxContent = $this->remoteService->convertTo('document.html', $htmlStream, $targetFormat);
 
 		return $docxContent;
 	}
@@ -58,7 +58,19 @@ EOF;
 		$taskInput = $prompt . "\n\n" . $description;
 		$csvContent = $this->runTextToTextTask($taskInput, $userId);
 		$csvStream = $this->stringToStream($csvContent);
-		$xlsxContent = $this->remoteService->convertTo('document.csv', $csvStream, $targetFormat, true);
+
+		// Passing these will ensure the CSV is correctly
+		// parsed into a spreadsheet
+		$conversionOptions = [
+			// Sets the input filter to use the following:
+			//      44 - , (comma) as the field separator
+			//      34 - " (double quote) as the text delimiter
+			//      76 - UTF-8 as the character set
+			//       1 - Start at line one of the input
+			'infilterOptions' => '44,34,76,1',
+		];
+
+		$xlsxContent = $this->remoteService->convertTo('document.csv', $csvStream, $targetFormat, $conversionOptions);
 
 		return $xlsxContent;
 	}

--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -72,7 +72,7 @@ class RemoteService {
 	 * @param resource $stream
 	 * @return resource|string
 	 */
-	public function convertTo(string $filename, $stream, string $format, bool $sendFilename = false) {
+	public function convertTo(string $filename, $stream, string $format, ?array $conversionOptions = []) {
 		$client = $this->clientService->newClient();
 		$options = RemoteOptionsService::getDefaultOptions();
 		// FIXME: can be removed once https://github.com/CollaboraOnline/online/issues/6983 is fixed upstream
@@ -82,11 +82,13 @@ class RemoteService {
 			$options['verify'] = false;
 		}
 
-		$options['multipart'] = [['name' => $filename, 'contents' => $stream]];
-		// collabora does not want to read the input if there is no filename (for csv content for example)
-		if ($sendFilename) {
-			$options['multipart'][0]['filename'] = $filename;
-		}
+		$options['multipart'] = [
+			array_merge([
+				'name' => $filename,
+				'filename' => $filename,
+				'contents' => $stream
+			], $conversionOptions),
+		];
 
 		try {
 			$response = $client->post($this->appConfig->getCollaboraUrlInternal() . '/cool/convert-to/' . $format, $options);


### PR DESCRIPTION
* Part of: https://github.com/nextcloud/richdocuments/issues/4622
* Target version: main

### Summary
Pass the required input filters to correctly parse the CSV output that the LLM generates. We assume that the LLM generates an output that always uses a set of standards, like `,` for the field separator and `"` as the text delimiter.

The `RemoteService::convertTo()` method can now accept conversion options which are mixed in with the multipart form data, as required to pass input filters. But they are optional.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
