### PR TITLE
Show statusbar by default for all doc types

### DIFF
--- a/src/helpers/coolParameters.js
+++ b/src/helpers/coolParameters.js
@@ -7,7 +7,7 @@ import { loadState } from '@nextcloud/initial-state'
 
 const getUIDefaults = () => {
 	const defaults = loadState('richdocuments', 'uiDefaults', {})
-	const statusBar = 'false'
+	const statusBar = 'true'
 	const textRuler = 'false'
 	const sidebar = 'false'
 	const saveAsMode = 'group'
@@ -16,7 +16,7 @@ const getUIDefaults = () => {
 	let uiDefaults = 'TextRuler=' + textRuler + ';'
 	uiDefaults += 'TextSidebar=' + sidebar + ';TextStatusbar=' + statusBar + ';'
 	uiDefaults += 'PresentationSidebar=' + sidebar + ';PresentationStatusbar=' + statusBar + ';'
-	uiDefaults += 'SpreadsheetSidebar=' + sidebar + ';SpreadsheetStatusbar=true;'
+	uiDefaults += 'SpreadsheetSidebar=' + sidebar + ';SpreadsheetStatusbar=' + statusBar + ';'
 	uiDefaults += 'UIMode=' + uiMode + ';'
 	uiDefaults += 'UITheme=' + getUITheme() + ';'
 	uiDefaults += 'SaveAsMode=' + saveAsMode + ';'


### PR DESCRIPTION
Status bar is expected to be visible when working with office documents as it has important status (word count, formula, selection) and controls (zoom, page navigation).

This seems to be what office users expect by default. Nevertheless, user can still hide it by going to View > Status Bar and that preference is then remembered.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
