### PR TITLE
fix: undefined share for preview

### DIFF
--- a/lib/Listener/BeforeFetchPreviewListener.php
+++ b/lib/Listener/BeforeFetchPreviewListener.php
@@ -38,6 +38,7 @@ class BeforeFetchPreviewListener implements IEventListener {
 		}
 		$shareToken = $this->request->getParam('token');
 
+		$share = null;
 		try {
 			$share = $shareToken ?
 				// Get different share for public previews as the share from the node is only set for mounted shares


### PR DESCRIPTION
* Target version: main

### Summary
Prevents `$share` being `undefined` and causing an error in the logs. If we cannot compute `$share` for some reason, we simply pass `null` to the `PermissionManager::shouldWatermark()` method and it will handle the rest.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
