### PR TITLE
Revert "chore: skip unrelated failing tests for now"

### DIFF
--- a/cypress/e2e/talk.spec.js
+++ b/cypress/e2e/talk.spec.js
@@ -50,7 +50,7 @@ describe('Talk integraiton integration', function() {
 		})
 	})
 
-	it.skip('See that the file is shared without download', function() {
+	it('See that the file is shared without download', function() {
 		cy.nextcloudTestingAppConfigSet('files', 'watermark_enabled', 'yes')
 		cy.nextcloudTestingAppConfigSet('files', 'watermark_shareTalkPublic', 'yes')
 		cy.nextcloudTestingAppConfigSet('files', 'watermark_text', 'TestingWatermark')

--- a/cypress/e2e/templates.spec.js
+++ b/cypress/e2e/templates.spec.js
@@ -94,7 +94,7 @@ describe('Global templates', function() {
 		cy.waitForCollabora()
 	})
 
-	it.skip('Create a file from a system template as guest', () => {
+	it('Create a file from a system template as guest', () => {
 		cy.uploadSystemTemplate({
 			fixturePath: 'templates/presentation.otp',
 			fileName: 'myslides.otp',


### PR DESCRIPTION
Reverts nextcloud/richdocuments#4882

Can be merged once https://github.com/nextcloud/server/pull/53635 is merged