### PR TITLE
fix(SlideDeckService): Fix JSON syntax of example in slide deck prompt

### DIFF
--- a/lib/Service/SlideDeckService.php
+++ b/lib/Service/SlideDeckService.php
@@ -24,7 +24,7 @@ class SlideDeckService {
 Draft a presentation slide deck with headlines and a maximum of 5 bullet points per headline. Use the following JSON structure for your whole output and output only the JSON array, no introductory text:
 
 ```
-[{"headline": "Headline 1", points: ["Bullet point 1", "Bullet point 2"]}, {"headline": "Headline 2", points: ["Bullet point 1", "Bullet point 2"]}]
+[{"headline": "Headline 1", "points": ["Bullet point 1", "Bullet point 2"]}, {"headline": "Headline 2", "points": ["Bullet point 1", "Bullet point 2"]}]
 ```
 
 Here is the presentation text:


### PR DESCRIPTION
* Target version: main

### Summary
ChatGPT is forgiving and will still output valid JSON, Llama 3.x is not as forgiving and diligently provides faulty JSON...


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
