### PR TITLE
fix: correctly watermark PDFs

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -209,6 +209,7 @@ class AppConfig {
 		return array_merge(
 			Capabilities::MIMETYPES,
 			Capabilities::MIMETYPES_MSOFFICE,
+			Capabilities::MIMETYPES_OPTIONAL,
 		);
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4862
* Target version: main

### Summary
A bug was introduced in https://github.com/nextcloud/richdocuments/pull/4772 that caused watermarks to no longer be shown on PDFs opened with Collabora. The problem was that not every supported mime type was checked so the `application/pdf` mime type did not trigger the watermarking as it should have. Before, the check never existed to begin with.

> ⚠️ The failing tests are unrelated.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
