### PR TITLE
[TaskProcessing] Run sub tasks immediately

### DIFF
--- a/lib/Service/DocumentGenerationService.php
+++ b/lib/Service/DocumentGenerationService.php
@@ -10,6 +10,10 @@ use League\CommonMark\GithubFlavoredMarkdownConverter;
 use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\TaskProcessing\TextToDocumentProvider;
 use OCA\Richdocuments\TaskProcessing\TextToSpreadsheetProvider;
+use OCP\TaskProcessing\Exception\Exception;
+use OCP\TaskProcessing\Exception\PreConditionNotMetException;
+use OCP\TaskProcessing\Exception\UnauthorizedException;
+use OCP\TaskProcessing\Exception\ValidationException;
 use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\Task;
 use OCP\TaskProcessing\TaskTypes\TextToText;
@@ -77,7 +81,11 @@ EOF;
 			Application::APPNAME,
 			$userId,
 		);
-		$task = $this->taskProcessingManager->runTask($task);
+		try {
+			$task = $this->taskProcessingManager->runTask($task);
+		} catch (PreConditionNotMetException|UnauthorizedException|ValidationException|Exception $e) {
+			throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+		}
 		$taskOutput = $task->getOutput();
 		if ($taskOutput === null) {
 			throw new RuntimeException('Task with id ' . $task->getId() . ' does not have any output');

--- a/lib/Service/SlideDeckService.php
+++ b/lib/Service/SlideDeckService.php
@@ -9,6 +9,10 @@ namespace OCA\Richdocuments\Service;
 use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\TemplateManager;
 use OCP\IConfig;
+use OCP\TaskProcessing\Exception\Exception;
+use OCP\TaskProcessing\Exception\PreConditionNotMetException;
+use OCP\TaskProcessing\Exception\UnauthorizedException;
+use OCP\TaskProcessing\Exception\ValidationException;
 use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\Task;
 use OCP\TaskProcessing\TaskTypes\TextToText;
@@ -129,7 +133,11 @@ EOF;
 			$userId
 		);
 
-		$task = $this->taskProcessingManager->runTask($task);
+		try {
+			$task = $this->taskProcessingManager->runTask($task);
+		} catch (PreConditionNotMetException|UnauthorizedException|ValidationException|Exception $e) {
+			throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
+		}
 		$taskOutput = $task->getOutput();
 		if ($taskOutput === null) {
 			throw new RuntimeException('Task with id ' . $task->getId() . ' does not have any output');


### PR DESCRIPTION
We can use the `TaskProcessingManager::runTask` method to run the LLM task. It will:
* run it it the same bg job
* remove the potential delay for the sub task to get picked up
* prevent keeping 2 workers busy

Also made a small change to make the slide deck JSON generation safer.