### PR TITLE
feat(design): outline icons

### DIFF
--- a/src/components/AdminSettings/GlobalTemplates.vue
+++ b/src/components/AdminSettings/GlobalTemplates.vue
@@ -52,7 +52,7 @@ import { loadState } from '@nextcloud/initial-state'
 import '@nextcloud/dialogs/style.css'
 import axios from '@nextcloud/axios'
 import NewTemplateIcon from 'vue-material-design-icons/FileDocumentPlusOutline.vue'
-import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
 
 export default {
 	name: 'GlobalTemplates',

--- a/src/components/DocSigningField.vue
+++ b/src/components/DocSigningField.vue
@@ -25,7 +25,7 @@
 <script>
 import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
 
 export default {
 	name: 'DocSigningField',

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -127,7 +127,7 @@ import NcSettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection.
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import DocSigningField from './DocSigningField.vue'
-import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
 import axios from '@nextcloud/axios'
 import {
 	getCurrentUser,

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -17,7 +17,7 @@
 			<NcButton id="templateSelectButton"
 				type="secondary"
 				@click="onTemplateSelectButtonClick">
-				<span class="icon-folder"
+				<FolderIcon :size="20"
 					:title="t('richdocuments', 'Select a personal template folder')"
 					data-toggle="tooltip" />
 			</NcButton>
@@ -128,6 +128,7 @@ import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import DocSigningField from './DocSigningField.vue'
 import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
+import FolderIcon from 'vue-material-design-icons/FolderOutline.vue'
 import axios from '@nextcloud/axios'
 import {
 	getCurrentUser,
@@ -144,6 +145,7 @@ export default {
 		NcTextField,
 		NcButton,
 		DocSigningField,
+		FolderIcon,
 		DeleteIcon,
 		CoolFrame,
 	},
@@ -313,9 +315,5 @@ export default {
 	display: inline-block;
 	margin-bottom: 1rem;
 	color: var(--color-warning);
-}
-
-.icon-folder::before {
-	content: "\1F4C1";
 }
 </style>

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -79,7 +79,7 @@
 </template>
 
 <script>
-import PencilIcon from 'vue-material-design-icons/Pencil.vue'
+import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4878
* Target version: main

### Summary
We are changing most icons to use the outlined versions, so this pull requests switches any solid icons we might be using here to the outlined ones. From a quick exploration of various settings and such on the web interface, it seems like this is all of them. Hopefully.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
