### PR TITLE
chore(workflows): add stable32 branch to workflows

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable31', 'stable30', 'stable29']
+        branches: ['main', 'master', 'stable32', 'stable31', 'stable30']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'master', 'stable31', 'stable30', 'stable29']
+        branches: ['main', 'master', 'stable32', 'stable31', 'stable30']
 
     name: update-nextcloud-ocp-${{ matrix.branches }}
 


### PR DESCRIPTION
Technically we did not do the branch off yet, but since I already made the mistake of adding a `stable32` branch we can update the workflows for updating `nextcloud/ocp` and `npm audit` to remove the `stable29` branch (no longer supported) and add `stable32` to keep it up-to-date