### PR TITLE
Allow Collabora Online to fetch settings config from richdocuments

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -414,7 +414,7 @@ class WopiController extends Controller {
 
 		try {
 			$wopi = $this->wopiMapper->getWopiForToken($access_token);
-			if ($wopi->getTokenType() !== Wopi::TOKEN_TYPE_SETTING_AUTH) {
+			if ($wopi->getTokenType() !== Wopi::TOKEN_TYPE_SETTING_AUTH && $wopi->getTokenType() !== Wopi::TOKEN_TYPE_USER) {
 				return new JSONResponse(['error' => 'Invalid token type'], Http::STATUS_BAD_REQUEST);
 			}
 

--- a/lib/Middleware/WOPIMiddleware.php
+++ b/lib/Middleware/WOPIMiddleware.php
@@ -63,7 +63,7 @@ class WOPIMiddleware extends Middleware {
 			return;
 		}
 
-		if (str_contains($this->request->getRequestUri(), '/wopi/settings/upload')) {
+		if (str_contains($this->request->getRequestUri(), '/wopi/settings')) {
 			return;
 		}
 

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -55,6 +55,7 @@
 			<input name="theme" :value="formData.theme" type="hidden">
 			<input name="buy_product" value="https://nextcloud.com/pricing" type="hidden">
 			<input name="host_session_id" :value="formData.hostSessionID" type="hidden">
+			<input name="wopi_setting_base_url" :value="formData.wopiSettingBaseUrl" type="hidden">
 		</form>
 		<iframe :id="iframeId"
 			ref="documentFrame"
@@ -93,6 +94,7 @@ import { getRandomId } from '../helpers/index.js'
 import {
 	getNextcloudUrl,
 	getWopiUrl,
+	getConfigFileUrl,
 } from '../helpers/url.js'
 import PostMessageService from '../services/postMessage.tsx'
 import FilesAppIntegration from './FilesAppIntegration.js'
@@ -198,6 +200,7 @@ export default {
 				cssVariables: generateCSSVarTokens(),
 				theme: getCollaboraTheme(),
 				hostSessionID: 'nextcloud ' + OC.config.version + ' - richdocuments ' + getCapabilities().version,
+				wopiSettingBaseUrl: getConfigFileUrl(),
 			},
 		}
 	},


### PR DESCRIPTION
This allows Collabora Online to have an in-app settings iframe dialog just like the one in Nextcloud Settings -> Office

* Target version: main

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
