### PR TITLE
fix(test): do not install composer dev dependencies

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Install composer dependencies
         working-directory: apps/richdocuments
         run: |
-          composer install
+          composer install --no-dev
 
       - name: Build talk
         working-directory: apps/spreed

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Set up PHPUnit
         working-directory: apps/${{ env.APP_NAME }}
-        run: composer i
+        run: composer install --no-dev
 
       - name: Set up Nextcloud
         env:
@@ -178,7 +178,7 @@ jobs:
 
       - name: Set up PHPUnit
         working-directory: apps/${{ env.APP_NAME }}
-        run: composer i
+        run: composer install --no-dev
 
       - name: Set up Nextcloud
         env:
@@ -259,7 +259,7 @@ jobs:
 
       - name: Set up PHPUnit
         working-directory: apps/${{ env.APP_NAME }}
-        run: composer i
+        run: composer install --no-dev
 
       - name: Set up Nextcloud
         env:
@@ -350,7 +350,7 @@ jobs:
 
       - name: Set up PHPUnit
         working-directory: apps/${{ env.APP_NAME }}
-        run: composer i
+        run: composer install --no-dev
 
       - name: Set up Nextcloud
         run: |


### PR DESCRIPTION
Dev dependencies are causing widespread issues on `main` with Cypress and integration tests. So here we can at least temporarily not install them until we know what the problem is.