### PR TITLE
Use Material Symbol variant for delete icon

### DIFF
--- a/src/components/AdminSettings/GlobalTemplates.vue
+++ b/src/components/AdminSettings/GlobalTemplates.vue
@@ -52,7 +52,7 @@ import { loadState } from '@nextcloud/initial-state'
 import '@nextcloud/dialogs/style.css'
 import axios from '@nextcloud/axios'
 import NewTemplateIcon from 'vue-material-design-icons/FileDocumentPlusOutline.vue'
-import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
+import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 
 export default {
 	name: 'GlobalTemplates',

--- a/src/components/DocSigningField.vue
+++ b/src/components/DocSigningField.vue
@@ -25,7 +25,7 @@
 <script>
 import NcTextArea from '@nextcloud/vue/dist/Components/NcTextArea.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
-import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
+import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 
 export default {
 	name: 'DocSigningField',

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -127,7 +127,7 @@ import NcSettingsSection from '@nextcloud/vue/dist/Components/NcSettingsSection.
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import DocSigningField from './DocSigningField.vue'
-import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
+import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 import FolderIcon from 'vue-material-design-icons/FolderOutline.vue'
 import axios from '@nextcloud/axios'
 import {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Use Material Symbol variant instead of material design icon

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
