### PR TITLE
Add Config for Open With Capability

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -11,6 +11,7 @@ namespace OCA\Richdocuments;
 use OCA\Richdocuments\Service\CapabilitiesService;
 use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 
 class Capabilities implements ICapability {
@@ -90,6 +91,7 @@ class Capabilities implements ICapability {
 	private ?array $capabilities = null;
 
 	public function __construct(
+		private IConfig $iconfig,
 		private AppConfig $config,
 		private CapabilitiesService $capabilitiesService,
 		private PermissionManager $permissionManager,
@@ -151,6 +153,18 @@ class Capabilities implements ICapability {
 			$defaultMimetypes[] = 'application/pdf';
 		}
 
+		$configuredOptionalMimetypes = $this->iconfig->getSystemValue('richdocuments_optional_mimetypes', null);
+		if (is_string($configuredOptionalMimetypes) && strtolower(trim($configuredOptionalMimetypes)) === 'all') {
+			$defaultMimetypes = [];
+		} else if (is_array($configuredOptionalMimetypes)) {
+			$defaultMimetypes = array_diff($defaultMimetypes, $configuredOptionalMimetypes);
+		}
+
+		// For an unknown reason there must be at least one mimetype
+		if (count($defaultMimetypes) === 0) {
+			$defaultMimetypes = ['dummy-by-nextcloud-office-for-no-default-mimetype'];
+		}
+
 		return $defaultMimetypes;
 	}
 
@@ -170,6 +184,13 @@ class Capabilities implements ICapability {
 			$optionalMimetypes = array_values(array_diff($optionalMimetypes, ['application/pdf']));
 		}
 
-		return $optionalMimetypes;
+		$configuredOptionalMimetypes = $this->iconfig->getSystemValue('richdocuments_optional_mimetypes', null);
+		if (is_string($configuredOptionalMimetypes) && strtolower(trim($configuredOptionalMimetypes)) === 'all') {
+			$optionalMimetypes = array_merge($optionalMimetypes, $this->getDefaultMimetypes());
+		} else if (is_array($configuredOptionalMimetypes)) {
+			$optionalMimetypes = array_merge($optionalMimetypes, $configuredOptionalMimetypes);
+		}
+
+		return array_values($optionalMimetypes);
 	}
 }

--- a/src/file-actions.js
+++ b/src/file-actions.js
@@ -32,10 +32,7 @@ const openPdf = {
 			return false
 		}
 
-		const isPdf = nodes[0].mime === 'application/pdf'
-		// Only enable the file action when files_pdfviewer is enabled
-		const optionalMimetypes = getCapabilities().mimetypesNoDefaultOpen
-		return isPdf && optionalMimetypes.includes('application/pdf')
+		return getCapabilities().mimetypesNoDefaultOpen.includes(nodes[0].mime)
 	},
 
 	exec: ({ nodes }) => {


### PR DESCRIPTION
* Resolves: #305
* Target version: main

### Summary

I installed Nextcloud Office on my Nextcloud instance. Anyway, most of the time I simply want to download the file and view or edit it locally. Even more, this applies to receivers of share links.

Therefore, this pull request adds one system config property to control the behavior of the Nextcloud Office app to open all kind of files by default. When setting the property "richdocuments_optional_mimetypes" to "all" or an array of mimetypes files are simply downloaded.

In addition, I made the context menu function "Edit with Nextcloud Office" a little more flexible to apply to all of the mimetypes that Nextcloud Office is capable to open but does not open by default. Thanks to that change, I'm still able to use Nextcloud Office on demand.

This is somewhat of a prototype. Nonetheless, I hope it helps someone to integrate a similar feature.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
