### PR TITLE
fix: register handler within init script

### DIFF
--- a/lib/Listener/LoadViewerListener.php
+++ b/lib/Listener/LoadViewerListener.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace OCA\Richdocuments\Listener;
 
+use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\PermissionManager;
 use OCA\Richdocuments\Service\InitialStateService;
 use OCA\Viewer\Event\LoadViewer;
@@ -36,7 +37,8 @@ class LoadViewerListener implements IEventListener {
 		}
 		if ($this->permissionManager->isEnabledForUser() && $this->userId !== null) {
 			$this->initialStateService->provideCapabilities();
-			Util::addScript('richdocuments', 'richdocuments-viewer', 'viewer');
+			Util::addInitScript(Application::APPNAME, Application::APPNAME . '-init-viewer');
+			Util::addScript(Application::APPNAME, Application::APPNAME . '-viewer', 'viewer');
 			$this->eventDispatcher->dispatchTyped(new RenderReferenceEvent());
 		}
 	}

--- a/lib/Listener/ShareLinkListener.php
+++ b/lib/Listener/ShareLinkListener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace OCA\Richdocuments\Listener;
 
 use OCA\Files_Sharing\Event\ShareLinkAccessedEvent;
+use OCA\Richdocuments\AppInfo\Application;
 use OCA\Richdocuments\PermissionManager;
 use OCA\Richdocuments\Service\InitialStateService;
 use OCP\EventDispatcher\Event;
@@ -41,8 +42,9 @@ class ShareLinkListener implements \OCP\EventDispatcher\IEventListener {
 			$this->initialStateService->prepareParams(['userId' => $loggedInUser]);
 			$this->initialStateService->provideCapabilities();
 
-			Util::addScript('richdocuments', 'richdocuments-viewer', 'viewer');
-			Util::addScript('richdocuments', 'richdocuments-public', 'viewer');
+			Util::addInitScript(Application::APPNAME, Application::APPNAME . '-init-viewer');
+			Util::addScript(Application::APPNAME, Application::APPNAME . '-viewer', 'viewer');
+			Util::addScript(Application::APPNAME, Application::APPNAME . '-public', 'viewer');
 		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
-        "@nextcloud/vue": "^8.27.0",
+        "@nextcloud/viewer": "^1.0.0",
+        "@nextcloud/vue": "^8.30.0",
         "vue": "^2.7.16",
         "vue-material-design-icons": "^5.3.1"
       },
@@ -3468,10 +3469,19 @@
         "npm": "^10.0.0"
       }
     },
+    "node_modules/@nextcloud/viewer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/viewer/-/viewer-1.0.0.tgz",
+      "integrity": "sha512-AaVXh+KyJ0q28AaqjBwDjjEuVB+v1GarIuuLCO2nfpkg/ekngQw25rmb4PzKVvbN8N35nb92GpQXBpG1ZtBrzg==",
+      "license": "AGPL-3.0-or-later",
+      "peerDependencies": {
+        "vue": "^2.7.16"
+      }
+    },
     "node_modules/@nextcloud/vue": {
-      "version": "8.29.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.29.2.tgz",
-      "integrity": "sha512-kxi5KEF5K0JiYo3P/JvorbZ7u1/g7kkbcba1IEAR1hliAOS9Mwqdr+5BdJGUdIB2AIH/bj8YTg85P4g4gGZnXA==",
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.30.0.tgz",
+      "integrity": "sha512-/FurCDvPmgI/HDGKv6L0flBw9gg2WkvlDydlL8G+VNmEVwW/RWXJ4uvqDhXLb1iIwS8yQXnYheDpeOKZr7aVIQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -22746,10 +22756,16 @@
         "@types/jquery": "3.5.16"
       }
     },
+    "@nextcloud/viewer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/viewer/-/viewer-1.0.0.tgz",
+      "integrity": "sha512-AaVXh+KyJ0q28AaqjBwDjjEuVB+v1GarIuuLCO2nfpkg/ekngQw25rmb4PzKVvbN8N35nb92GpQXBpG1ZtBrzg==",
+      "requires": {}
+    },
     "@nextcloud/vue": {
-      "version": "8.29.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.29.2.tgz",
-      "integrity": "sha512-kxi5KEF5K0JiYo3P/JvorbZ7u1/g7kkbcba1IEAR1hliAOS9Mwqdr+5BdJGUdIB2AIH/bj8YTg85P4g4gGZnXA==",
+      "version": "8.30.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.30.0.tgz",
+      "integrity": "sha512-/FurCDvPmgI/HDGKv6L0flBw9gg2WkvlDydlL8G+VNmEVwW/RWXJ4uvqDhXLb1iIwS8yQXnYheDpeOKZr7aVIQ==",
       "requires": {
         "@floating-ui/dom": "^1.1.0",
         "@linusborg/vue-simple-portal": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "@nextcloud/moment": "^1.3.4",
     "@nextcloud/paths": "^2.2.1",
     "@nextcloud/router": "^3.0.1",
-    "@nextcloud/vue": "^8.27.0",
     "@nextcloud/sharing": "^0.2.4",
+    "@nextcloud/viewer": "^1.0.0",
+    "@nextcloud/vue": "^8.30.0",
     "vue": "^2.7.16",
     "vue-material-design-icons": "^5.3.1"
   },

--- a/src/init-viewer.js
+++ b/src/init-viewer.js
@@ -1,0 +1,23 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import './init-shared.js'
+
+import { getCapabilities } from './services/capabilities.ts'
+import { registerHandler } from '@nextcloud/viewer'
+
+const supportedMimes = getCapabilities().mimetypes
+const AsyncViewerComponent = () => import('./view/Viewer.vue')
+
+const viewerHandler = {
+	id: 'richdocuments',
+	group: null,
+	mimes: supportedMimes,
+	component: AsyncViewerComponent,
+	theme: 'default',
+	canCompare: true,
+}
+
+registerHandler(viewerHandler)

--- a/src/viewer.js
+++ b/src/viewer.js
@@ -6,23 +6,6 @@
 import './init-shared.js'
 import '../css/filetypes.scss'
 
-import { getCapabilities } from './services/capabilities.ts'
 import { autoSetupBuiltInCodeServerIfNeeded } from './services/builtInCode.ts'
-
-const supportedMimes = getCapabilities().mimetypes
-const AsyncViewerComponent = () => import('./view/Viewer.vue')
-
-if (OCA.Viewer) {
-	OCA.Viewer.registerHandler({
-		id: 'richdocuments',
-		group: null,
-		mimes: supportedMimes,
-		component: AsyncViewerComponent,
-		theme: 'default',
-		canCompare: true,
-	})
-} else {
-	console.error('Unable to register viewer handler')
-}
 
 autoSetupBuiltInCodeServerIfNeeded()

--- a/webpack.js
+++ b/webpack.js
@@ -10,6 +10,7 @@ const BabelLoaderExcludeNodeModulesExcept = require('babel-loader-exclude-node-m
 
 webpackConfig.entry = {
 	viewer: path.join(__dirname, 'src', 'viewer.js'),
+	'init-viewer': path.join(__dirname, 'src', 'init-viewer.js'),
 	fileActions: path.join(__dirname, 'src', 'file-actions.js'),
 	document: path.join(__dirname, 'src', 'document.js'),
 	admin: path.join(__dirname, 'src', 'admin.js'),


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/4168
* Resolves: https://github.com/nextcloud/richdocuments/issues/3815
* Target version: main

### Summary

Based on https://github.com/nextcloud/viewer/pull/2922

This should fix all the loading order issues, we now have an API package.
So we can register the handler in an init script and thus its always registered.

I cannot test this locally due to missing dev setup of Collabora, maybe you could help me testing @elzody ?

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
