### PR TITLE
fix: prevent error when send null to json_decode

### DIFF
--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -139,6 +139,9 @@ class CapabilitiesService extends CachedRequestService {
 
 	private function getParsedCapabilities() {
 		$response = $this->get();
+		if (!$response) {
+			return [];
+		}
 		return json_decode($response, true);
 	}
 }


### PR DESCRIPTION
This fixed the follow warning:

```
json_decode(): Passing null to parameter #1 ($json) of type string is deprecated at /var/www/html/apps-extra/richdocuments/lib/Service/CapabilitiesService.php#142
```

* Target version: main

### Summary

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
