### PR TITLE
fix: do not exclude dependency `src/`

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -29,7 +29,7 @@ node_modules
 psalm.xml
 run-eslint.sh
 screenshots
-src
+/src/
 tests
 tsconfig.json
 webpack.*


### PR DESCRIPTION
* Target version: main

### Summary
In the last release, it was discovered that composer dependencies with `src` directories are getting excluded due to a rule in the `.nextcloudignore` file. This resolves this error


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
