### PR TITLE
chore(release): prepare for new beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 -->
 # Changelog
 
+## 9.0.0-beta.2
+
+### Added
+- New blank document template based on MS Word's styling by @emberfiend in [#4971](https://github.com/nextcloud/richdocuments/pull/4971)
+- Allow Collabora Online to fetch settings configuration from Nextcloud by @mohit-marathe in [#4974](https://github.com/nextcloud/richdocuments/pull/4974)
+
+### Fixed
+- Do not rely on speculative `getMountPoint()` by @blizzz in [#5012](https://github.com/nextcloud/richdocuments/pull/5012)
+- Error when send `null` to `json_decode` by @vitormattos in [#4994](https://github.com/nextcloud/richdocuments/pull/4994)
+- Do not exclude dependency `src` directories by @elzody in [#4991](https://github.com/nextcloud/richdocuments/pull/4991)
+- Use Material Symbol variant for delete icon by @AndyScherzinger in [#4973](https://github.com/nextcloud/richdocuments/pull/4973)
+- Incorrect URL when Nextcloud installed under a subdirectory by @timar in [#4954](https://github.com/nextcloud/richdocuments/pull/4954)
+- Do not install Composer dev dependencies for tests by @elzody in [#4968](https://github.com/nextcloud/richdocuments/pull/4968)
+
+### Other
+- Adjust testing matrix for Nextcloud 32 on stable32 by @nickvergessen in [#4995](https://github.com/nextcloud/richdocuments/pull/4995)
+- Dependency updates
+- Node and NPM engine versions update
+
 ## 9.0.0-beta.1
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>9.0.0-beta.1</version>
+	<version>9.0.0-beta.2</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "9.0.0-beta.1",
+  "version": "9.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "9.0.0-beta.1",
+      "version": "9.0.0-beta.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "9.0.0-beta.1",
+  "version": "9.0.0-beta.2",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
* Target version: stable32

### Summary
Bumps the version and updates the changelog in preparation for the second beta release of Nextcloud 32.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
