### PR TITLE
fix(Templates): like MS docs, also include OpenDocument docs in templates

### DIFF
--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -30,21 +30,25 @@ class TemplateManager {
 	/** Accepted templates mime types */
 	public const MIMES_DOCUMENTS = [
 		'application/vnd.oasis.opendocument.text-template',
+		'application/vnd.oasis.opendocument.text',
 		'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
 		'application/msword'
 	];
 	public const MIMES_SHEETS = [
 		'application/vnd.oasis.opendocument.spreadsheet-template',
+		'application/vnd.oasis.opendocument.spreadsheet',
 		'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
 		'application/vnd.ms-excel'
 	];
 	public const MIMES_PRESENTATIONS = [
 		'application/vnd.oasis.opendocument.presentation-template',
+		'application/vnd.oasis.opendocument.presentation',
 		'application/vnd.openxmlformats-officedocument.presentationml.template',
 		'application/vnd.ms-powerpoint'
 	];
 	public const MIMES_DRAWINGS = [
 		'application/vnd.oasis.opendocument.graphics-template',
+		'application/vnd.oasis.opendocument.graphics',
 	];
 
 	/** @var array Template mime types match */


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

We had inconsistent logic about which document types to include from the templates directory. From MS formats, both templates and documents where taken into account, for OpenDocument formats only template files. This is inconsistent and thus surprising. Adding OpenDocument documents now as well.

### Checklist

- [X] Code is properly formatted
- [X] Sign-off message is added to all commits
- [X] Documentation (manuals or wiki) has been updated or is not required
