### PR TITLE
Handle template source for guest users

### DIFF
--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -527,7 +527,7 @@ class TemplateManager {
 
 			$query = $this->db->getQueryBuilder();
 			$query->delete('richdocuments_template')
-				->where($query->expr()->eq('userid', $query->createNamedParameter($this->userId)))
+			    ->where($this->userId !== null ? $query->expr()->eq('userid', $query->createNamedParameter($this->userId, IQueryBuilder::PARAM_STR)) : $query->expr()->isNull('userid'))
 				->andWhere($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
 			$query->executeStatement();
 		} catch (Throwable $e) {


### PR DESCRIPTION
* Resolves: #5024
* Target version: main

### Summary

This fixes #5024 where documents created by guest users (using a public share link) are reset to the template contents every time they are open.

This is due to the template entry in `richdocuments_template` not being properly deleted when retrieved for the initial WOPI token. A fix was merged for the matching select but did not fix the delete statement.

See also: 1833a05611853c4f138a1413618ca51aa4802204

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
