### PR TITLE
zotero: remove zotero API key textbox

### DIFF
--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -34,47 +34,6 @@
 			</em>
 		</p>
 
-		<!-- Zotero -->
-		<div class="zotero-section">
-			<p><strong>{{ t('richdocuments', 'Zotero') }}</strong></p>
-			<template v-if="hasZoteroSupport">
-				<div class="input-wrapper">
-					<div class="zotero-inline">
-						<div class="zotero-input-wrapper">
-							<NcTextField id="zoteroAPIKeyField"
-								:value="zoteroAPIKey"
-								:label="t('richdocuments', 'Enter Zotero API Key')"
-								@update:value="setZoteroAPIKey" />
-						</div>
-						<NcButton id="zoteroAPIKeySave"
-							type="secondary"
-							@click="saveZoteroAPIKey">
-							{{ t('richdocuments', 'Save') }}
-						</NcButton>
-						<NcButton id="zoteroAPIKeyRemove"
-							type="secondary"
-							:title="t('richdocuments', 'Remove Zotero API Key')"
-							@click="resetZoteroAPI">
-							<DeleteIcon :size="20" />
-						</NcButton>
-					</div>
-					<p>
-						<em>
-							{{ t('richdocuments', 'To use Zotero specify your API key here. You can create your API key in your') }}
-							<a href="https://www.zotero.org/settings/keys" target="_blank">
-								{{ t('richdocuments', 'Zotero account API settings.') }}
-							</a>
-						</em>
-					</p>
-				</div>
-			</template>
-			<p v-else>
-				<em>
-					{{ t('richdocuments', 'This instance does not support Zotero, because the feature is missing or disabled. Please contact the administration.') }}
-				</em>
-			</p>
-		</div>
-
 		<!-- Document signing -->
 		<div class="docsign-section">
 			<p class="doc_sign_head">


### PR DESCRIPTION
COOL is now capable of handling and storing zotero key This PR only removes the textbox because the actual zotero key will be reused and transferred to COOL

removing all the zotero fields will require user to reenter the key 

relevant COOL PRs:
https://github.com/CollaboraOnline/online/pull/12694 
https://github.com/CollaboraOnline/online/pull/13091


* Target version: main


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
