### PR TITLE
refactor: untangle Node|ICacheEntry parameter in shouldWatermark

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -136,7 +136,7 @@ class WopiController extends Controller {
 		$isTaskProcessingEnabled = $isSmartPickerEnabled && $this->taskProcessingManager->isTaskProcessingEnabled();
 
 		$share = $this->getShareForWopiToken($wopi, $file);
-		$shouldUseSecureView = $this->permissionManager->shouldWatermark($file, $wopi->getEditorUid(), $share);
+		$shouldUseSecureView = $this->permissionManager->shouldWatermarkByNode($file, $wopi->getEditorUid(), $share);
 
 		// If the file is locked manually by a user we want to open it read only for all others
 		$canWriteThroughLock = true;

--- a/lib/Listener/BeforeFetchPreviewListener.php
+++ b/lib/Listener/BeforeFetchPreviewListener.php
@@ -49,7 +49,7 @@ class BeforeFetchPreviewListener implements IEventListener {
 		}
 
 		$userId = $this->userSession->getUser() ? $this->userSession->getUser()->getUID() : null;
-		if ($this->permissionManager->shouldWatermark($event->getNode(), $userId, $share)) {
+		if ($this->permissionManager->shouldWatermarkByNode($event->getNode(), $userId, $share)) {
 			throw new NotFoundException();
 		}
 	}

--- a/lib/Listener/OverwritePublicSharePropertiesListener.php
+++ b/lib/Listener/OverwritePublicSharePropertiesListener.php
@@ -33,7 +33,7 @@ class OverwritePublicSharePropertiesListener implements IEventListener {
 			return;
 		}
 
-		if ($this->permissionManager->shouldWatermark($node, $this->userId, $share)) {
+		if ($this->permissionManager->shouldWatermarkByNode($node, $this->userId, $share)) {
 			$share->setHideDownload(true);
 		}
 	}

--- a/lib/Storage/SecureViewWrapper.php
+++ b/lib/Storage/SecureViewWrapper.php
@@ -107,7 +107,7 @@ class SecureViewWrapper extends Wrapper {
 		$share = $isSharedStorage ? $storage->getShare() : null;
 		$userId = $this->userSession->getUser()?->getUID();
 
-		return $this->permissionManager->shouldWatermark($cacheEntry, $userId, $share, $storage->getOwner($path) ?: null);
+		return $this->permissionManager->shouldWatermarkByCacheEntry($cacheEntry, $userId, $share, $storage->getOwner($path) ?: null);
 	}
 
 


### PR DESCRIPTION
Addition to #5058

Results in split methods as we do not have nice overloading in PHP. But simplifies parameters when calling them, while implementation is being hidden yet simplified as it does not have to deal with different objects but a few primitive types.

Additionally has a small fix in the tests (provides file id as int).

Actually I am a bit torn about this one. What do you find better maintainable? 

