### PR TITLE
fix(workflow): run cypress on stable32 server version

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -31,7 +31,7 @@ jobs:
         containers: [1, 2, 3]
         php-versions: [ '8.1' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable32' ]
 
     name: runner ${{ matrix.code-image}}-${{ matrix.containers }}
 


### PR DESCRIPTION
I guess during the stable32 branch-off, this workflow was never changed. Dropping PHP 8.1 support for 33+ causes the Cypress tests to fail now on stable32 because the Cypress workflow here was still using master version of server. But we want to run it against the stable32 branch of server.