### PR TITLE
fix: Drop nonexisting onenote support from mime type list

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -38,7 +38,6 @@ class Capabilities implements ICapability {
 	];
 
 	public const MIMETYPES_MSOFFICE = [
-		'application/msonenote',
 		'application/msword',
 		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 		'application/vnd.openxmlformats-officedocument.wordprocessingml.template',


### PR DESCRIPTION
Fix https://github.com/nextcloud/richdocuments/issues/4920

Collabora does not allow opening onenote files so we should also not attempt to open them.