### PR TITLE
fix self-mention in comments

### DIFF
--- a/src/mixins/uiMention.js
+++ b/src/mixins/uiMention.js
@@ -7,6 +7,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import axios from '@nextcloud/axios'
 import Config from '../services/config.tsx'
 import { getNextcloudUrl } from '../helpers/url.js'
+import { getCurrentUser } from '@nextcloud/auth'
 
 export default {
 	methods: {
@@ -24,6 +25,18 @@ export default {
 					}
 				}
 
+				// Workaround to add the current user to the suggestions if they are not already in the list
+				// https://github.com/nextcloud/server/issues/48180
+				const currentUser = getCurrentUser()
+				const userExists = users.some(user => user.id === currentUser.uid)
+
+				if (!userExists) {
+					const matchesSearch = currentUser.uid.toLowerCase().includes(text.toLowerCase()) || currentUser.displayName.toLowerCase().includes(text.toLowerCase())
+					if (matchesSearch) {
+						users.push({ id: currentUser.uid, label: currentUser.displayName })
+					}
+				}
+
 				const list = users.map((user) => {
 					const profile = window.location.protocol + '//' + getNextcloudUrl() + '/index.php/u/' + user.id
 					return {
@@ -32,7 +45,6 @@ export default {
 						profile,
 					}
 				})
-
 				this.sendPostMessage('Action_Mention', { list })
 			}
 			if (type === 'selected') {


### PR DESCRIPTION
* Resolves: #4184
* Target version: main

### Summary

This workaround fixes the self-mention issue described in #4184 until https://github.com/nextcloud/server/issues/48180 is implemented. The current user is now allowed to mention himself in the comments.