### PR TITLE
fix: Pass document target through viewer component

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -401,8 +401,20 @@ class DocumentController extends Controller {
 
 			$this->tokenManager->setGuestName($wopi, $guestName);
 
+			$params = [
+				'urlSrc' => $this->tokenManager->getUrlSrc($file)
+			];
+
+			$targetData = $this->session->get(self::SESSION_FILE_TARGET);
+			if ($targetData) {
+				$this->session->remove(self::SESSION_FILE_TARGET);
+				if ($targetData['fileId'] === $fileId) {
+					$params['target'] = $targetData['target'];
+				}
+			}
+
 			return new DataResponse(array_merge(
-				[ 'urlSrc' => $this->tokenManager->getUrlSrc($file) ],
+				$params,
 				$wopi->jsonSerialize(),
 			));
 		} catch (Exception $e) {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -332,6 +332,7 @@ export default {
 				revisionHistory: !this.isPublic,
 				closeButton: !Config.get('hideCloseButton') && !this.isEmbedded,
 				startPresentation: Config.get('startPresentation'),
+				target: data.target,
 			})
 			this.$set(this.formData, 'action', action)
 			this.$set(this.formData, 'accessToken', data.token)


### PR DESCRIPTION
This fixes a regression from removing the nested iframes where the target in a document to open was no longer passed along to the collabora iframe.

Steps to reproduce:

- Have a spreadsheet with multiple sheets
- Open a text file
- Use the smart picket to link to a specific sheet in the spreadsheet file
- Click the link

## Before

You ended up on the first sheet

## After

You end up on the sheet picked in the smart picker