### PR TITLE
fix: Do not set the container for the file picker

### DIFF
--- a/src/view/DocumentTargetPicker.vue
+++ b/src/view/DocumentTargetPicker.vue
@@ -120,7 +120,6 @@ export default {
 						self.fetchReferences()
 					},
 				})
-				.setContainer(this.$refs.picker)
 				.build()
 				.pick()
 		},


### PR DESCRIPTION
The container is not allowed to be an element so we cannot use the ref

Minimal fix to bring the feature back to working on 29 where https://github.com/nextcloud/richdocuments/pull/3995 was not backported to

https://github.com/nextcloud-libraries/nextcloud-dialogs/blob/v5.3.8/lib/filepicker-builder.ts#L122-L131