### PR TITLE
[stable30] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3082,12 +3082,12 @@
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.2.tgz",
-      "integrity": "sha512-1dr+Xhvg2QtsFC23KFXJSkU524EVgI/+WFBGTZ8tFa+9hmcZ3CqZIHjtXm3KxUvezwAY5023Ml0n2vpdYkpBXQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.3.tgz",
+      "integrity": "sha512-KIhWLk0BKcP4hvypE4o11YqKOPeFMfEFjRrhUUF+h7Fry+dhTBIEIxuQPVCKXMIpjTDd8791y8V6UdRZ2feKAQ==",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/event-bus": "^3.3.2"
       },
       "engines": {
@@ -3124,15 +3124,12 @@
       }
     },
     "node_modules/@nextcloud/browser-storage": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
-      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
-      "dependencies": {
-        "core-js": "3.37.0"
-      },
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
+      "integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA==",
+      "license": "GPL-3.0-or-later",
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^24 || ^22 || ^20"
       }
     },
     "node_modules/@nextcloud/browserslist-config": {
@@ -3540,16 +3537,16 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.32.0.tgz",
-      "integrity": "sha512-V2ICZh7K9aVneXjmBV9p2sosYKj4Xr4Da8/Elat0u/v9GprBcRnITMipPXDBqtdf341YjRbaAkfGnpaA7M2GyA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.33.0.tgz",
+      "integrity": "sha512-OtRWrWbiR66zmBUYL89I6hB+E4OmUShwkT2Fd6wcRpbuywLtrmWxayribsmwZs75ZtaPekZij2UVzXF87qCrhQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.7.4",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.5.2",
+        "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
-        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
@@ -3564,7 +3561,7 @@
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.7",
+        "dompurify": "^3.3.0",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",
@@ -22526,11 +22523,11 @@
       "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ=="
     },
     "@nextcloud/auth": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.2.tgz",
-      "integrity": "sha512-1dr+Xhvg2QtsFC23KFXJSkU524EVgI/+WFBGTZ8tFa+9hmcZ3CqZIHjtXm3KxUvezwAY5023Ml0n2vpdYkpBXQ==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.5.3.tgz",
+      "integrity": "sha512-KIhWLk0BKcP4hvypE4o11YqKOPeFMfEFjRrhUUF+h7Fry+dhTBIEIxuQPVCKXMIpjTDd8791y8V6UdRZ2feKAQ==",
       "requires": {
-        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/event-bus": "^3.3.2"
       }
     },
@@ -22552,12 +22549,9 @@
       "requires": {}
     },
     "@nextcloud/browser-storage": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.4.0.tgz",
-      "integrity": "sha512-D6XxznxCYmJ3oBCC3p0JB6GZJ2RZ9dgbB1UqtTePXrIvHUMBAeF/YkiGKYxLAVZCZb+NSNZXgAYHm/3LnIUbDg==",
-      "requires": {
-        "core-js": "3.37.0"
-      }
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/browser-storage/-/browser-storage-0.5.0.tgz",
+      "integrity": "sha512-usYr4GlJQlK3hgZURvklqWb9ivi7sgsSuFqXrs7s4hl1LTS4enzPrnkQumm6nRsQruf0ITS+OBsK+oELEbvYPA=="
     },
     "@nextcloud/browserslist-config": {
       "version": "3.0.1",
@@ -22798,15 +22792,15 @@
       "requires": {}
     },
     "@nextcloud/vue": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.32.0.tgz",
-      "integrity": "sha512-V2ICZh7K9aVneXjmBV9p2sosYKj4Xr4Da8/Elat0u/v9GprBcRnITMipPXDBqtdf341YjRbaAkfGnpaA7M2GyA==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.33.0.tgz",
+      "integrity": "sha512-OtRWrWbiR66zmBUYL89I6hB+E4OmUShwkT2Fd6wcRpbuywLtrmWxayribsmwZs75ZtaPekZij2UVzXF87qCrhQ==",
       "requires": {
         "@floating-ui/dom": "^1.7.4",
         "@linusborg/vue-simple-portal": "^0.1.5",
-        "@nextcloud/auth": "^2.5.2",
+        "@nextcloud/auth": "^2.5.3",
         "@nextcloud/axios": "^2.5.2",
-        "@nextcloud/browser-storage": "^0.4.0",
+        "@nextcloud/browser-storage": "^0.5.0",
         "@nextcloud/capabilities": "^1.2.0",
         "@nextcloud/event-bus": "^3.3.2",
         "@nextcloud/initial-state": "^2.2.0",
@@ -22821,7 +22815,7 @@
         "blurhash": "^2.0.5",
         "clone": "^2.1.2",
         "debounce": "^2.2.0",
-        "dompurify": "^3.2.7",
+        "dompurify": "^3.3.0",
         "emoji-mart-vue-fast": "^15.0.5",
         "escape-html": "^1.0.3",
         "floating-vue": "^1.0.0-beta.19",


### PR DESCRIPTION
# Audit report

This audit fix resolves 14 of the total 15 vulnerabilities found in your project.

## Updated dependencies
* [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [floating-vue](#user-content-floating-vue)
* [postcss](#user-content-postcss)
* [vue](#user-content-vue)
* [vue-frag](#user-content-vue-frag)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue2-datepicker](#user-content-vue2-datepicker)
## Fixed vulnerabilities

### @linusborg/vue-simple-portal <a href="#user-content-\@linusborg\/vue-simple-portal" id="\@linusborg\/vue-simple-portal">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@linusborg/vue-simple-portal`

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: 4.2.0-beta.1 - 6.4.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
  * [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
  * [floating-vue](#user-content-floating-vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
  * [vue2-datepicker](#user-content-vue2-datepicker)
* Affected versions: <=8.33.0
* Package usage:
  * `node_modules/@nextcloud/vue`

### @nextcloud/vue-select <a href="#user-content-\@nextcloud\/vue-select" id="\@nextcloud\/vue-select">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vue-select`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### floating-vue <a href="#user-content-floating-vue" id="floating-vue">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-resize](#user-content-vue-resize)
* Affected versions: <=1.0.0-beta.19
* Package usage:
  * `node_modules/floating-vue`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### vue <a href="#user-content-vue" id="vue">#</a>
* ReDoS vulnerability in vue package that is exploitable through inefficient regex evaluation in the parseHTML function
* Severity: **low** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
* Affected versions: 2.0.0-alpha.1 - 2.7.16
* Package usage:
  * `node_modules/vue`

### vue-frag <a href="#user-content-vue-frag" id="vue-frag">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: >=1.3.1
* Package usage:
  * `node_modules/vue-frag`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue2-datepicker <a href="#user-content-vue2-datepicker" id="vue2-datepicker">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: <=1.9.8 || 3.0.2 - 3.11.1
* Package usage:
  * `node_modules/vue2-datepicker`