### PR TITLE
fix: select range without extension on SaveAs or ExportAs

### DIFF
--- a/src/components/Modal/SaveAs.vue
+++ b/src/components/Modal/SaveAs.vue
@@ -91,9 +91,14 @@ export default {
 		const extension = filename.split('.').pop()
 		const filenameWithoutExtension = filename.substring(0, filename.length - extension.length - 1)
 		this.$nextTick(() => {
-			const input = this.$refs.nameInput.$refs.inputField.$el.querySelector('input')
-			input.setSelectionRange(0, filenameWithoutExtension.length)
-			input.focus()
+			// Wait for NcTextField to fully render and populate the input value
+			setTimeout(() => {
+				const input = this.$refs.nameInput?.$refs.inputField?.$el?.querySelector('input')
+				if (input && input.value) {
+					input.focus()
+					input.setSelectionRange(0, filenameWithoutExtension.length)
+				}
+			}, 50)
 		})
 	},
 	methods: {


### PR DESCRIPTION
* Resolves: https://support.nextcloud.com/#ticket/zoom/87435
* Target version: main

### Summary
#### Before
When clicking on "Save As" or "Export As" a dialog appears where the user can rename the new file they want to save or export. The input field should per default be focused and the filename selected, so that the user can start typing right away. But the filename AND extension/format (e.g. pdf, odt, ...) were selected, so when the user started typing, also the format disappeared, not just the filename. 

<img width="619" height="254" alt="before" src="https://github.com/user-attachments/assets/a3cc376e-b1d7-48a4-bd90-73081b7d9490" />


#### After
Now only the filename is selected and the format does not disappear when the user starts typing.

<img width="619" height="254" alt="after" src="https://github.com/user-attachments/assets/b97904dc-146b-49c4-bd5b-8f8d404610c2" />


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [X] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
