### PR TITLE
fix: Properly handle authenticated links being an array

### DIFF
--- a/lib/Controller/DocumentAPIController.php
+++ b/lib/Controller/DocumentAPIController.php
@@ -65,9 +65,11 @@ class DocumentAPIController extends \OCP\AppFramework\OCSController {
 				$share = $this->shareManager->getShareByToken($shareToken);
 
 				if ($share->getPassword()) {
-					if (!$this->session->exists('public_link_authenticated')
-						|| $this->session->get('public_link_authenticated') !== (string)$share->getId()
-					) {
+					$authenticatedLinks = $this->session->get('public_link_authenticated');
+
+					$isAuthenticated = (is_array($authenticatedLinks) && in_array($share->getId(), $authenticatedLinks));
+					$isAuthenticated = $isAuthenticated || ($authenticatedLinks === (string)$share->getId());
+					if (!$isAuthenticated) {
 						throw new Exception('Invalid password');
 					}
 				}

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -242,9 +242,11 @@ class DocumentController extends Controller {
 			$share = $this->shareManager->getShareByToken($shareToken);
 			// not authenticated ?
 			if ($share->getPassword()) {
-				if (!$this->session->exists('public_link_authenticated')
-					|| $this->session->get('public_link_authenticated') !== (string)$share->getId()
-				) {
+				$authenticatedLinks = $this->session->get('public_link_authenticated');
+
+				$isAuthenticated = (is_array($authenticatedLinks) && in_array($share->getId(), $authenticatedLinks));
+				$isAuthenticated = $isAuthenticated || ($authenticatedLinks === (string)$share->getId());
+				if (!$isAuthenticated) {
 					throw new Exception('Invalid password');
 				}
 			}
@@ -459,9 +461,12 @@ class DocumentController extends Controller {
 	private function getFileForShare(IShare $share, ?int $fileId, ?string $path = null): File {
 		// not authenticated ?
 		if ($share->getPassword()) {
-			if (!$this->session->exists('public_link_authenticated')
-				|| $this->session->get('public_link_authenticated') !== (string)$share->getId()
-			) {
+			$authenticatedLinks = $this->session->get('public_link_authenticated');
+
+			$isAuthenticated = (is_array($authenticatedLinks) && in_array($share->getId(), $authenticatedLinks));
+			$isAuthenticated = $isAuthenticated || ($authenticatedLinks === (string)$share->getId());
+
+			if (!$isAuthenticated) {
 				throw new NotPermittedException('Invalid password');
 			}
 		}


### PR DESCRIPTION
This broke with the last server release as the authenticated link session value can now be an array

https://github.com/nextcloud/server/pull/55955