### PR TITLE
fix: Ensure public links are always considered public

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -127,10 +127,10 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$isPublic = empty($wopi->getEditorUid());
+		$isPublic = $wopi->getShare() !== null || empty($wopi->getEditorUid());
 		$guestUserId = 'Guest-' . \OCP\Server::get(\OCP\Security\ISecureRandom::class)->generate(8);
 		$user = $this->userManager->get($wopi->getEditorUid());
-		$userDisplayName = $user !== null && !$isPublic ? $user->getDisplayName() : $wopi->getGuestDisplayname();
+		$userDisplayName = $user !== null ? $user->getDisplayName() : $wopi->getGuestDisplayname();
 		$isVersion = $version !== '0';
 		$isSmartPickerEnabled = (bool)$wopi->getCanwrite() && !$isPublic && !$wopi->getDirect();
 		$isTaskProcessingEnabled = $isSmartPickerEnabled && $this->taskProcessingManager->isTaskProcessingEnabled();
@@ -146,7 +146,7 @@ class WopiController extends Controller {
 		} catch (NoLockProviderException|PreConditionNotMetException) {
 		}
 
-		$userId = !$isPublic ? $wopi->getEditorUid() : $guestUserId;
+		$userId = !empty($wopi->getEditorUid()) ? $wopi->getEditorUid() : $guestUserId;
 
 
 		$response = [


### PR DESCRIPTION
Fix #5198 

A public share link can also be opened with an active user session. In this case the share button was shown but not working. With this change we let the isPublic variable be what it is supposed to, a check if the file is accessed through a public share link. 

Steps to reproduce:
- Share a file as a public share link
- Be logged in as a user
- Open the share link

Before:
- The share button is visible

After:
- The share button is hidden as on the public share link there is no way to open the sharing sidebar