### PR TITLE
fix(mobile): pass format to SaveAs

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -183,12 +183,7 @@ describe('Direct editing (legacy)', function() {
 					.should('be.visible')
 				cy.get('.saveas-dialog input[type=text]')
 					.should('be.visible')
-					.should('have.value', 'document.odt')
-
-				cy.get('.saveas-dialog input[type=text]')
-					.clear()
-				cy.get('.saveas-dialog input[type=text]')
-					.type('/document.rtf')
+					.should('have.value', 'document.rtf')
 
 				cy.get('.saveas-dialog button.button-vue--vue-primary').click()
 

--- a/src/document.js
+++ b/src/document.js
@@ -474,7 +474,7 @@ const documentsMain = {
 							SaveAs,
 							{
 								path: documentsMain.fileName,
-								format: args.Format,
+								format: args.format,
 							},
 							(value) => value && PostMessages.sendWOPIPostMessage('loolframe', 'Action_SaveAs', { Filename: value, Notify: true }),
 						)


### PR DESCRIPTION
In the mobile app, `args.format` was typoed as `args.Format`, leading to format always being undefined. This meant that the save as popup would use the extension of the current file rather than the extension you were trying to save as. You could workaround by editing this manually, but it was annoying and not working as intended...

The browser version wasn't broken, as it uses a different code path to save documents (see src/mixins/saveAs.js)


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
