### PR TITLE
fix: Properly work with non-numeric version ids

### DIFF
--- a/lib/Command/ConvertToBigInt.php
+++ b/lib/Command/ConvertToBigInt.php
@@ -32,7 +32,7 @@ class ConvertToBigInt extends Command {
 
 	protected function getColumnsByTable() {
 		return [
-			'richdocuments_wopi' => ['id', 'fileid', 'version', 'template_id', 'template_destination', 'expiry'],
+			'richdocuments_wopi' => ['id', 'fileid', 'template_id', 'template_destination', 'expiry'],
 			'richdocuments_direct' => ['id', 'fileid', 'template_id', 'template_destination', 'timestamp'],
 			'richdocuments_assets' => ['id', 'fileid', 'timestamp'],
 		];

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -495,8 +495,7 @@ class DocumentController extends Controller {
 		throw new NotFoundException();
 	}
 
-	private function getToken(File $file, ?IShare $share = null, ?int $version = null, bool $isGuest = false): Wopi {
-		// Pass through $version
+	private function getToken(File $file, ?IShare $share = null, ?string $version = null, bool $isGuest = false): Wopi {
 		$templateFile = $this->templateManager->getTemplateSource($file->getId());
 		if ($templateFile) {
 			$owneruid = $share?->getShareOwner() ?? $file->getOwner()->getUID();
@@ -518,7 +517,7 @@ class DocumentController extends Controller {
 		return $this->tokenManager->generateWopiToken($this->getWopiFileId($file->getId(), $version), $share?->getToken(), $this->userId);
 	}
 
-	private function getWopiFileId(int $fileId, ?int $version = null): string {
+	private function getWopiFileId(int $fileId, ?string $version = null): string {
 		return $fileId . '_' . $this->config->getSystemValue('instanceid') . ($version ? '_' . $version : '');
 	}
 }

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -17,8 +17,8 @@ use OCP\DB\Types;
  * @method string getEditorUid()
  * @method void setFileid(int $fileid)
  * @method int getFileid()
- * @method void setVersion(int $version)
- * @method int getVersion()
+ * @method void setVersion(string $version)
+ * @method string getVersion()
  * @method void setCanwrite(bool $canwrite)
  * @method bool getCanwrite()
  * @method void setServerHost(string $host)
@@ -82,7 +82,7 @@ class Wopi extends Entity implements \JsonSerializable {
 	/** @var int */
 	protected $fileid;
 
-	/** @var int */
+	/** @var string */
 	protected $version;
 
 	/** @var bool */
@@ -128,7 +128,7 @@ class Wopi extends Entity implements \JsonSerializable {
 		$this->addType('ownerUid', Types::STRING);
 		$this->addType('editorUid', Types::STRING);
 		$this->addType('fileid', Types::INTEGER);
-		$this->addType('version', Types::INTEGER);
+		$this->addType('version', Types::STRING);
 		$this->addType('canwrite', Types::BOOLEAN);
 		$this->addType('serverHost', Types::STRING);
 		$this->addType('token', Types::STRING);

--- a/lib/Db/WopiMapper.php
+++ b/lib/Db/WopiMapper.php
@@ -31,7 +31,7 @@ class WopiMapper extends QBMapper {
 	 * @param int $fileId
 	 * @param string $owner
 	 * @param string $editor
-	 * @param int $version
+	 * @param string $version
 	 * @param bool $updatable
 	 * @param string $serverHost
 	 * @param string $guestDisplayname

--- a/lib/Migration/Version10000Date20251217143558.php
+++ b/lib/Migration/Version10000Date20251217143558.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Update version column in richdocuments_wopi table to support alphanumeric versions
+ */
+class Version10000Date20251217143558 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[Override]
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('richdocuments_wopi')) {
+			return null;
+		}
+
+		$table = $schema->getTable('richdocuments_wopi');
+		
+		if (!$table->hasColumn('version')) {
+			return null;
+		}
+
+		$column = $table->getColumn('version');
+		
+		if ($column->getType()->getName() === 'string') {
+			return null;
+		}
+
+		$table->changeColumn('version', [
+			'type' => 'string',
+			'notnull' => false,
+			'length' => 1024,
+			'default' => '0',
+		]);
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[Override]
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+	}
+}

--- a/lib/Migration/Version2060Date20200302131958.php
+++ b/lib/Migration/Version2060Date20200302131958.php
@@ -74,11 +74,10 @@ class Version2060Date20200302131958 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 20,
 			]);
-			$table->addColumn('version', 'bigint', [
-				//'notnull' => true,
+			$table->addColumn('version', 'string', [
 				'notnull' => false,
-				'length' => 20,
-				'default' => 0,
+				'length' => 1024,
+				'default' => '0',
 			]);
 			$table->addColumn('canwrite', 'boolean', [
 				//'notnull' => true,

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -196,7 +196,7 @@ class TokenManager {
 			$targetFile->getId(),
 			$owneruid,
 			$editoruid,
-			0,
+			'0',
 			$updatable,
 			$serverHost,
 			$isGuest ? '' : null,

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -315,7 +315,7 @@ export default {
 	methods: {
 		async load() {
 			const fileid = this.fileid ?? basename(dirname(this.source))
-			const version = this.fileid ? 0 : basename(this.source)
+			const version = this.fileid ? '0' : basename(this.source)
 
 			enableScrollLock()
 
@@ -339,8 +339,8 @@ export default {
 
 			// Generate form and submit to the iframe
 			const action = getWopiUrl({
-				fileId: fileid + '_' + loadState('richdocuments', 'instanceId', 'instanceid') + (version > 0 ? '_' + version : ''),
-				readOnly: forceReadOnly || version > 0,
+				fileId: fileid + '_' + loadState('richdocuments', 'instanceId', 'instanceid') + (version && version !== '0' ? '_' + version : ''),
+				readOnly: forceReadOnly || (version && version !== '0'),
 				revisionHistory: !this.isPublic,
 				closeButton: !Config.get('hideCloseButton') && !this.isEmbedded,
 				startPresentation: Config.get('startPresentation'),


### PR DESCRIPTION
### Summary

When using https://github.com/nextcloud/files_versions_s3 version ids in Nextcloud may not be numberic, but:

> Version IDs are Unicode, UTF-8 encoded, URL-ready, opaque strings that are no more than 1,024 bytes long.

This PR changes the database schema of richdocuments to make it work with that and adapts code where we enforce numeric values

To test with minio and primary object storage:

```
docker compose exec minio mc alias set docker http://localhost:9000 nextcloud nextcloud
docker compose exec minio mc version enable docker/nc-nextcloud