### PR TITLE
test(ci): pin server repo to commit before @nextcloud/files v4

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -49,7 +49,9 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           repository: nextcloud/server
-          ref: ${{ matrix.server-versions }}
+          # TODO: revert after viewer is fixed with latest server and `@nextcloud/files` v4.x
+          #ref: ${{ matrix.server-versions }}
+          ref: 282341a8d67b552a89768a1f91c1efe59b6ae254
 
       - name: Checkout submodules
         shell: bash


### PR DESCRIPTION
Currently all Cypress tests fail because server already upgraded to
`@nextcloud/files` v4 but viewer and assistant app weren't updated yet.

This is a temporary fix to get back meaningful e2e tests that needs to
be reverted once viewer and assistant apps got updated to be compatible
with latest server and `@nextcloud/files` v4.