### PR TITLE
[stable32] revert: skip failing test

### DIFF
--- a/cypress/e2e/share-link.js
+++ b/cypress/e2e/share-link.js
@@ -8,7 +8,7 @@ import { randHash } from '../utils/index.js'
 const shareOwner = new User(randHash(), randHash())
 const otherUser = new User(randHash(), randHash())
 
-describe.skip('Public sharing of office documents', () => {
+describe('Public sharing of office documents', () => {
 	before(function() {
 		cy.nextcloudTestingAppConfigSet('richdocuments', 'doc_format', '')
 		cy.createUser(shareOwner)
@@ -21,7 +21,7 @@ describe.skip('Public sharing of office documents', () => {
 
 	const userMatrix = [shareOwner, otherUser]
 
-	describe.skip('Share with users', () => {
+	describe('Share with users', () => {
 		describe('Readonly file', () => {
 			for (const user of userMatrix) {
 				it('Loads readonly file as user: ' + user.userId, () => {


### PR DESCRIPTION
Related: https://github.com/CollaboraOnline/online/issues/13855
Related: https://github.com/nextcloud/richdocuments/pull/5249

Revert skipping the test once fix upstream is released