### PR TITLE
fix(SecureView): ensure `shouldSecure()` doesn't attempt to call `fopen()` on directories

### DIFF
--- a/lib/Service/SecureViewService.php
+++ b/lib/Service/SecureViewService.php
@@ -28,16 +28,40 @@ class SecureViewService {
 	}
 
 	/**
-	 * @throws NotFoundException
+	 * Prepares metadata and context needed to decide if SecureView restrictions (such as watermarking or
+	 * download blocking) may apply to a given file or folder. Ensures filecache metadata is available by
+	 * triggering backend cache updates for files if requested, and supports external storages. Delegates
+	 * the actual policy decision to shouldWatermark().
+	 *
+	 * @param string $path      Relative storage path to check.
+	 * @param IStorage $storage Storage backend instance.
+	 * @param bool $tryOpen     Whether to attempt opening files to force/cache refresh file metadata.
+	 * @return bool             True if SecureView restrictions may apply (per shouldWatermark()), false otherwise.
+	 * @throws NotFoundException If neither the file nor its parent are present in the filecache/remote storage.
 	 */
 	public function shouldSecure(string $path, IStorage $storage, bool $tryOpen = true): bool {
-		if ($tryOpen) {
-			// pity… fopen() does not document any possible Exceptions
+		// First: try to get the cache entry for $path
+		$cacheEntry = $storage->getCache()->get($path);
+
+		$isDir = false;
+		// Prefer cache for fast directory check; fall back to (potentially slower) is_dir() if needed
+		if ($cacheEntry && !empty($cacheEntry['mimetype']) && $cacheEntry['mimetype'] === 'httpd/unix-directory') {
+			$isDir = true;
+		} elseif (!$cacheEntry && method_exists($storage, 'is_dir') && $storage->is_dir($path)) {
+			$isDir = true;
+		}
+		
+		if ($tryOpen && !isDir) {
+			// Attempt to open the file to potentially trigger cache entry creation
 			$fp = $storage->fopen($path, 'r');
-			fclose($fp);
+			if ($fp !== false && is_resource($fp)) {
+				fclose($fp);
+			}
+			// Re-fetch the cache entry after the 'poke'
+			$cacheEntry = $storage->getCache()->get($path);
 		}
 
-		$cacheEntry = $storage->getCache()->get($path);
+		// Fallback to parent *only if cache entry still missing after poke*
 		if (!$cacheEntry) {
 			$parent = dirname($path);
 			if ($parent === '.') {
@@ -45,16 +69,25 @@ class SecureViewService {
 			}
 			$cacheEntry = $storage->getCache()->get($parent);
 			if (!$cacheEntry) {
-				throw new NotFoundException(sprintf('Could not find cache entry for path and parent of %s within storage %s ', $path, $storage->getId()));
+				throw new NotFoundException(sprintf(
+					'Could not find cache entry for path and parent of %s within storage %s',
+					$path, $storage->getId()
+				));
 			}
 		}
 
+		// Now carry on with original SecureView logic...
 		$isSharedStorage = $storage->instanceOfStorage(ISharedStorage::class);
 		/** @noinspection PhpPossiblePolymorphicInvocationInspection */
 		/** @psalm-suppress UndefinedMethod **/
 		$share = $isSharedStorage ? $storage->getShare() : null;
 		$userId = $this->userSession->getUser()?->getUID();
 
-		return $this->permissionManager->shouldWatermark($cacheEntry, $userId, $share, $storage->getOwner($path) ?: null);
+		return $this->permissionManager->shouldWatermark(
+			$cacheEntry,
+			$userId,
+			$share,
+			$storage->getOwner($path) ?: null
+		);
 	}
 }

--- a/lib/Service/SecureViewService.php
+++ b/lib/Service/SecureViewService.php
@@ -33,10 +33,10 @@ class SecureViewService {
 	 * triggering backend cache updates for files if requested, and supports external storages. Delegates
 	 * the actual policy decision to shouldWatermark().
 	 *
-	 * @param string $path      Relative storage path to check.
+	 * @param string $path Relative storage path to check.
 	 * @param IStorage $storage Storage backend instance.
-	 * @param bool $tryOpen     Whether to attempt opening files to force/cache refresh file metadata.
-	 * @return bool             True if SecureView restrictions may apply (per shouldWatermark()), false otherwise.
+	 * @param bool $tryOpen Whether to attempt opening files to force/cache refresh file metadata.
+	 * @return bool True if SecureView restrictions may apply (per shouldWatermark()), false otherwise.
 	 * @throws NotFoundException If neither the file nor its parent are present in the filecache/remote storage.
 	 */
 	public function shouldSecure(string $path, IStorage $storage, bool $tryOpen = true): bool {

--- a/lib/Service/SecureViewService.php
+++ b/lib/Service/SecureViewService.php
@@ -51,7 +51,7 @@ class SecureViewService {
 			$isDir = true;
 		}
 		
-		if ($tryOpen && !isDir) {
+		if ($tryOpen && !$isDir) {
 			// Attempt to open the file to potentially trigger cache entry creation
 			$fp = $storage->fopen($path, 'r');
 			if ($fp !== false && is_resource($fp)) {


### PR DESCRIPTION
* Resolves: nextcloud/server#57342
* Target version: main

### Summary

Improve the `shouldSecure()` method to reliably determine whether a path is a file or directory -- using both the filecache and storage API -- before attempting to open the path. This prevents unnecessary or erroneous `fopen()` calls on directories (especially in external storage), ensures filecache metadata is prepared for permission checks, and enhances stability and clarity when applying SecureView restrictions.

Helps with nextcloud/server#57342 (and may even resolve it, though there may be additional things going on there - TBD; this improvement is useful either way).

Related: #5171

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
