### PR TITLE
fix: Emit files:node:updated event on UI_Save

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -513,6 +513,9 @@ export default {
 					FilesAppIntegration.updateFileInfo(undefined, Date.now())
 				}
 				break
+			case 'UI_Save':
+				FilesAppIntegration.updateFileInfo(undefined, Date.now())
+				break
 			case 'Clicked_Button':
 				this.buttonClicked(args)
 				break


### PR DESCRIPTION
* Resolves: #5267 
* Target version: main

### Summary
Handle `UI_Save` post message to update file info and emit `files:node:updated` event, allowing other components like the versions sidebar to react to document saves.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
