### PR TITLE
fix: Properly handle sidebar in 33

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -123,6 +123,7 @@ import uiMention from '../mixins/uiMention.js'
 import version from '../mixins/version.js'
 import { getCurrentUser, getGuestNickname } from '@nextcloud/auth'
 import { shouldAskForGuestName } from '../helpers/guestName.js'
+import { getSidebar } from '@nextcloud/files'
 
 const FRAME_DOCUMENT = 'FRAME_DOCUMENT'
 
@@ -288,7 +289,7 @@ export default {
 				},
 			})
 
-			window.OCA?.Files?.Sidebar?.close()
+			getSidebar()?.close()
 		}
 		this.postMessage.registerPostMessageHandler(this.postMessageHandler)
 


### PR DESCRIPTION
Removes old API calls and replaces with the new one from `@nextcloud/files`