### PR TITLE
fix: Use first uploader element

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -456,6 +456,7 @@ Cypress.Commands.add('makeTalkRoomPublic', (user, token, password = '') => {
 
 Cypress.Commands.add('newFileFromMenu', (fileType = 'document', fileName = 'MyNewFile') => {
 	cy.get('form[data-cy-upload-picker=""]')
+		.first()
 		.should('be.visible')
 		.click()
 


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
