### PR TITLE
fix(psalm): use template response constant

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -63,7 +63,7 @@ class Admin implements ISettings {
 					'setting_iframe_url' => $this->tokenManager->getUrlSrcForMimeType('Settings'),
 				],
 			],
-			'blank'
+			TemplateResponse::RENDER_AS_BLANK
 		);
 	}
 

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -49,7 +49,7 @@ class Personal implements ISettings {
 				'publicWopiUrl' => $this->appConfig->getCollaboraUrlPublic(),
 				'setting_iframe_url' => $this->tokenManager->getUrlSrcForMimeType('Settings'),
 			],
-			'blank'
+			TemplateResponse::RENDER_AS_BLANK
 		);
 	}
 


### PR DESCRIPTION
* Target version: main

### Summary
Uses the `TemplateResponse::RENDER_AS_BLANK` constant since `blank` is not accepted.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
