### PR TITLE
refactor: improve InitialStateService robustness and maintainability

### DIFF
--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -1,11 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-declare(strict_types=1);
 
 namespace OCA\Richdocuments\Service;
 
@@ -21,6 +21,7 @@ use OCP\IURLGenerator;
 
 class InitialStateService {
 	private bool $hasProvidedCapabilities = false;
+	private bool $hasProvidedOptions = false;
 
 	public function __construct(
 		private IInitialState $initialState,
@@ -45,19 +46,55 @@ class InitialStateService {
 		$this->initialState->provideInitialState('hasNextcloudBranding', $this->capabilitiesService->hasNextcloudBranding());
 		$this->initialState->provideInitialState('instanceId', $this->config->getSystemValue('instanceid'));
 		$this->initialState->provideInitialState('wopi_callback_url', $this->appConfig->getNextcloudUrl());
-
 		$this->provideOptions();
 
 		$this->hasProvidedCapabilities = true;
 	}
 
+	/**
+	 * Provides the initial state for a document editing session.
+	 *
+	 * @param Wopi $wopi The WOPI session object containing access token and file metadata
+	 * @param array $params Document parameters that override defaults. Required parameters:
+	 *                      - urlsrc: WOPI source URL (will fail without it)
+	 *                      - fileId: The file identifier (backend cannot locate file without it)
+	 *                      - token: Access token for authentication (will fail without it)
+	 *
+	 *                      Parameters with safe fallbacks (possibly degraded functionality if omitted):
+	 *                      - title: Document title/filename (default: '' - cosmetic only)
+	 *                      - path: File path relative to user folder (default: '' - affects context)
+	 *                      - permissions: File permissions bitmask (default: '' - read-only mode)
+	 *                      - token_ttl: Token time-to-live in seconds (default: 0)
+	 *
+	 *                      Optional parameters:
+	 *                      - isPublicShare: Whether accessed via public share (default: false)
+	 *                      - directEdit: Whether in direct edit mode (default: false)
+	 *                      - directGuest: Whether direct guest access (default: false)
+	 *                      - hideCloseButton: Whether to hide close button
+	 *                      - target: Optional bookmark/section target
+	 *                      - userId: User identifier (may include remote server for federation)
+	 * @return void
+	 * @throws \InvalidArgumentException if critical parameters are missing
+	 */	
 	public function provideDocument(Wopi $wopi, array $params): void {
 		$this->provideCapabilities();
 
+		// These keys are critical; the frontend will fail to load or authenticate properly if missing or empty.
+		if (!isset($params['urlsrc']) || $params['urlsrc'] === '') {
+			throw new \InvalidArgumentException('urlsrc is required for editor initialization');
+		}
+		if (!isset($params['fileId']) || $params['fileId'] === '') {
+			throw new \InvalidArgumentException('fileId is required to identify the document');
+		}
+		if (!isset($params['token']) || $params['token'] === '') {
+			throw new \InvalidArgumentException('token is required for authentication');
+		}
+
+		// merge provided parameters with default parameters
 		$this->initialState->provideInitialState('document', $this->prepareParams($params));
 
 		$this->initialState->provideInitialState('wopi', $wopi);
-
+		// Options may have been set already, but ensure anyway.
 		$this->provideOptions();
 	}
 
@@ -80,11 +117,16 @@ class InitialStateService {
 		]);
 	}
 
+	/**
+	 * Parameters for a document editing session.
+	 * Merges defaults with supplied params.
+	 * Does not validate parameters; any validation should happen at the call site.
+	 */
 	public function prepareParams(array $params): array {
 		$defaults = [
 			'instanceId' => $this->config->getSystemValue('instanceid'),
 			'canonical_webroot' => $this->config->getAppValue(Application::APPNAME, 'canonical_webroot', ''),
-			'userId' => $this->userId,
+			'userId' => $this->userId, // @todo: confirm this is reasonable for all circumstances
 			'token' => '',
 			'token_ttl' => 0,
 			'directEdit' => false,
@@ -100,24 +142,41 @@ class InitialStateService {
 		return array_merge($defaults, $params);
 	}
 
+	/**
+	 * Frontend options.
+	 */
 	private function provideOptions(): void {
-		$this->initialState->provideInitialState('loggedInUser', $this->userId ?? false);
-
-		$this->initialState->provideInitialState('theme', $this->config->getAppValue(Application::APPNAME, 'theme', 'nextcloud'));
-		$this->initialState->provideInitialState('uiDefaults', [
-			'UIMode' => $this->config->getAppValue(Application::APPNAME, 'uiDefaults-UIMode', 'notebookbar')
-		]);
-
-		$logoType = 'logoheader';
-		$logoSet = $this->imageManager->hasImage($logoType);
-		if (!$logoSet) {
-			$logoType = 'logo';
-			$logoSet = $this->imageManager->hasImage($logoType);
+		if ($this->hasProvidedOptions) {
+			return;
 		}
 
-		$logo = $logoSet ? $this->imageManager->getImageUrlAbsolute($logoType) : false;
-
-		$this->initialState->provideInitialState('theming-customLogo', $logo);
+		$this->initialState->provideInitialState('loggedInUser', $this->userId ?? false);
+		$this->setThemeOptions();
+		$this->setLogoOptions();
 		$this->initialState->provideInitialState('open_local_editor', $this->config->getAppValue(Application::APPNAME, 'open_local_editor', 'yes') === 'yes');
+
+		$this->hasProvidedOptions = true;
+	}
+
+	private function setThemeOptions(): void {
+		$this->initialState->provideInitialState(
+			'theme',
+			$this->config->getAppValue(Application::APPNAME, 'theme', 'nextcloud')
+		);
+		$this->initialState->provideInitialState(
+			'uiDefaults',
+			['UIMode' => $this->config->getAppValue(Application::APPNAME, 'uiDefaults-UIMode', 'notebookbar')]
+		);
+	}
+
+	private function setLogoOptions(): void {
+		$logoType = false;
+		if ($this->imageManager->hasImage('logoheader')) { // prefer custom header logo
+			$logoType = 'logoheader';
+		} elseif ($this->imageManager->hasImage('logo')) {
+			$logoType = 'logo';
+		}
+		$logoUrl = $logoType ? $this->imageManager->getImageUrlAbsolute($logoType) : false;
+		$this->initialState->provideInitialState('theming-customLogo', $logoUrl);
 	}
 }

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -75,7 +75,7 @@ class InitialStateService {
 	 *                      - userId: User identifier (may include remote server for federation)
 	 * @return void
 	 * @throws \InvalidArgumentException if critical parameters are missing
-	 */	
+	 */
 	public function provideDocument(Wopi $wopi, array $params): void {
 		$this->provideCapabilities();
 

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -15,9 +15,7 @@ use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\TemplateManager;
 use OCA\Theming\ImageManager;
 use OCP\AppFramework\Services\IInitialState;
-use OCP\Defaults;
 use OCP\IConfig;
-use OCP\IURLGenerator;
 
 class InitialStateService {
 	private bool $hasProvidedCapabilities = false;
@@ -29,8 +27,6 @@ class InitialStateService {
 		private ImageManager $imageManager,
 		private TemplateManager $templateManager,
 		private CapabilitiesService $capabilitiesService,
-		private IURLGenerator $urlGenerator,
-		private Defaults $themingDefaults,
 		private IConfig $config,
 		private ?string $userId,
 	) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

This PR refactors the `InitialStateService` class to enhance robustness, maintainability, and clarity:

- **Guards against duplicate provisioning** by introducing `$hasProvidedOptions` flags to ensure option state is only set once per request.
- **Introduces strict validation** of universally critical parameters (`urlsrc`, `fileId`, `token`) in `provideDocument()`, throwing exceptions when missing to prevent frontend/session errors.
- **Modularizes frontend option setup** by breaking out theming and logo logic into dedicated helper methods (`setThemeOptions`, `setLogoOption`), improving readability and separation of concerns.
- **Enhances documentation** with comprehensive PHPDoc and inline comments, making intent and requirements clearer to maintainers.

These improvements collectively make the service safer, easier to follow, and more maintainable for future development.

No breaking changes introduced; the new exceptions will only trigger on situations that would have already failed in some other way.

### TODO


### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
