### PR TITLE
chore: drop dead code from ShareLinkListener

### DIFF
--- a/lib/Listener/ShareLinkListener.php
+++ b/lib/Listener/ShareLinkListener.php
@@ -40,7 +40,6 @@ class ShareLinkListener implements \OCP\EventDispatcher\IEventListener {
 		$loggedInUser = $this->permissionManager->loggedInUser();
 
 		if ($this->permissionManager->isEnabledForUser($owner)) {
-			$this->initialStateService->prepareParams(['userId' => $loggedInUser]);
 			$this->initialStateService->provideCapabilities();
 
 			Util::addInitScript(Application::APPNAME, Application::APPNAME . '-init-viewer');


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

The return value from this isn't being used so it's a no-op.

I don't think it's needed; I believe nextcloud/auth is mostly used by the front-end for this sort of thing.

If it's needed than it's currently a bug since it's not actually doing anything. ;)

### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
