### PR TITLE
[stable33] fix: Use first uploader element

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -455,8 +455,8 @@ Cypress.Commands.add('makeTalkRoomPublic', (user, token, password = '') => {
 })
 
 Cypress.Commands.add('newFileFromMenu', (fileType = 'document', fileName = 'MyNewFile') => {
-	cy.get('div[data-cy-files-content-breadcrumbs=""]')
-		.find('form[data-cy-upload-picker=""]')
+	cy.get('form[data-cy-upload-picker=""]')
+		.first()
 		.should('be.visible')
 		.click()
 


### PR DESCRIPTION
Manual back-port of https://github.com/nextcloud/richdocuments/pull/5302