### PR TITLE
fix: Remove hasDrawSupport check that strips .odg mimetypes

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -118,14 +118,6 @@ class Capabilities implements ICapability {
 				array_push($optionalMimetypes, ...self::MIMETYPES_MSOFFICE);
 			}
 
-			// If version is too old, draw is not supported
-			if (!$this->capabilitiesService->hasDrawSupport()) {
-				$defaultMimetypes = array_diff($defaultMimetypes, [
-					'application/vnd.oasis.opendocument.graphics',
-					'application/vnd.oasis.opendocument.graphics-flat-xml',
-				]);
-			}
-
 			if (!$this->appManager->isEnabledForUser('files_pdfviewer')) {
 				$defaultMimetypes[] = 'application/pdf';
 				$optionalMimetypes = array_diff($optionalMimetypes, ['application/pdf']);
@@ -134,7 +126,7 @@ class Capabilities implements ICapability {
 			$this->capabilities = [
 				'richdocuments' => [
 					'version' => $this->appManager->getAppVersion('richdocuments'),
-					'mimetypes' => array_values($defaultMimetypes),
+					'mimetypes' => $defaultMimetypes,
 					'mimetypesNoDefaultOpen' => array_values($optionalMimetypes),
 					'mimetypesSecureView' => $this->config->useSecureViewAdditionalMimes() ? self::SECURE_VIEW_ADDITIONAL_MIMES : [],
 					'collabora' => $collaboraCapabilities,

--- a/lib/Listener/RegisterTemplateFileCreatorListener.php
+++ b/lib/Listener/RegisterTemplateFileCreatorListener.php
@@ -89,9 +89,6 @@ class RegisterTemplateFileCreatorListener implements IEventListener {
 			return $odpType;
 		});
 
-		if (!$this->capabilitiesService->hasDrawSupport()) {
-			return;
-		}
 		$templateManager->registerTemplateFileCreator(function () use ($ooxml, $appPath) {
 			$odpType = new TemplateFileCreator('richdocuments', $this->l10n->t('New diagram'), '.odg');
 			$odpType->addMimetype('application/vnd.oasis.opendocument.graphics');

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -69,10 +69,6 @@ class CapabilitiesService extends CachedRequestService {
 		return $this->isVersionAtLeast('21.11');
 	}
 
-	public function hasDrawSupport(): bool {
-		return $this->isVersionAtLeast('6.4.7');
-	}
-
 	public function hasTemplateSource(): bool {
 		return $this->getCapabilities()['hasTemplateSource'] ?? false;
 	}

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -40,7 +40,7 @@ class InitialStateService {
 		}
 
 		$this->initialState->provideInitialState('productName', $this->capabilitiesService->getProductName());
-		$this->initialState->provideInitialState('hasDrawSupport', $this->capabilitiesService->hasDrawSupport());
+		$this->initialState->provideInitialState('hasDrawSupport', true);
 		$this->initialState->provideInitialState('hasNextcloudBranding', $this->capabilitiesService->hasNextcloudBranding());
 		$this->initialState->provideInitialState('instanceId', $this->config->getSystemValue('instanceid'));
 		$this->initialState->provideInitialState('wopi_callback_url', $this->appConfig->getNextcloudUrl());

--- a/tests/lib/Listener/RegisterTemplateFileCreatorListenerTest.php
+++ b/tests/lib/Listener/RegisterTemplateFileCreatorListenerTest.php
@@ -73,33 +73,10 @@ class RegisterTemplateFileCreatorListenerTest extends TestCase {
 		$this->permissionManager->method('isEnabledForUser')->willReturn(true);
 		$this->permissionManager->method('userCanEdit')->willReturn(true);
 		$this->capabilitiesService->method('getCapabilities')->willReturn(['something']);
-		$this->capabilitiesService->method('hasDrawSupport')->willReturn(true);
 		$this->config->method('getAppValue')->willReturn('ooxml');
 		$this->appManager->method('getAppPath')->willReturn('/tmp');
 
 		$this->templateManager->expects($this->exactly(4))->method('registerTemplateFileCreator');
-
-		$listener = new RegisterTemplateFileCreatorListener(
-			$this->l10n,
-			$this->config,
-			$this->appManager,
-			$this->capabilitiesService,
-			$this->permissionManager
-		);
-		$listener->handle($event);
-	}
-
-	public function testHandleRegistersWithoutDrawSupport() {
-		$event = $this->createMock(RegisterTemplateCreatorEvent::class);
-		$event->method('getTemplateManager')->willReturn($this->templateManager);
-		$this->permissionManager->method('isEnabledForUser')->willReturn(true);
-		$this->permissionManager->method('userCanEdit')->willReturn(true);
-		$this->capabilitiesService->method('getCapabilities')->willReturn(['something']);
-		$this->capabilitiesService->method('hasDrawSupport')->willReturn(false);
-		$this->config->method('getAppValue')->willReturn('ooxml');
-		$this->appManager->method('getAppPath')->willReturn('/tmp');
-
-		$this->templateManager->expects($this->exactly(3))->method('registerTemplateFileCreator');
 
 		$listener = new RegisterTemplateFileCreatorListener(
 			$this->l10n,


### PR DESCRIPTION
hasDrawSupport() checked whether Collabora was at least version 6.4.7. When the Collabora capabilities cache was empty (between background job refreshes), productVersion defaulted to '0.0.0.0', causing the check to strip .odg and .odg-flat-xml mimetypes from the OCS capabilities. This prevented .odg files from being opened in the viewer.

Collabora 6.4.7 was released years ago and no supported Nextcloud version ships with anything older — remove the check entirely.
