### PR TITLE
ci: Skip nightly collabora images for our stable branches

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        code-image: [ 'release', 'nightly' ]
+        code-image: [ 'release' ]
         node-version: [16.x]
         containers: [1, 2, 3]
         php-versions: [ '8.2' ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        code-image: [ 'release', 'nightly' ]
+        code-image: [ 'release' ]
         php-versions: ['8.2']
         databases: ['sqlite']
         server-versions: ['master']


### PR DESCRIPTION
As discussed with @elzody this makes CI a bit more stable for the stable branches 🙈 