### PR TITLE
[stable32] fix: For now assume we have form filling if no version can be determined

### DIFF
--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -90,7 +90,8 @@ class CapabilitiesService extends CachedRequestService {
 	}
 
 	public function hasFormFilling(): bool {
-		return $this->isVersionAtLeast('24.04.5.2');
+		$productVersion = $this->getCapabilities()['productVersion'] ?? '0.0.0.0';
+		return $this->isVersionAtLeast('24.04.5.2') || $productVersion === '0.0.0.0';
 	}
 
 	private function isVersionAtLeast(string $version): bool {


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/richdocuments/pull/5381 since the bot is unresponsive