### PR TITLE
[stable32] ci: Skip nightly collabora images for our stable branches

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        code-image: [ 'release', 'nightly' ]
+        code-image: [ 'release' ]
         node-version: [16.x]
         containers: [1, 2, 3]
         php-versions: [ '8.1' ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        code-image: [ 'release', 'nightly' ]
+        code-image: [ 'release' ]
         php-versions: ['8.1']
         databases: ['sqlite']
         server-versions: ['stable32']


### PR DESCRIPTION
Manual back-port of https://github.com/nextcloud/richdocuments/pull/5380 due to unresponsive back-port bot