### PR TITLE
fix(cypress): use stable33 server for cypress tests

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -34,7 +34,7 @@ jobs:
         containers: [1, 2, 3]
         php-versions: [ '8.2' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable33' ]
 
     name: runner ${{ matrix.code-image}}-${{ matrix.containers }}
 


### PR DESCRIPTION
* Target version: stable33

### Summary
This was causing tests to fail regarding the jQuery change in 34, but we should use the stable33 server branch here because this is... well... stable33.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
