### PR TITLE
feat: make preview conversion timeout and max file size configurable

### DIFF
--- a/docs/app_settings.md
+++ b/docs/app_settings.md
@@ -41,6 +41,14 @@ By default Nextcloud will generate previews of Office files using the Collabora 
 
 	occ config:app:set richdocuments preview_generation --type boolean --lazy --value false
 
+The timeout for preview conversion requests (in seconds) can be configured. The default is 5 seconds:
+
+	occ config:app:set richdocuments preview_conversion_timeout --type integer --value 10
+
+Files larger than the configured maximum file size will be skipped and no preview will be generated. The default limit is 100 MB (104857600 bytes):
+
+	occ config:app:set richdocuments preview_conversion_max_filesize --type integer --value 52428800
+
 ### Electronic signature
 From a shell running in the Nextcloud root directory, run the following `occ`
 command to configure a non-default base URL for eID Easy. For example:

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -32,9 +32,14 @@ class AppConfig {
 	// Default: 'no', set to 'yes' to enable
 	public const USE_SECURE_VIEW_ADDITIONAL_MIMES = 'use_secure_view_additional_mimes';
 
+	public const PREVIEW_CONVERSION_TIMEOUT = 'preview_conversion_timeout';
+	public const PREVIEW_CONVERSION_MAX_FILESIZE = 'preview_conversion_max_filesize';
+
 	private array $defaults = [
 		'wopi_url' => '',
 		'timeout' => 15,
+		'preview_conversion_timeout' => 5,
+		'preview_conversion_max_filesize' => 104857600, // 100 MB
 		'watermark_text' => '{userId}',
 		'watermark_allGroupsList' => [],
 		'watermark_allTagsList' => [],
@@ -246,6 +251,21 @@ class AppConfig {
 
 	public function isPreviewGenerationEnabled(): bool {
 		return $this->appConfig->getAppValueBool('preview_generation', true);
+	}
+
+	/**
+	 * Returns the timeout in seconds for preview conversion requests to Collabora.
+	 */
+	public function getPreviewConversionTimeout(): int {
+		return (int)$this->getAppValue(self::PREVIEW_CONVERSION_TIMEOUT);
+	}
+
+	/**
+	 * Returns the maximum file size in bytes for which preview conversion is attempted.
+	 * Files larger than this limit will be skipped and return no preview.
+	 */
+	public function getPreviewConversionMaxFileSize(): int {
+		return (int)$this->getAppValue(self::PREVIEW_CONVERSION_MAX_FILESIZE);
 	}
 
 	private function getGSDomains(): array {

--- a/lib/Preview/Office.php
+++ b/lib/Preview/Office.php
@@ -38,12 +38,22 @@ abstract class Office implements IProviderV2 {
 
 	#[\Override]
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
-		if ($file->getSize() === 0) {
+		$fileSize = $file->getSize();
+		if ($fileSize === 0) {
+			return null;
+		}
+
+		$maxFileSize = $this->appConfig->getPreviewConversionMaxFileSize();
+		if ($fileSize > $maxFileSize) {
+			$this->logger->debug('Skipping preview conversion: file size {size} exceeds limit {limit}', [
+				'size' => $fileSize,
+				'limit' => $maxFileSize,
+			]);
 			return null;
 		}
 
 		try {
-			$response = $this->remoteService->convertFileTo($file, 'png');
+			$response = $this->remoteService->convertFileTo($file, 'png', $this->appConfig->getPreviewConversionTimeout());
 			$image = new Image();
 			$image->loadFromData($response);
 

--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -59,23 +59,28 @@ class RemoteService {
 	/**
 	 * @return resource|string
 	 */
-	public function convertFileTo(File $file, string $format) {
+	public function convertFileTo(File $file, string $format, int $timeout = RemoteOptionsService::REMOTE_TIMEOUT_DEFAULT) {
 		$fileName = $file->getStorage()->getLocalFile($file->getInternalPath());
 		$stream = fopen($fileName, 'rb');
 
 		if ($stream === false) {
 			throw new Exception('Failed to open stream');
 		}
-		return $this->convertTo($file->getName(), $stream, $format);
+
+		try {
+			return $this->convertTo($file->getName(), $stream, $format, [], $timeout);
+		} finally {
+			fclose($stream);
+		}
 	}
 
 	/**
 	 * @param resource $stream
 	 * @return resource|string
 	 */
-	public function convertTo(string $filename, $stream, string $format, ?array $conversionOptions = []) {
+	public function convertTo(string $filename, $stream, string $format, ?array $conversionOptions = [], int $timeout = RemoteOptionsService::REMOTE_TIMEOUT_DEFAULT) {
 		$client = $this->clientService->newClient();
-		$options = RemoteOptionsService::getDefaultOptions();
+		$options = RemoteOptionsService::getDefaultOptions($timeout);
 		// FIXME: can be removed once https://github.com/CollaboraOnline/online/issues/6983 is fixed upstream
 		$options['expect'] = false;
 

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -63,4 +63,40 @@ class AppConfigTest extends TestCase {
 
 		$this->assertSame([], $result);
 	}
+
+	public function testGetPreviewConversionTimeoutReturnsDefault(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('richdocuments', 'preview_conversion_timeout', 5)
+			->willReturn(5);
+
+		$this->assertSame(5, $this->appConfig->getPreviewConversionTimeout());
+	}
+
+	public function testGetPreviewConversionTimeoutReturnsConfiguredValue(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('richdocuments', 'preview_conversion_timeout', 5)
+			->willReturn(30);
+
+		$this->assertSame(30, $this->appConfig->getPreviewConversionTimeout());
+	}
+
+	public function testGetPreviewConversionMaxFileSizeReturnsDefault(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('richdocuments', 'preview_conversion_max_filesize', 104857600)
+			->willReturn(104857600);
+
+		$this->assertSame(104857600, $this->appConfig->getPreviewConversionMaxFileSize());
+	}
+
+	public function testGetPreviewConversionMaxFileSizeReturnsConfiguredValue(): void {
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->with('richdocuments', 'preview_conversion_max_filesize', 104857600)
+			->willReturn(52428800);
+
+		$this->assertSame(52428800, $this->appConfig->getPreviewConversionMaxFileSize());
+	}
 }

--- a/tests/lib/Preview/OfficeTest.php
+++ b/tests/lib/Preview/OfficeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Tests\Richdocuments\Preview;
+
+use OCA\Richdocuments\AppConfig;
+use OCA\Richdocuments\Capabilities;
+use OCA\Richdocuments\Preview\Office;
+use OCA\Richdocuments\Service\RemoteService;
+use OCP\Files\File;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class OfficeTest extends TestCase {
+	private RemoteService&MockObject $remoteService;
+	private LoggerInterface&MockObject $logger;
+	private AppConfig&MockObject $appConfig;
+	private Capabilities&MockObject $capabilities;
+	private Office $provider;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->remoteService = $this->createMock(RemoteService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->appConfig = $this->createMock(AppConfig::class);
+		$this->capabilities = $this->createMock(Capabilities::class);
+		$this->capabilities->method('getCapabilities')->willReturn(['richdocuments' => []]);
+
+		$this->provider = new class($this->remoteService, $this->logger, $this->appConfig, $this->capabilities) extends Office {
+			#[\Override]
+			public function getMimeType(): string {
+				return '/application\\/test/';
+			}
+		};
+	}
+
+	public function testGetThumbnailSkipsConversionWhenFileIsTooLarge(): void {
+		$file = $this->createMock(File::class);
+		$file->expects($this->once())->method('getSize')->willReturn(101 * 1024 * 1024);
+
+		$this->appConfig->expects($this->once())
+			->method('getPreviewConversionMaxFileSize')
+			->willReturn(100 * 1024 * 1024);
+		$this->remoteService->expects($this->never())->method('convertFileTo');
+
+		$result = $this->provider->getThumbnail($file, 64, 64);
+
+		$this->assertNull($result);
+	}
+
+	public function testGetThumbnailReturnsNullForEmptyFile(): void {
+		$file = $this->createMock(File::class);
+		$file->expects($this->once())->method('getSize')->willReturn(0);
+
+		$this->appConfig->expects($this->never())->method('getPreviewConversionMaxFileSize');
+		$this->remoteService->expects($this->never())->method('convertFileTo');
+
+		$result = $this->provider->getThumbnail($file, 64, 64);
+
+		$this->assertNull($result);
+	}
+
+	public function testGetThumbnailAttemptsConversionWhenFileSizeIsExactlyAtLimit(): void {
+		$file = $this->createMock(File::class);
+		$file->expects($this->once())->method('getSize')->willReturn(100 * 1024 * 1024);
+
+		$this->appConfig->expects($this->once())
+			->method('getPreviewConversionMaxFileSize')
+			->willReturn(100 * 1024 * 1024);
+		// Conversion is attempted; throw to keep the test simple (image loading is not unit-tested here)
+		$this->remoteService->expects($this->once())
+			->method('convertFileTo')
+			->with($file, 'png')
+			->willThrowException(new \Exception('conversion failed'));
+
+		$result = $this->provider->getThumbnail($file, 64, 64);
+
+		$this->assertNull($result);
+	}
+
+	public function testGetThumbnailReturnsNullWhenConversionFails(): void {
+		$file = $this->createMock(File::class);
+		$file->expects($this->once())->method('getSize')->willReturn(1024);
+
+		$this->appConfig->expects($this->once())
+			->method('getPreviewConversionMaxFileSize')
+			->willReturn(100 * 1024 * 1024);
+		$this->remoteService->expects($this->once())
+			->method('convertFileTo')
+			->with($file, 'png')
+			->willThrowException(new \Exception('conversion failed'));
+
+		$result = $this->provider->getThumbnail($file, 64, 64);
+
+		$this->assertNull($result);
+	}
+}


### PR DESCRIPTION
Attempt to implement with Claude Sonnet 4.6 and a custom agent definition, therefore collecting my personal feedback on that a bit here:

- Prompt was rather simple with more context in the github issue: `Create a branch, Implement the feature described in https://github.com/nextcloud/richdocuments/issues/5404 and open a pull request for it`
- Did one manual fixup [1f269e6](https://github.com/nextcloud/richdocuments/pull/5408/commits/1f269e6d2be898ced3b057b926d7d1db8a991178) but otherwise this is good 👍 
- Not a fan of the changes summary in the pr message, could be improved in prompting
- It needed some guidance to run phpunit tests with the xml configuration file
- Asked to cover this with phpunit tests [2a2ed3e](https://github.com/nextcloud/richdocuments/pull/5408/commits/2a2ed3ed773d78e9c52e0c7fdd9abccc46d3d21b)
- 
## Summary

Fixes #5404

Adds two new configurable options for preview conversion:

- **Timeout**: The timeout (in seconds) for preview conversion requests to Collabora. Defaults to 5 seconds.
- **Max file size**: Files larger than this limit are skipped and no preview is generated. Defaults to 100 MB.

Both options can be set via `occ config:app:set`:

```
occ config:app:set richdocuments preview_conversion_timeout --type integer --value 10
occ config:app:set richdocuments preview_conversion_max_filesize --type integer --value 52428800
```

## Changes
- Added `PREVIEW_CONVERSION_TIMEOUT` and `PREVIEW_CONVERSION_MAX_FILESIZE` constants + getter methods to `AppConfig`
- `Office::getThumbnail` now skips conversion when file size exceeds the configured limit
- `RemoteService::convertFileTo` passes the configured timeout to the HTTP client
- `RemoteService::convertTo` accepts a `$timeout` parameter (defaults to `REMOTE_TIMEOUT_DEFAULT` for non-preview callers)
- Documentation updated in `docs/app_settings.md`
