### PR TITLE
fix: :bug: :wrench: Widen DB field uids for federated sharing

### DIFF
--- a/lib/Migration/Version10100Date20260226000000.php
+++ b/lib/Migration/Version10100Date20260226000000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Override;
+
+/**
+ * Widen owner_uid and editor_uid columns from varchar(64) to varchar(255) to support federated cloud IDs
+ */
+class Version10100Date20260226000000 extends SimpleMigrationStep {
+	#[Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$changed = false;
+
+		if ($schema->hasTable('richdocuments_wopi')) {
+			$table = $schema->getTable('richdocuments_wopi');
+			foreach (['owner_uid', 'editor_uid'] as $columnName) {
+				if ($table->hasColumn($columnName) && $table->getColumn($columnName)->getLength() < 255) {
+					$table->changeColumn($columnName, [
+						'length' => 255,
+					]);
+					$changed = true;
+				}
+			}
+		}
+
+		return $changed ? $schema : null;
+	}
+}


### PR DESCRIPTION
Uids in several fields are not long enough for names, this shifts length 64 >>>255


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

When a federated cloud ID exceeds 64 characters, the `owner_uid` and `editor_uid` columns in the `oc_richdocuments_wopi` table silently truncate the value. This can prevent federated users from opening documents in Collabora.

This PR adds a database migration to widen `owner_uid` and `editor_uid` from `varchar(64)` to `varchar(255)`, aligning them with the maximum length of a federated cloud ID (`user@remote`).

## Background

The `oc_richdocuments_wopi` table stores active Collabora editing sessions. The `owner_uid` column identifies the file owner and `editor_uid` identifies the current editor. In a federation context, these values may contain a full cloud ID in the format `user@remote.domain`, which can easily exceed 64 characters with longer usernames or domain names.

The columns were originally defined as `varchar(64)` in `Version2060Date20200302131958`, which matches the local Nextcloud user ID limit but does not account for federated cloud IDs.

## Changes

### New migration: `Version10100Date20260226000000`

- Widens `owner_uid` from `varchar(64)` to `varchar(255)` on `oc_richdocuments_wopi`
- Widens `editor_uid` from `varchar(64)` to `varchar(255)` on `oc_richdocuments_wopi`
- Includes guard checks to only alter columns if they are below the target length
- Returns `null` (no-op) if the table or columns do not exist or are already the correct size

## Affected table

| Table | Column | Before | After |
|---|---|---|---|
| `oc_richdocuments_wopi` | `owner_uid` | `varchar(64)` | `varchar(255)` |
| `oc_richdocuments_wopi` | `editor_uid` | `varchar(64)` | `varchar(255)` |

## Notes

- The `uid` columns in `oc_richdocuments_direct` and `oc_richdocuments_assets` are also `varchar(64)` but currently only store local user IDs (`$this->userId`), so they are not affected by this issue. They can be addressed separately if needed.
- The original migration (`Version2060Date20200302131958`) could also be updated to use `varchar(255)` for these columns so that fresh installations get the correct size immediately.


### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
