### PR TITLE
fix(widget): set sensible height for embedded widget

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -640,7 +640,8 @@ export default {
 	}
 
 	&__embedding {
-		min-height: 400px;
+		min-height: min(50vh, 100vh - 120px) !important;
+		max-height: calc(100vh - 120px) !important;
 
 		.toggle-interactive {
 			position: sticky;


### PR DESCRIPTION
Fixes: nextcloud/text#8119

Values taken from Deck widget as they proved to work well there.

### Screenshots

Before | After
--- | ---
<img width="1942" height="1601" alt="image" src="https://github.com/user-attachments/assets/af16d931-ad1d-4d09-b6f6-bae44155a943" /> | <img width="1942" height="1601" alt="image" src="https://github.com/user-attachments/assets/0b1a9605-d4d4-4e69-a837-b382cf7157dd" />

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
