### PR TITLE
fix(officeViewer): remove superfluous high z-index

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -610,7 +610,6 @@ export default {
 </script>
 <style lang="scss" scoped>
 .office-viewer {
-	z-index: 100000;
 	max-width: 100%;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
The high z-index caused issues with embedded widgets.

Tested with office documents opened in Viewer and in embedded widgets in Text (standalone and Collectives).

Contributes to: #4068

### Screenshots

Before | After
--- | ---
<img width="1815" height="726" alt="image" src="https://github.com/user-attachments/assets/3a4a8ea3-a6e3-4c69-a801-7a7df145bfe6" /> | <img width="1815" height="726" alt="image" src="https://github.com/user-attachments/assets/c79c4c00-f9d6-4771-beb8-810e7850a11e" />

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
