### PR TITLE
feat(preview): Add thumbnail providers for RTF and MSPowerPoint

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -31,10 +31,12 @@ use OCA\Richdocuments\Middleware\WOPIMiddleware;
 use OCA\Richdocuments\Notification\Notifier;
 use OCA\Richdocuments\Preview\EMF;
 use OCA\Richdocuments\Preview\MSExcel;
+use OCA\Richdocuments\Preview\MSPowerPoint;
 use OCA\Richdocuments\Preview\MSWord;
 use OCA\Richdocuments\Preview\OOXML;
 use OCA\Richdocuments\Preview\OpenDocument;
 use OCA\Richdocuments\Preview\Pdf;
+use OCA\Richdocuments\Preview\Rtf;
 use OCA\Richdocuments\Reference\OfficeTargetReferenceProvider;
 use OCA\Richdocuments\Storage\SecureViewWrapper;
 use OCA\Richdocuments\TaskProcessing\SlideDeckGenerationProvider;
@@ -100,10 +102,12 @@ class Application extends App implements IBootstrap {
 
 		$context->registerPreviewProvider(EMF::class, EMF::MIMETYPE_REGEX);
 		$context->registerPreviewProvider(MSExcel::class, MSExcel::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(MSPowerPoint::class, MSPowerPoint::MIMETYPE_REGEX);
 		$context->registerPreviewProvider(MSWord::class, MSWord::MIMETYPE_REGEX);
 		$context->registerPreviewProvider(OOXML::class, OOXML::MIMETYPE_REGEX);
 		$context->registerPreviewProvider(OpenDocument::class, OpenDocument::MIMETYPE_REGEX);
 		$context->registerPreviewProvider(Pdf::class, Pdf::MIMETYPE_REGEX);
+		$context->registerPreviewProvider(Rtf::class, Rtf::MIMETYPE_REGEX);
 		$context->registerFileConversionProvider(ConversionProvider::class);
 		$context->registerNotifierService(Notifier::class);
 

--- a/lib/Preview/MSPowerPoint.php
+++ b/lib/Preview/MSPowerPoint.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Richdocuments\Preview;
+
+class MSPowerPoint extends Office {
+	public const MIMETYPE_REGEX = '/application\/vnd.ms-powerpoint/';
+	/**
+	 * {@inheritDoc}
+	 */
+	#[\Override]
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
+	}
+}

--- a/lib/Preview/Rtf.php
+++ b/lib/Preview/Rtf.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Richdocuments\Preview;
+
+class Rtf extends Office {
+	public const MIMETYPE_REGEX = '/application\/rtf/';
+	/**
+	 * {@inheritDoc}
+	 */
+	#[\Override]
+	public function getMimeType(): string {
+		return self::MIMETYPE_REGEX;
+	}
+}


### PR DESCRIPTION
RTF (application/rtf) and MSPowerPoint (application/vnd.ms-powerpoint) were missing from the preview providers, so no thumbnails were generated for these file types in the Files view.


* Resolves: # <!-- related github issue -->
* Target version: main

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
