### PR TITLE
fix(a11y): Add accessKey to Open in local editor button

### DIFF
--- a/src/document.js
+++ b/src/document.js
@@ -306,6 +306,7 @@ const documentsMain = {
 								label: t('richdocuments', 'Open in local editor'),
 								hint: t('richdocuments', 'Open in local editor'),
 								insertBefore: 'print',
+								accessKey: '2',
 							})
 						}
 

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -407,6 +407,7 @@ export default {
 					        label: t('richdocuments', 'Open in local editor'),
 					        hint: t('richdocuments', 'Open in local editor'),
 					        insertBefore: 'print',
+					        accessKey: '2',
 				        })
 			        }
 				} else if (args.Status === 'Failed') {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
<img width="359" height="337" alt="image" src="https://github.com/user-attachments/assets/c97989a8-bbde-41b1-ba2d-d03ecd2dc14b" />
Added `2` as `accessKey` for button.