### PR TITLE
fix: Restore editor focus on Save As modal close

### DIFF
--- a/src/components/Modal/SaveAs.vue
+++ b/src/components/Modal/SaveAs.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcModal :name="t('richdocuments', 'Save as')">
+	<NcModal :name="t('richdocuments', 'Save as')" @close="cancel">
 		<div class="saveas-dialog">
 			<h1>{{ name }}</h1>
 			<p>{{ description }}</p>
@@ -149,12 +149,14 @@ export default {
 					}
 				}
 
+				emit('richdocuments:grab-focus')
 				this.$emit('close', this.newFileName)
 			} finally {
 				this.isChecking = false
 			}
 		},
 		cancel() {
+			emit('richdocuments:grab-focus')
 			this.$emit('close', null)
 		},
 	},

--- a/src/document.js
+++ b/src/document.js
@@ -4,7 +4,7 @@
  */
 import './init-shared.js'
 import $ from 'jquery'
-import { emit } from '@nextcloud/event-bus'
+import { emit, subscribe } from '@nextcloud/event-bus'
 import { generateOcsUrl, getRootUrl, imagePath } from '@nextcloud/router'
 import { getRequestToken } from '@nextcloud/auth'
 import { loadState } from '@nextcloud/initial-state'
@@ -27,6 +27,10 @@ import SaveAs from './components/Modal/SaveAs.vue'
 const PostMessages = new PostMessageService({
 	parent: window.parent,
 	loolframe: () => document.getElementById('loleafletframe').contentWindow,
+})
+
+subscribe('richdocuments:grab-focus', () => {
+	PostMessages.sendWOPIPostMessage('loolframe', 'Grab_Focus')
 })
 
 if (isDirectEditing()) {

--- a/src/mixins/saveAs.js
+++ b/src/mixins/saveAs.js
@@ -4,11 +4,21 @@
  */
 
 import { spawnDialog } from '@nextcloud/dialogs'
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 import { basename } from 'path'
 import SaveAs from '../components/Modal/SaveAs.vue'
 
 export default {
+	mounted() {
+		subscribe('richdocuments:grab-focus', this.grabFocus)
+	},
+	beforeDestroy() {
+		unsubscribe('richdocuments:grab-focus', this.grabFocus)
+	},
 	methods: {
+		grabFocus() {
+			this.sendPostMessage('Grab_Focus')
+		},
 		async saveAs(format) {
 			spawnDialog(
 				SaveAs,


### PR DESCRIPTION
fix: Restore editor focus on Save As modal close

When the Save As dialog is dismissed (via Cancel or Esc), focus was not returning to the document iframe. This change restores focus to the document iframe by sending a Grab_Focus postMessage before the close event.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
