### PR TITLE
fix: Force hide viewer header after changed iframe z-index

### DIFF
--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -38,6 +38,11 @@ describe('Open existing office files', function() {
 
 			cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 
+			cy.get('#viewer .modal-header')
+				.should('exist')
+				.and('not.be.visible')
+				.and('have.css', 'display', 'none')
+
 			// Share action
 			cy.wait(2000)
 			cy.get('@loleafletframe').within(() => {
@@ -64,6 +69,11 @@ describe('Open existing office files', function() {
 			cy.openFile(filename)
 			cy.waitForViewer()
 			cy.waitForCollabora()
+
+			cy.get('#viewer .modal-header')
+				.should('exist')
+				.and('not.be.visible')
+				.and('have.css', 'display', 'none')
 
 			cy.screenshot('open-file_' + filename)
 			cy.get('@loleafletframe').within(() => {

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -669,6 +669,10 @@ export default {
 	position: absolute;
 }
 
+[data-handler="richdocuments"] .modal-header {
+	display: none !important;
+}
+
 [data-handler="richdocuments"] .modal-container {
 	bottom: 0;
 }


### PR DESCRIPTION
* Resolves: #5495 
* Target version: main

### Summary

Fixes regression from https://github.com/nextcloud/richdocuments/pull/5459 where the z-index removal caused the viewer header to overlap the collabora iframe, while we want to have it full screen.

This fix now hides it.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
