### PR TITLE
fix(files): Check read permission before showing PDF edit action

### DIFF
--- a/src/file-actions.js
+++ b/src/file-actions.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { registerFileAction } from '@nextcloud/files'
+import { Permission, registerFileAction } from '@nextcloud/files'
 import { getCapabilities } from './services/capabilities.ts'
 import { translate as t } from '@nextcloud/l10n'
 
@@ -25,6 +25,10 @@ const openPdf = {
 
 	enabled: ({ nodes }) => {
 		if (nodes.length !== 1) {
+			return false
+		}
+
+		if ((nodes[0].permissions & Permission.READ) === 0) {
 			return false
 		}
 


### PR DESCRIPTION
The "Edit with Collabora" file action was displayed for files the user lacks permission to access. Added a Permission.READ check in the enabled callback, consistent with how core Nextcloud file actions gate on node permissions.
