### PR TITLE
fix(widget): allow to leave edit mode

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -69,10 +69,11 @@
 			:src="iframeSrc"
 			:title="iframeTitle" />
 
-		<NcButton v-if="isEmbedded && !hasWidgetEditingEnabled" class="toggle-interactive" @click="toggleEdit">
-			{{ t('richdocuments', 'Edit') }}
+		<NcButton v-if="isEmbedded" class="toggle-interactive" @click="toggleEdit">
+			{{ toggleEditString }}
 			<template #icon>
-				<PencilIcon />
+				<EyeIcon v-if="hasWidgetEditingEnabled" />
+				<PencilIcon v-else />
 			</template>
 		</NcButton>
 		<ZoteroHint :show.sync="showZotero" @submit="reload" />
@@ -80,6 +81,7 @@
 </template>
 
 <script>
+import EyeIcon from 'vue-material-design-icons/EyeOutline.vue'
 import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
@@ -141,6 +143,7 @@ export default {
 		NcButton,
 		NcEmptyContent,
 		NcLoadingIcon,
+		EyeIcon,
 		PencilIcon,
 		ZoteroHint,
 	},
@@ -253,6 +256,11 @@ export default {
 		},
 		showAdminWebsocketFailure() {
 			return getCurrentUser()?.isAdmin && this.errorType === 'websocketconnectionfailed'
+		},
+		toggleEditString() {
+			return this.hasWidgetEditingEnabled
+				? t('richdocuments', 'Preview')
+				: t('richdocuments', 'Edit')
 		},
 	},
 	watch: {
@@ -548,7 +556,7 @@ export default {
 		},
 
 		toggleEdit() {
-			this.hasWidgetEditingEnabled = true
+			this.hasWidgetEditingEnabled = !this.hasWidgetEditingEnabled
 		},
 
 		getDocumentTypeIcon() {
@@ -644,12 +652,9 @@ export default {
 		max-height: calc(100vh - 120px) !important;
 
 		.toggle-interactive {
-			position: sticky;
-			bottom: 12px;
-			right: 12px;
-			z-index: 1;
-			margin-left: auto;
-			margin-right: 0;
+			position: absolute;
+			bottom: calc(var(--default-grid-baseline) * 2);
+			right: calc(var(--default-grid-baseline) * 2);
 		}
 	}
 


### PR DESCRIPTION
Fixes: #5458


### Screenshots

Before | After
--- | ---
<img width="1138" height="829" alt="image" src="https://github.com/user-attachments/assets/cc364da4-415f-43b2-b5ab-3c0ea360a962" /> | <img width="1138" height="829" alt="image" src="https://github.com/user-attachments/assets/cd2fa37d-8919-4d3e-b3d7-3e8d927b9892" />
<img width="1140" height="829" alt="image" src="https://github.com/user-attachments/assets/71f7fa28-4259-4e51-b099-7975bde3a49b" /> | <img width="1138" height="829" alt="image" src="https://github.com/user-attachments/assets/484c386a-a7f1-408d-8423-6a9114c0ac01" />

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
