### PR TITLE
templateManager: allow using regular document files as templates

### DIFF
--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -506,7 +506,9 @@ class TemplateManager {
 	public function isSupportedTemplateSource(string $extension): bool {
 		$supportedExtensions = [
 			'ott', 'otg', 'otp', 'ots',
+			'odt', 'odg', 'odp', 'ods',
 			'dotx', 'xltx', 'potx',
+			'docx', 'xlsx', 'pptx',
 			'dot', 'xlt', 'pot',
 		];
 		return in_array($extension, $supportedExtensions, true);


### PR DESCRIPTION
As Collabora Online does not support creating templates, allow the user to reuse documents created with richdocuments as templates.

Collabora Online supports thoe as templates.

Fixes: #5277