### PR TITLE
fix(widget): hide sidebar in edit mode

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -419,8 +419,8 @@ export default {
 				        })
 			        }
 
-                    if (this.isEmbedded && this.hasWidgetEditingEnabled) {
-                      this.sendPostMessage('Hide_Sidebar')
+					if (this.isEmbedded && this.hasWidgetEditingEnabled) {
+						this.sendPostMessage('Hide_Sidebar')
 					}
 				} else if (args.Status === 'Failed') {
 					this.loading = LOADING_STATE.FAILED


### PR DESCRIPTION
* Related: https://github.com/nextcloud/richdocuments/issues/5458
* Target version: main

### Summary
When going into edit mode inside of an office widget, the sidebar should be closed to increase the viewing area and keep the UI free of clutter. In this PR this is achieved by sending a post message when the edit mode is enabled and the file is embedded in a widget. It might also be worth it to collapse the notebook bar in some cases.

I wanted to accomplish this in a cleaner way, like setting a UI default, but it seems those are overridden by the user's settings and the state is remembered. The post message solution is what I was left with.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
