### PR TITLE
fix(format): makes OpenDocument the default format

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -40,7 +40,7 @@ class AppConfig {
 		'watermark_allTagsList' => [],
 		'watermark_linkTagsList' => [],
 		'token_ttl' => 36000, // 10 hours
-		'doc_format' => 'ooxml',
+		'doc_format' => 'odf',
 	];
 
 	public const WATERMARK_APP_NAMESPACE = 'files';

--- a/lib/Listener/RegisterTemplateFileCreatorListener.php
+++ b/lib/Listener/RegisterTemplateFileCreatorListener.php
@@ -46,7 +46,7 @@ class RegisterTemplateFileCreatorListener implements IEventListener {
 		}
 
 		$templateManager = $event->getTemplateManager();
-		$ooxml = $this->config->getAppValue(Application::APPNAME, 'doc_format', 'ooxml') === 'ooxml';
+		$ooxml = $this->config->getAppValue(Application::APPNAME, 'doc_format', 'odf') === 'ooxml';
 		$appPath = $this->appManager->getAppPath('richdocuments');
 
 		$templateManager->registerTemplateFileCreator(function () use ($ooxml, $appPath) {

--- a/lib/Service/SlideDeckService.php
+++ b/lib/Service/SlideDeckService.php
@@ -79,7 +79,7 @@ EOF;
 	public function generateSlideDeck(?string $userId, string $presentationText, bool $includeWatermark = true) {
 		$rawModelOutput = $this->runLLMQuery($userId, $presentationText);
 
-		$ooxml = $this->config->getAppValue(Application::APPNAME, 'doc_format', 'ooxml') === 'ooxml';
+		$ooxml = $this->config->getAppValue(Application::APPNAME, 'doc_format', 'odp') === 'ooxml';
 		$format = $ooxml ? 'pptx' : 'odp';
 
 		try {

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -47,7 +47,7 @@ class Admin implements ISettings {
 					'wopi_allowlist' => $this->config->getAppValue('richdocuments', 'wopi_allowlist'),
 					'edit_groups' => $this->config->getAppValue('richdocuments', 'edit_groups'),
 					'use_groups' => $this->config->getAppValue('richdocuments', 'use_groups'),
-					'doc_format' => $this->config->getAppValue('richdocuments', 'doc_format', 'ooxml'),
+					'doc_format' => $this->config->getAppValue('richdocuments', 'doc_format', 'odf'),
 					'external_apps' => $this->config->getAppValue('richdocuments', 'external_apps'),
 					'canonical_webroot' => $this->config->getAppValue('richdocuments', 'canonical_webroot'),
 					'disable_certificate_verification' => $this->config->getAppValue('richdocuments', 'disable_certificate_verification', '') === 'yes',

--- a/lib/TemplateManager.php
+++ b/lib/TemplateManager.php
@@ -417,7 +417,7 @@ class TemplateManager {
 	 * @return array
 	 */
 	public function formatNodeReturn(File $template) {
-		$ooxml = $this->config->getAppValue(Application::APPNAME, 'doc_format', 'ooxml') === 'ooxml';
+		$ooxml = $this->config->getAppValue(Application::APPNAME, 'doc_format', 'odf') === 'ooxml';
 		$documentType = $this->flipTypes()[$template->getMimeType()];
 		return [
 			'id' => $template->getId(),


### PR DESCRIPTION
This reverts commit 8b464b6 by setting "od[fp]" instead of "ooxml" as a default.

Following several downvotes and arguments against making the Microsoft-controlled format OOXML a default. See the many comments on issue #4812 for getting more context.

Main arguments are:
- Nextcloud already pointed out the risk of letting big tech companies in charge:
> The big Tech companies are dominating every aspect of our lives and work, and we’re all getting tired of it. Their power is a threat to privacy, and, on a bigger scale, democracy and the sovereignty of entire countries. And for businesses, there is a real risk to resilience, compliance and security. [0](https://nextcloud.com/blog/nextcloud-hub26-winter/)

- The Document Foundation made a statement explaining why this is a bad idea (at the time, directed toward OnlyOffice) [1](https://blog.documentfoundation.org/blog/2026/02/16/why-odf-and-not-ooxml/)
- Germany is now requiring ODF (and forbids OOXML) in its administration [2](https://blog.documentfoundation.org/blog/2026/03/19/germanys-sovereign-digital-stack-mandates-odf/) and this has good chances to spread in Europe as well.
- Microsoft do not honor its own standard and bribed the ISO participants to have it make a competing standardized when OpenDocument was already established [3](https://www.linuxjournal.com/content/buy-cheat-steal-and-lie-ooxml-story) [4](https://www.wired.com/2007/08/microsoft-allegedly-bullies-and-bribes-to-make-office-an-international-standard/) [5](
https://effi.org/blog-kai-2007-09-05-en/)
- Microsoft is subject to American rule of law which can go as far as imposing sanctions to out-of-jurisdiction institutions through their software [6](https://www.whitehouse.gov/presidential-actions/2025/02/imposing-sanctions-on-the-international-criminal-court/) [7](https://www.computerweekly.com/opinion/Microsofts-ICC-email-block-reignites-European-data-sovereignty-concerns)
