### PR TITLE
fix: Respect overwriteprotocol for WOPI server host

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -113,6 +113,10 @@ class WopiController extends Controller {
 			[$fileId, , $version] = Helper::parseFileId($fileId);
 
 			$wopi = $this->wopiMapper->getWopiForToken($access_token);
+			if ($this->config->getSystemValue('overwriteprotocol', '') === 'https') {
+				$serverHost = preg_replace('/^http:/i', 'https:', $wopi->getServerHost());
+				$wopi->setServerHost($serverHost);
+			}
 			$file = $this->getFileForWopiToken($wopi);
 			if (!($file instanceof File)) {
 				throw new NotFoundException('No valid file found for ' . $fileId);
@@ -541,6 +545,10 @@ class WopiController extends Controller {
 
 		try {
 			$wopi = $this->wopiMapper->getWopiForToken($access_token);
+			if ($this->config->getSystemValue('overwriteprotocol', '') === 'https') {
+				$serverHost = preg_replace('/^http:/i', 'https:', $wopi->getServerHost());
+				$wopi->setServerHost($serverHost);
+			}
 		} catch (UnknownTokenException $e) {
 			$this->logger->debug($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);


### PR DESCRIPTION
## Summary

When Nextcloud runs behind a reverse proxy that terminates TLS, the generated WOPI server host URL can incorrectly use HTTP instead of HTTPS. This causes Collabora to fail loading documents as it attempts to contact Nextcloud over HTTP and receives a redirect it cannot follow. This change corrects the protocol of the WOPI server host to HTTPS if 'overwriteprotocol' is set, ensuring Collabora can communicate with Nextcloud correctly.

## Changes

- **lib/Controller/WopiController.php**: In both checkFileInfo and putFile methods, after fetching the WOPI token object, check if 'overwriteprotocol' is set to 'https' and if so, update the serverHost on the WOPI object to use https. This ensures that any subsequent use of the server host for generating URLs within the request will use the correct protocol.

## Related Issue

Closes #5511

