### PR TITLE
fix(tests): enhance direct editing test with postMessage handling

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -109,9 +109,15 @@ describe('Direct editing (legacy)', function() {
 			.then((token) => {
 				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'classic')
 				cy.logout()
-				cy.visit(token)
+				cy.visit(token, {
+					onBeforeLoad(win) {
+						cy.spy(win, 'postMessage').as('postMessage')
+					},
+				})
 				cy.waitForCollabora(false)
+				cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 				cy.screenshot('direct')
+				cy.closeDirectDocument()
 			})
 	})
 
@@ -131,6 +137,7 @@ describe('Direct editing (legacy)', function() {
 						cy.waitForCollabora(false)
 						cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 						cy.screenshot('direct-new')
+						cy.closeDirectDocument()
 					})
 			})
 	})
@@ -141,9 +148,15 @@ describe('Direct editing (legacy)', function() {
 				.then((token) => {
 					cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'classic')
 					cy.logout()
-					cy.visit(token)
+					cy.visit(token, {
+						onBeforeLoad(win) {
+							cy.spy(win, 'postMessage').as('postMessage')
+						},
+					})
 					cy.waitForCollabora(false)
+					cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 					cy.screenshot('direct-share-link')
+					cy.closeDirectDocument()
 				})
 		})
 	})
@@ -168,11 +181,16 @@ describe('Direct editing (legacy)', function() {
 			.then((token) => {
 				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'tabbed')
 				cy.logout()
-				cy.visit(token)
+				cy.visit(token, {
+					onBeforeLoad(win) {
+						cy.spy(win, 'postMessage').as('postMessage')
+					},
+				})
 				cy.waitForCollabora(false)
+				cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 
 				cy.get('@loleafletframe').within(() => {
-					cy.get('.notebookbar-tabs-container', { timeout: 30_000 })
+					cy.get('.notebookbar-tabs-container')
 						.should('be.visible')
 
 					cy.get('button[aria-label="File"]').click()
@@ -192,6 +210,7 @@ describe('Direct editing (legacy)', function() {
 				cy.get('@loleafletframe').within(() => {
 					cy.verifyOpen('document.rtf')
 				})
+				cy.closeDirectDocument()
 			})
 	})
 

--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -91,21 +91,28 @@ const createDirectEditingLinkForShareToken = (shareToken, host = undefined, path
 
 describe('Direct editing (legacy)', function() {
 	let randUser
-	let fileId
 
 	before(function() {
 		cy.createRandomUser().then(user => {
 			randUser = user
-			cy.login(user)
-			cy.uploadFile(user, 'document.odt', 'application/vnd.oasis.opendocument.text', '/document.odt')
-				.then((id) => {
-					fileId = id
-				})
 		})
 	})
 
+	beforeEach(function() {
+		cy.uploadFile(randUser, 'document.odt', 'application/vnd.oasis.opendocument.text', '/document.odt')
+			.then((id) => {
+				cy.wrap(id).as('fileId')
+			})
+	})
+
+	afterEach(function() {
+		cy.deleteFile(randUser, '/document.odt')
+		cy.deleteFile(randUser, '/mynewfile.odt')
+		cy.deleteFile(randUser, '/document.rtf')
+	})
+
 	it('Open an existing file', function() {
-		createDirectEditingLink(randUser, fileId)
+		createDirectEditingLink(randUser, this.fileId)
 			.then((token) => {
 				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'classic')
 				cy.logout()
@@ -177,7 +184,7 @@ describe('Direct editing (legacy)', function() {
 	})
 
 	it('Save as', function() {
-		createDirectEditingLink(randUser, fileId)
+		createDirectEditingLink(randUser, this.fileId)
 			.then((token) => {
 				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'tabbed')
 				cy.logout()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -329,6 +329,14 @@ Cypress.Commands.add('closeDocument', () => {
 	cy.get('#viewer', { timeout: 5000 }).should('not.exist')
 })
 
+Cypress.Commands.add('closeDirectDocument', () => {
+	cy.get('@loleafletframe').within(() => {
+		cy.get('#closebutton').click()
+	})
+
+	cy.get('#mainContainer').should('not.exist')
+})
+
 Cypress.Commands.add('verifyOpen', (filename) => {
 	cy.get('input#document-name-input').should(($docName) => {
 		expect($docName.val()).to.equal(filename)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -337,6 +337,25 @@ Cypress.Commands.add('closeDirectDocument', () => {
 	cy.get('#mainContainer').should('not.exist')
 })
 
+Cypress.Commands.add('deleteFile', (user, target) => {
+	cy.login(user)
+	const rootPath = `${url}/remote.php/dav/files/${encodeURIComponent(user.userId)}`
+	const filePath = target.split('/').map(encodeURIComponent).join('/')
+
+	return cy.request('/csrftoken')
+		.then(({ body }) => body.token)
+		.then(requesttoken => {
+			return cy.request({
+				url: `${rootPath}/${filePath}`,
+				method: 'DELETE',
+				headers: {
+					requesttoken,
+				},
+				failOnStatusCode: false,
+			})
+		})
+})
+
 Cypress.Commands.add('verifyOpen', (filename) => {
 	cy.get('input#document-name-input').should(($docName) => {
 		expect($docName.val()).to.equal(filename)


### PR DESCRIPTION
Because the Collabora server cannot use bind-mounting on CI, it has to make a full copy of the file when creating its jail directory; this is a lot slower than when using bind mounts, e.g. when running the Collabora server locally where it has sufficient permissions to do so.

Consequently, each kit child process managed by the ForKit daemon spawns much slower. There is a pool of pre-spawned processes, but because this pool was being exhausted by other tests in `direct.spec.js` and they could not be replenished fast enough, it was leading to the "Save as" test failing. This is because it takes a while after the previous test completes before the document session is torn down due to running much slower on CI; locally you wouldn't notice a difference.

In general, because the tests were all using the same document to do their assertions and carry out their individual test cases, the Collabora server was still in the middle of tearing down the document session when another one was requested. One of the easiest solutions is to set up a `beforeEach` step that uploads a fresh document before each test, and an `afterEach` step that cleans up the documents generated by that test. The deletion means that any WOPI tokens for those documents are revoked, and when Collabora then tries to make another WOPI call it is met with a 404 and quickly unloads the document and does any tear-down it needs to. This releases the kit process back to the pool before the next test runs. 

TL;DR: On CI Collabora cannot maintain enough kit child processes in the pool so creating a fresh document before each test and cleaning it up afterward actually makes it faster because it can immediately clean up the document session and restore the process to the pool.