### PR TITLE
fix(wopi): Mark wopi token as sensitive also on controller level

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -108,7 +108,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'GET', url: 'wopi/files/{fileId}')]
-	public function checkFileInfo(string $fileId, string $access_token): JSONResponse {
+	public function checkFileInfo(
+		string $fileId,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse {
 		try {
 			[$fileId, , $version] = Helper::parseFileId($fileId);
 
@@ -329,7 +333,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'GET', url: 'wopi/files/{fileId}/contents')]
-	public function getFile(string $fileId, string $access_token): JSONResponse|StreamResponse|Http\Response {
+	public function getFile(
+		string $fileId,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse|StreamResponse|Http\Response {
 		[$fileId, , $version] = Helper::parseFileId($fileId);
 
 		try {
@@ -410,7 +418,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'GET', url: 'wopi/settings')]
-	public function getSettings(string $type, string $access_token): JSONResponse {
+	public function getSettings(
+		string $type,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse {
 		if (empty($type)) {
 			return new JSONResponse(['error' => 'Invalid type parameter'], Http::STATUS_BAD_REQUEST);
 		}
@@ -440,7 +452,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'POST', url: 'wopi/settings/upload')]
-	public function uploadSettingsFile(string $fileId, string $access_token): JSONResponse {
+	public function uploadSettingsFile(
+		string $fileId,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse {
 		try {
 			$wopi = $this->wopiMapper->getWopiForToken($access_token);
 			$userId = $wopi->getEditorUid();
@@ -488,7 +504,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'DELETE', url: 'wopi/settings')]
-	public function deleteSettingsFile(string $fileId, string $access_token): JSONResponse {
+	public function deleteSettingsFile(
+		string $fileId,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse {
 		try {
 			$wopi = $this->wopiMapper->getWopiForToken($access_token);
 			if ($wopi->getTokenType() !== Wopi::TOKEN_TYPE_SETTING_AUTH) {
@@ -535,7 +555,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'POST', url: 'wopi/files/{fileId}/contents')]
-	public function putFile(string $fileId, string $access_token): JSONResponse {
+	public function putFile(
+		string $fileId,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse {
 		[$fileId, , ] = Helper::parseFileId($fileId);
 		$isPutRelative = ($this->request->getHeader('X-WOPI-Override') === 'PUT_RELATIVE');
 
@@ -661,7 +685,11 @@ class WopiController extends Controller {
 	#[NoCSRFRequired]
 	#[PublicPage]
 	#[FrontpageRoute(verb: 'POST', url: 'wopi/files/{fileId}')]
-	public function postFile(string $fileId, string $access_token): JSONResponse {
+	public function postFile(
+		string $fileId,
+		#[\SensitiveParameter]
+		string $access_token,
+	): JSONResponse {
 		try {
 			$wopiOverride = $this->request->getHeader('X-WOPI-Override');
 			$wopiLock = $this->request->getHeader('X-WOPI-Lock');


### PR DESCRIPTION
Already done one level deeper:
https://github.com/nextcloud/richdocuments/blob/1df9ff818e01356b78760becd439f71e1f3a6297/lib/Db/WopiMapper.php#L133-L134

But still leaks here in case of exceptions:
```
      {
        "file": "/var/www/html/custom_apps/richdocuments/lib/Controller/WopiController.php",
        "line": 390,
        "function": "fopen",
        "class": "OC\\Files\\Node\\File",
        "type": "->",
        "args": [
          "rb"
        ]
      },
      {
        "file": "/var/www/html/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 204,
        "function": "getFile",
        "class": "OCA\\Richdocuments\\Controller\\WopiController",
        "type": "->",
        "args": [
          "1085",
          "z9…LEAKED…VV"
        ]
      },
      {
        "file": "/var/www/html/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 118,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Richdocuments\\Controller\\WopiController"
          },
          "getFile"
        ]
      },
```

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
