### PR TITLE
fix(workflow): use oci 18 container

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -289,8 +289,6 @@ jobs:
         # Provide passwords and other environment variables to container
         env:
           ORACLE_PASSWORD: rootpassword
-          APP_USER: autotest
-          APP_USER_PASSWORD: owncloud
 
         # Forward Oracle port
         ports:
@@ -343,7 +341,7 @@ jobs:
         run: |
           mkdir data
           echo '<?php $CONFIG=["memcache.local"=>"\OC\Memcache\APCu","hashing_default_password"=>true];' > config/config.php
-          ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=1521 --database-user=autotest --database-pass=owncloud --admin-user admin --admin-pass password
+          ./occ maintenance:install --verbose --database=oci --database-name=XE --database-host=127.0.0.1 --database-port=1521 --database-user=system --database-pass=rootpassword --admin-user admin --admin-pass password
           php -f index.php
           ./occ app:enable --force ${{ env.APP_NAME }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -284,7 +284,7 @@ jobs:
 
     services:
       oracle:
-        image: ghcr.io/gvenzl/oracle-xe:11
+        image: ghcr.io/gvenzl/oracle-xe:18
 
         # Provide passwords and other environment variables to container
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -288,7 +288,7 @@ jobs:
 
         # Provide passwords and other environment variables to container
         env:
-          ORACLE_RANDOM_PASSWORD: true
+          ORACLE_PASSWORD: rootpassword
           APP_USER: autotest
           APP_USER_PASSWORD: owncloud
 


### PR DESCRIPTION
Oracle 11 is not supported anymore; the minimum is now 18+.

Source: https://docs.nextcloud.com/server/latest/admin_manual/release_notes/upgrade_to_33.html