### PR TITLE
fix(secure-view): allow server-side file reads in SecureViewWrapper

### DIFF
--- a/lib/Storage/SecureViewWrapper.php
+++ b/lib/Storage/SecureViewWrapper.php
@@ -15,6 +15,7 @@ use OCA\Richdocuments\Service\SecureViewService;
 use OCP\Files\ForbiddenException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Storage\IStorage;
+use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Server;
 
@@ -24,6 +25,7 @@ class SecureViewWrapper extends Wrapper {
 	private IRootFolder $rootFolder;
 	private IUserSession $userSession;
 	private SecureViewService $secureViewService;
+	private IRequest $request;
 
 	private string $mountPoint;
 
@@ -35,6 +37,7 @@ class SecureViewWrapper extends Wrapper {
 		$this->rootFolder = Server::get(IRootFolder::class);
 		$this->userSession = Server::get(IUserSession::class);
 		$this->secureViewService = Server::get(SecureViewService::class);
+		$this->request = Server::get(IRequest::class);
 
 		$this->mountPoint = $parameters['mountPoint'];
 	}
@@ -85,7 +88,12 @@ class SecureViewWrapper extends Wrapper {
 	 * @throws ForbiddenException
 	 */
 	private function checkFileAccess(string $path): void {
-		if (!$this->wopiMiddleware->isWOPIRequest() && $this->secureViewService->shouldSecure($path, $this, false)) {
+		// Only block direct client-facing downloads (GET requests). Server-side operations
+		// such as template creation and background jobs are non-GET or have no HTTP context
+		// and must not be blocked even when secure view applies.
+		if (!$this->wopiMiddleware->isWOPIRequest()
+			&& $this->request->getMethod() === 'GET'
+			&& $this->secureViewService->shouldSecure($path, $this, false)) {
 			throw new ForbiddenException('Download blocked due the secure view policy', false);
 		}
 	}


### PR DESCRIPTION
## Problem

`SecureViewWrapper::checkFileAccess()` was blocking **all** non-WOPI `fopen()` and
`file_get_contents()` calls on watermarked files, including server-side operations
that never expose file content to the client.

The most visible symptom: creating a new file from a template fails with
_"Unable to create new file from template"_ when Secure View is enabled for the
user's group. `TemplateManager::createFromTemplate()` reads the template file
server-side via `fopen()`, which was incorrectly treated as a download attempt.

Stack trace from the field:
```
OCP\Files\ForbiddenException: Download blocked due the secure view policy
SecureViewWrapper.php::checkFileAccess
Files/View.php::fopen
Files/Node/File.php::fopen
Files/Template/TemplateManager.php::createFromTemplate
files/Controller/TemplateController.php::create
```



## Relation to #5577

This is a companion fix to #5577, which addressed a related Secure View regression
where `shouldSecure()` called `fopen()` internally, causing a recursive
`ForbiddenException` during delete/trash operations. Both issues stem from
`SecureViewWrapper` wrapping too broadly and intercepting legitimate server-side
file operations.

## Fix

Server-side operations (template creation, background jobs, CLI) are either
non-GET or carry no HTTP context at all.
`checkFileAccess()` now checks the HTTP method. Only GET requests are blocked, which covers
all real download vectors (WebDAV, public shares, ZIP folder downloads, preview
thumbnails) while leaving server-side reads untouched.
