### PR TITLE
Fix overlapping buttons in header

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -676,9 +676,10 @@ export default {
 	height: 100dvh;
 	top: -50px;
 	position: absolute;
+	z-index: 10001;
 }
 
-[data-handler="richdocuments"] .modal-header {
+.viewer__content:not(.viewer--split) [data-handler="richdocuments"] .modal-header {
 	display: none !important;
 }
 


### PR DESCRIPTION
* Target version: stable33

### Summary

The bug was probably introduced in #5496 

Fixes this button overlap:
[
<img width="532" height="258" alt="image1" src="https://github.com/user-attachments/assets/8874181c-8928-46af-8b4d-8cb799e3c259" />
](url)


### Checklist

- [ x] Code is properly formatted
- [ x] Sign-off message is added to all commits
- [ x] Code is AI-generated
- [ ] Documentation (manuals or wiki) has been updated or is not required
