### PR TITLE
feat: add Office overview page with recent / shared / templates

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -55,4 +55,12 @@ You can also edit your documents off-line with the Collabora Office app from the
 		<personal>OCA\Richdocuments\Settings\Personal</personal>
 		<personal-section>OCA\Richdocuments\Settings\Section</personal-section>
 	</settings>
+	<navigations>
+		<navigation>
+			<name>Office</name>
+			<route>richdocuments.overview.index</route>
+			<icon>app.svg</icon>
+			<order>5</order>
+		</navigation>
+	</navigations>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -61,6 +61,17 @@ return [
 		['name' => 'templates#getPreview', 'url' => '/template/preview/{fileId}', 'verb' => 'GET'],
 		['name' => 'templates#add', 'url' => '/template', 'verb' => 'POST'],
 		['name' => 'templates#delete', 'url' => '/template/{fileId}', 'verb' => 'DELETE'],
+
+		// Overview SPA shell — a single route handles every overview path
+		// (Home, Recent, Shared, Templates) and delegates to Vue Router.
+		['name' => 'overview#index', 'url' => '/overview', 'verb' => 'GET'],
+		[
+			'name' => 'overview#index',
+			'url' => '/overview/{path}',
+			'verb' => 'GET',
+			'postfix' => 'subpath',
+			'requirements' => ['path' => '.+'],
+		],
 	],
 	'ocs' => [
 		// Public pages: new file creation
@@ -87,5 +98,12 @@ return [
 		['name' => 'TemplateField#fillFields', 'url' => '/api/v1/template/fields/fill/{fileId}', 'verb' => 'POST'],
 
 		['name' => 'Mention#mention', 'url' => '/api/v1/mention/{fileId}', 'verb' => 'POST'],
+
+		// Overview API
+		['name' => 'OverviewApi#recent', 'url' => '/api/v1/overview/recent', 'verb' => 'GET'],
+		['name' => 'OverviewApi#shared', 'url' => '/api/v1/overview/shared', 'verb' => 'GET'],
+		['name' => 'OverviewApi#templates', 'url' => '/api/v1/overview/templates', 'verb' => 'GET'],
+		['name' => 'OverviewApi#createFromTemplate', 'url' => '/api/v1/overview/create-from-template', 'verb' => 'POST'],
+		['name' => 'OverviewApi#favourite', 'url' => '/api/v1/overview/favourite', 'verb' => 'POST'],
 	],
 ];

--- a/css/overview.scss
+++ b/css/overview.scss
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+// The Vue app mounts at #content (replacing it) — see overview.js. All
+// per-component styles live in their respective .vue files; this file is
+// kept as a stable hook for any future page-wide tweaks.
+

--- a/docs/overview-spec.md
+++ b/docs/overview-spec.md
@@ -1,0 +1,336 @@
+# Nextcloud Office — Overview Page Specification
+
+## 1. Goal
+Add a new top-level "Overview" page to the richdocuments app that gives every user a single landing page for office work: their recently edited documents, documents shared with them that have been edited recently, and one-click access to user-defined templates.
+
+## 2. Navigation & entry point
+- **App-menu entry** registered via `<navigations><navigation>` in `appinfo/info.xml`.
+- **Icon**: reuse the existing richdocuments app icon.
+- **Label**: same as the existing richdocuments app entry ("Office").
+- **Visibility**: every user for whom richdocuments is enabled. No admin toggle, no per-user setting.
+- **Default landing**: clicking the icon opens the **Home** view.
+
+## 3. URLs / routes
+Each entry is a bookmarkable URL.
+
+| Entry              | Path                                    | Default |
+|--------------------|-----------------------------------------|---------|
+| Home               | `/apps/richdocuments/overview`          | ✓       |
+| My recent          | `/apps/richdocuments/overview/recent`   |         |
+| Shared with me     | `/apps/richdocuments/overview/shared`   |         |
+| Templates          | `/apps/richdocuments/overview/templates`|         |
+
+Implemented client-side via Vue Router (history mode), all served by a single PHP controller action that renders the SPA shell.
+
+## 4. Page layout
+Two-column layout using `@nextcloud/vue` primitives.
+
+- **Left sidebar** (`NcAppNavigation`, ~280 px): vertical list with four entries — Home, My recent, Shared with me, Templates. Each has an icon. Active entry highlighted.
+- **Main area** (`NcAppContent`): view content for the active route.
+
+Responsive:
+- ≥ 1024 px: sidebar + content side-by-side (default `NcAppNavigation` behaviour).
+- 768–1023 px: sidebar collapses into a slide-in drawer behind a hamburger.
+- < 768 px: same drawer behaviour; rows simplify to filename + date + thumbnail (drop folder path on small viewports).
+
+## 5. Document scope
+
+### File types
+A file qualifies iff its MIME type / extension is one of:
+`.docx`, `.xlsx`, `.pptx`, `.odt`, `.ods`, `.odp`, `.pdf`.
+
+PDFs are included. Clicking a PDF opens it in Collabora's PDF viewer mode (read-only or editable depending on the PDF — same behaviour as opening from the Files app).
+
+### "Edited lately" definition
+A file qualifies iff `mtime > now() - 60 days`. The single signal is the file's `mtime` from `oc_filecache`. No distinction between Collabora edits and other writes (sync client, drag-and-drop replace, WebDAV, etc.) — anything that bumps `mtime` counts.
+
+### Authorship
+"Edited by someone" semantics: a file shows up regardless of whether the current user did the edit. The row's "modified by" column reflects whoever made the most recent change (per filecache / activity), which may be the owner, a co-editor, or the current user.
+
+## 6. Views
+
+### 6.1 Home (default)
+Three sections stacked vertically. Each section caps at **6 items**, sorted newest-first.
+
+1. **My recent documents** — files in the user's own storage; "See all →" links to `/recent`.
+2. **Shared with me** — files reachable via accepted shares; "See all →" links to `/shared`.
+3. **Templates** — user-defined templates; "See all →" links to `/templates`.
+
+Each section renders independently — if one API call fails, the others still load. Empty section shows the generic empty-state copy (see §10) without breaking the layout.
+
+### 6.2 My recent documents
+- One row per file, newest-first. **Fixed sort** (no clickable column headers in v1).
+- **Row contents**: thumbnail (64×64, from core preview API) · filename · last-modified date (relative, e.g. "2 hours ago", with absolute date as tooltip) · last-modified-by (avatar + display name) · folder path (e.g. `/Projects/Reports`).
+- **Click row** → open in Collabora in the **same tab** (`/apps/richdocuments/index?fileId=…`).
+- **Search box** at the top of the view: matches against `filename` OR `folder path`, case-insensitive substring. Server-side, debounced 250 ms.
+- **Pagination**: page size 25, **infinite scroll** — fetch next page when the user scrolls within ~300 px of the bottom of the list. Spinner shown while loading the next page.
+
+### 6.3 Shared with me
+Same layout, behaviour, and row contents as My recent. Source set differs:
+
+**Included** share types:
+- Direct user shares (`oc_share` with `share_type = 0`)
+- Group shares (`share_type = 1`)
+- Circle shares (`share_type = 7`)
+- Federated incoming shares (`oc_share_external` / `share_type = 6`)
+
+**Excluded**:
+- Public link shares (not tracked per-user; we'd have no way to know which user "received" it).
+
+For federated rows, indicate the source server in the "modified by" column (`Alice (other.example)`).
+
+### 6.4 Templates
+- One row per template, sorted by template name asc.
+- **Source**: only **user-defined templates** — the templates folder configured for the user by richdocuments (typically `~/Templates`, exact path is whatever richdocuments has stored). Excluded from v1: admin/system templates, and the empty-type seed files in `emptyTemplates/`.
+- **Row contents**: thumbnail · template name · file-type icon.
+- **Search box**: matches template name only.
+- **Pagination**: 25 per page, infinite scroll.
+
+**Click a template** → open **"Create from template" modal** (§7).
+
+## 7. Create-from-template flow
+
+Modal (`NcModal`) with two fields and two buttons.
+
+- **Filename** (text input)
+  - Default: `<TemplateName> <YYYY-MM-DD>` (e.g. `Letter 2026-04-26`).
+  - Extension is appended automatically based on the template's MIME type — not editable.
+- **Save to folder** (folder picker from `@nextcloud/files`)
+  - Default: the user's last-used save location (persist in user config, key e.g. `richdocuments.overview.lastTemplateFolder`).
+  - Fallback if no last-used location: the user's root folder.
+- **Buttons**: `Cancel` / `Create`.
+
+On `Create`:
+1. POST to `/overview/create-from-template` with `{ templateFileId, filename, folderPath }`.
+2. Server copies the template into the chosen folder, validates name collision (auto-suffix `(1)`, `(2)`, … on conflict), persists `lastTemplateFolder`.
+3. Response includes the new file's `fileid`.
+4. Frontend navigates the same tab to `/apps/richdocuments/index?fileId=<newId>` and the editor opens.
+
+## 8. Backend API
+
+All endpoints live under the richdocuments app, OCS v2.
+
+| Method | Path                                                                     | Purpose                          |
+|--------|--------------------------------------------------------------------------|----------------------------------|
+| GET    | `/ocs/v2.php/apps/richdocuments/api/v1/overview/recent`                 | My recent documents              |
+| GET    | `/ocs/v2.php/apps/richdocuments/api/v1/overview/shared`                 | Shared with me                   |
+| GET    | `/ocs/v2.php/apps/richdocuments/api/v1/overview/templates`              | User templates                   |
+| POST   | `/ocs/v2.php/apps/richdocuments/api/v1/overview/create-from-template`   | Create new document from template|
+
+### 8.1 Common GET query params
+- `q` — search string (substring, case-insensitive). Optional.
+- `cursor` — opaque base64 cursor for keyset pagination. Empty/missing for first page.
+- `limit` — defaults to 25, server hard-caps at 25.
+
+### 8.2 Response shape — `recent` and `shared`
+```json
+{
+  "ocs": {
+    "data": {
+      "items": [
+        {
+          "fileid": 12345,
+          "name": "Q1 Report.docx",
+          "path": "/Projects/Reports/Q1 Report.docx",
+          "folder": "/Projects/Reports",
+          "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "size": 24576,
+          "mtime": 1714123200,
+          "modifiedBy": {
+            "uid": "alice",
+            "displayName": "Alice",
+            "avatarUrl": "/avatar/alice/64"
+          },
+          "thumbnailUrl": "/core/preview?fileId=12345&x=64&y=64&a=1",
+          "openUrl": "/apps/richdocuments/index?fileId=12345",
+          "shareSource": null
+        }
+      ],
+      "nextCursor": "eyJtdGltZSI6MTcxNDEyMzIwMCwiZmlsZWlkIjoxMjM0NX0="
+    }
+  }
+}
+```
+
+For `shared`, `shareSource` is populated:
+```json
+"shareSource": {
+  "type": "user|group|circle|federated",
+  "displayName": "Alice",
+  "remoteServer": "https://other.example/"
+}
+```
+`remoteServer` is `null` for non-federated shares.
+
+`nextCursor` is `null` when there are no more pages.
+
+### 8.3 Response shape — `templates`
+```json
+{
+  "ocs": {
+    "data": {
+      "items": [
+        {
+          "fileid": 99,
+          "name": "Letter Template.docx",
+          "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "thumbnailUrl": "/core/preview?fileId=99&x=64&y=64&a=1"
+        }
+      ],
+      "nextCursor": null
+    }
+  }
+}
+```
+
+### 8.4 Request shape — `create-from-template`
+```json
+POST /overview/create-from-template
+{
+  "templateFileId": 99,
+  "filename": "Letter 2026-04-26",
+  "folderPath": "/Documents"
+}
+```
+
+Response:
+```json
+{
+  "ocs": {
+    "data": {
+      "fileid": 67890,
+      "path": "/Documents/Letter 2026-04-26.docx",
+      "openUrl": "/apps/richdocuments/index?fileId=67890"
+    }
+  }
+}
+```
+
+Errors return standard OCS error envelope with one of:
+- `400 invalid_filename` (empty / contains `/` / etc.)
+- `403 folder_forbidden` (no write permission on target folder)
+- `404 template_not_found` / `404 folder_not_found`
+- `409 conflict` (only if auto-suffix is exhausted, which shouldn't happen)
+
+## 9. Query implementation notes
+
+### 9.1 Recent (own files)
+```sql
+SELECT f.fileid, f.name, f.path, f.mimetype, f.size, f.mtime, f.storage_mtime
+FROM oc_filecache f
+JOIN oc_mounts m ON m.storage_id = f.storage
+WHERE m.user_id = :uid
+  AND f.mimetype IN (:allowed_mimetype_ids)
+  AND f.mtime > :sixty_days_ago
+  AND ( :q IS NULL OR LOWER(f.name) LIKE :q_like OR LOWER(f.path) LIKE :q_like )
+  AND ( :cursor_mtime IS NULL OR (f.mtime, f.fileid) < (:cursor_mtime, :cursor_fileid) )
+ORDER BY f.mtime DESC, f.fileid DESC
+LIMIT 25;
+```
+Resolve `modifiedBy` via the user's last-modified-by index if present, otherwise default to the file owner.
+
+### 9.2 Shared with me
+- Enumerate `oc_share` rows where `share_with = :uid` (type 0/user) or `share_with` ∈ user's groups (type 1) or circles (type 7).
+- Plus `oc_share_external` rows where the recipient is `:uid` (type 6 federated).
+- Join file metadata, apply same mimetype + mtime filter, same search predicate, same keyset pagination.
+- De-duplicate on `fileid` (a file can be reshared via multiple paths) — pick the row whose share grants the highest permissions; if tied, lowest `share_id`.
+
+### 9.3 Templates
+Read the user's templates folder via the existing richdocuments templates service (whatever the app already uses to enumerate templates for the "create new" flow in Files). Filter by allowed MIME types. No mtime filter for templates.
+
+### 9.4 Pagination cursor
+Cursor = base64 of `{"mtime": <int>, "fileid": <int>}` (for `recent` / `shared`) or `{"name": "<lower>", "fileid": <int>}` (for `templates`). Keyset comparison `(mtime, fileid) < (cursor_mtime, cursor_fileid)` to avoid OFFSET drift on large result sets.
+
+### 9.5 Performance
+- Hard limit of 25 per page; no "fetch all" path.
+- All queries respect Nextcloud's permission scope — only files the user can read.
+- Profile the queries on a representative dataset before merging; add a composite index on `oc_filecache(storage, mimetype, mtime)` only if profiling shows it's needed (and check whether one already exists).
+- All four list endpoints should P95 < 200 ms on a user with up to 100 000 files and 1 000 incoming shares.
+
+## 10. States
+
+### Loading
+- **First load**: 6 skeleton rows (shimmer) on Home; 25 skeleton rows on dedicated views.
+- **Subsequent infinite-scroll loads**: small spinner at the bottom of the list.
+
+### Empty (generic copy is fine)
+- My recent / Shared with me, no data: `"No documents edited in the last 60 days."`
+- Templates, no data: `"You haven't created any templates yet."` + link to Nextcloud's templates help article.
+- Search yields nothing: `"No matches for "<query>"."`
+
+### Error
+- Per-section error inline (`NcEmptyContent` with a "Retry" button). Other sections on Home keep working.
+
+## 11. Frontend file layout
+
+New entry point and components inside `apps/richdocuments/`:
+
+```
+src/
+  overview.js                         # bootstrap (mounts <OverviewApp/>)
+  views/Overview/
+    OverviewApp.vue                   # NcAppNavigation + NcAppContent + <router-view/>
+    HomeView.vue
+    RecentView.vue
+    SharedView.vue
+    TemplatesView.vue
+    DocumentRow.vue                   # shared row
+    TemplateRow.vue
+    CreateFromTemplateModal.vue
+    SearchBar.vue
+    composables/
+      useInfiniteScroll.ts
+      useOverviewApi.ts
+```
+
+Add to `webpack.js`:
+```js
+overview: path.join(__dirname, 'src', 'overview.js'),
+```
+
+Use `@nextcloud/vue` components (`NcAppNavigation`, `NcAppContent`, `NcAppNavigationItem`, `NcAvatar`, `NcButton`, `NcModal`, `NcTextField`, `NcEmptyContent`, `NcLoadingIcon`) and `@nextcloud/files` for the folder picker.
+
+## 12. Backend file layout
+
+New PHP files under `apps/richdocuments/lib/`:
+
+```
+Controller/
+  OverviewController.php              # renders SPA shell at /overview*
+  OverviewApiController.php           # OCS endpoints
+Service/
+  OverviewService.php                 # query logic for recent / shared
+  TemplateOverviewService.php         # delegates to existing templates service
+```
+
+Wire up:
+- `appinfo/routes.php`: routes for `overview.index`, `overviewApi.recent`, `overviewApi.shared`, `overviewApi.templates`, `overviewApi.createFromTemplate`. The `overview.index` route uses a wildcard to catch all sub-paths (Vue Router handles them).
+- `appinfo/info.xml`: add `<navigations><navigation>` with `<route>richdocuments.overview.index</route>`, `<name>Office</name>`, `<icon>app.svg</icon>` (or whatever the existing icon file is).
+
+## 13. Out of scope for v1
+- Sortable column headers (newest-first is fixed).
+- Right-click / context menu actions (share, rename, delete, open folder).
+- Hover preview / quick look.
+- Filter by file type chip-bar.
+- Pinning / favouriting.
+- System / admin templates and `emptyTemplates/` seeds in the Templates view.
+- Tracking which public-link-shared docs the user has opened.
+- Multi-select / bulk actions.
+- Activity-app integration.
+- Admin toggle to disable the overview entry.
+
+## 14. Acceptance checklist
+- [ ] Overview entry appears in the top app menu for any user with richdocuments enabled.
+- [ ] Clicking it lands on Home at `/apps/richdocuments/overview`.
+- [ ] Home shows three sections, each with up to 6 newest-first items.
+- [ ] Each "See all →" routes to the corresponding dedicated view.
+- [ ] Dedicated views paginate 25-at-a-time with infinite scroll.
+- [ ] Search box filters by filename + folder path, debounced 250 ms, server-side.
+- [ ] Clicking a doc opens it in Collabora in the same tab.
+- [ ] Clicking a template opens the Create-from-template modal; on Create the new doc is saved to the chosen folder and opened.
+- [ ] Only `.docx`, `.xlsx`, `.pptx`, `.odt`, `.ods`, `.odp`, `.pdf` are surfaced.
+- [ ] Only files with `mtime > now() − 60 d` appear in Recent / Shared.
+- [ ] Shared with me includes user / group / circle / federated shares; excludes public link shares.
+- [ ] PDFs are included and open in Collabora's PDF viewer.
+- [ ] Layout is usable on mobile (drawer nav + condensed rows).
+- [ ] Empty / loading / error states render per §10.

--- a/lib/Controller/OverviewApiController.php
+++ b/lib/Controller/OverviewApiController.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Controller;
+
+use InvalidArgumentException;
+use OCA\Richdocuments\Service\OverviewService;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSBadRequestException;
+use OCP\AppFramework\OCS\OCSException;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\AppFramework\OCSController;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OCS endpoints powering the Overview page.
+ *
+ * All endpoints require an authenticated user (no public access). The
+ * Nextcloud OCS framework adds CSRF protection, brute-force throttling,
+ * and rate limiting. Inputs are coerced to safe types here and validated
+ * deeper in OverviewService.
+ */
+class OverviewApiController extends OCSController {
+	private const MAX_QUERY_LENGTH = 200;
+	private const MAX_FILENAME_LENGTH = 200;
+	private const MAX_FOLDER_PATH_LENGTH = 4000;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private OverviewService $service,
+		private ?string $userId,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @throws OCSForbiddenException when called by a guest
+	 */
+	#[NoAdminRequired]
+	public function recent(?string $q = null, ?string $type = null, int $offset = 0, int $limit = 0): DataResponse {
+		$this->requireUser();
+		[$q, $type, $offset, $limit] = $this->normalizeListParams($q, $type, $offset, $limit);
+		return new DataResponse($this->service->getRecent($this->userId, $q, $type, $offset, $limit));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @throws OCSForbiddenException when called by a guest
+	 */
+	#[NoAdminRequired]
+	public function shared(?string $q = null, ?string $type = null, int $offset = 0, int $limit = 0): DataResponse {
+		$this->requireUser();
+		[$q, $type, $offset, $limit] = $this->normalizeListParams($q, $type, $offset, $limit);
+		return new DataResponse($this->service->getShared($this->userId, $q, $type, $offset, $limit));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @throws OCSForbiddenException when called by a guest
+	 */
+	#[NoAdminRequired]
+	public function templates(?string $q = null, ?string $type = null, int $offset = 0, int $limit = 0): DataResponse {
+		$this->requireUser();
+		[$q, $type, $offset, $limit] = $this->normalizeListParams($q, $type, $offset, $limit);
+		return new DataResponse($this->service->getTemplates($this->userId, $q, $type, $offset, $limit));
+	}
+
+	/**
+	 * Toggle "favourite" status for a file the current user can see.
+	 * Pins / unpins the file in the overview list.
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @throws OCSBadRequestException invalid arguments
+	 * @throws OCSNotFoundException   file not visible to the user
+	 * @throws OCSForbiddenException  guest call
+	 */
+	#[NoAdminRequired]
+	public function favourite(int $fileid = 0, bool $favorite = false): DataResponse {
+		$this->requireUser();
+		if ($fileid <= 0) {
+			throw new OCSBadRequestException('fileid is required');
+		}
+		try {
+			$this->service->setFavourite($this->userId, $fileid, $favorite);
+		} catch (NotFoundException) {
+			throw new OCSNotFoundException();
+		} catch (\Throwable $e) {
+			$this->logger->error('Overview: failed to toggle favourite', [
+				'exception' => $e,
+				'app' => 'richdocuments',
+			]);
+			throw new OCSException('Failed to toggle favourite');
+		}
+		return new DataResponse(['fileid' => $fileid, 'favorite' => $favorite]);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * @throws OCSBadRequestException invalid arguments
+	 * @throws OCSNotFoundException   template or folder missing
+	 * @throws OCSForbiddenException  no write permission on folder
+	 * @throws OCSException           unexpected server error
+	 */
+	#[NoAdminRequired]
+	public function createFromTemplate(int $templateFileId = 0, string $filename = '', string $folderPath = '/'): DataResponse {
+		$this->requireUser();
+
+		if ($templateFileId <= 0) {
+			throw new OCSBadRequestException('templateFileId is required');
+		}
+		$filename = trim($filename);
+		if ($filename === '' || mb_strlen($filename) > self::MAX_FILENAME_LENGTH) {
+			throw new OCSBadRequestException('filename is required and must be <= ' . self::MAX_FILENAME_LENGTH . ' characters');
+		}
+		if (mb_strlen($folderPath) > self::MAX_FOLDER_PATH_LENGTH) {
+			throw new OCSBadRequestException('folderPath is too long');
+		}
+
+		try {
+			$result = $this->service->createFromTemplate($this->userId, $templateFileId, $filename, $folderPath);
+			return new DataResponse($result);
+		} catch (NotFoundException) {
+			throw new OCSNotFoundException('Template or target folder not found');
+		} catch (NotPermittedException) {
+			throw new OCSForbiddenException('No permission to create file in target folder');
+		} catch (InvalidArgumentException $e) {
+			throw new OCSBadRequestException($e->getMessage());
+		} catch (\Throwable $e) {
+			$this->logger->error('Overview: failed to create document from template', [
+				'exception' => $e,
+				'app' => 'richdocuments',
+			]);
+			throw new OCSException('Failed to create document from template');
+		}
+	}
+
+	/**
+	 * @return array{0: ?string, 1: ?string, 2: int, 3: int}
+	 */
+	private function normalizeListParams(?string $q, ?string $type, int $offset, int $limit): array {
+		// Normalize search string.
+		if ($q !== null) {
+			$q = trim($q);
+			if ($q === '') {
+				$q = null;
+			} elseif (mb_strlen($q) > self::MAX_QUERY_LENGTH) {
+				$q = mb_substr($q, 0, self::MAX_QUERY_LENGTH);
+			}
+		}
+
+		// Validate the type filter strictly: only known group keys (or "all"
+		// / null) are accepted. Anything else collapses to null so a stray
+		// query param can never widen the result set unexpectedly.
+		if ($type !== null) {
+			$type = trim($type);
+			if ($type === '' || $type === 'all') {
+				$type = null;
+			} elseif (!array_key_exists($type, OverviewService::TYPE_GROUPS)) {
+				$type = null;
+			}
+		}
+
+		// Clamp pagination. Server caps at PAGE_SIZE; clients can ask for less but not more.
+		$offset = max(0, $offset);
+		$limit = $limit <= 0 ? OverviewService::PAGE_SIZE : min(max(1, $limit), OverviewService::PAGE_SIZE);
+
+		return [$q, $type, $offset, $limit];
+	}
+
+	/**
+	 * @throws OCSForbiddenException
+	 */
+	private function requireUser(): void {
+		if ($this->userId === null || $this->userId === '') {
+			throw new OCSForbiddenException();
+		}
+	}
+}

--- a/lib/Controller/OverviewController.php
+++ b/lib/Controller/OverviewController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Controller;
+
+use OCA\Richdocuments\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IRequest;
+
+/**
+ * Renders the SPA shell that hosts the Vue overview app.
+ *
+ * The Vue router takes over once the shell is mounted, so a single route
+ * handles every overview path (Home, Recent, Shared, Templates).
+ */
+class OverviewController extends Controller {
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private IInitialState $initialState,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	public function index(): TemplateResponse {
+		$this->initialState->provideInitialState('overview', [
+			'pageSize' => \OCA\Richdocuments\Service\OverviewService::PAGE_SIZE,
+			'homeSectionLimit' => \OCA\Richdocuments\Service\OverviewService::HOME_SECTION_LIMIT,
+			'windowDays' => \OCA\Richdocuments\Service\OverviewService::RECENT_WINDOW_DAYS,
+		]);
+
+		return new TemplateResponse(Application::APPNAME, 'overview', [], TemplateResponse::RENDER_AS_USER);
+	}
+}

--- a/lib/Service/OverviewService.php
+++ b/lib/Service/OverviewService.php
@@ -1,0 +1,639 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Service;
+
+use OC\Files\Search\SearchBinaryOperator;
+use OC\Files\Search\SearchComparison;
+use OC\Files\Search\SearchOrder;
+use OC\Files\Search\SearchQuery;
+use OCA\Richdocuments\TemplateManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
+use OCP\Files\Search\ISearchComparison;
+use OCP\Files\Search\ISearchOrder;
+use OCP\IDBConnection;
+use OCP\ITagManager;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\Share\IManager as IShareManager;
+use OCP\Share\IShare;
+
+/**
+ * Service powering the Overview page (recent / shared / templates).
+ *
+ * Design notes:
+ *   - "Recent" and "Shared with me" are both backed by the same indexed
+ *     search across the user's folder. Files mounted from incoming shares
+ *     (user/group/circle/federated) appear in the user's folder
+ *     automatically, so we partition the search results by file owner:
+ *     owner == current user -> recent, owner != current user -> shared.
+ *     This keeps the query plan single-shot and predictable.
+ *   - Pagination is offset-based, server-capped at 25 per request. Within
+ *     a single 60-day window with a mimetype filter the result count is
+ *     bounded enough that offset drift is acceptable.
+ *   - Search predicate matches against name and path (both stored in the
+ *     file cache); we apply it as a server-side LIKE filter.
+ */
+class OverviewService {
+	public const PAGE_SIZE = 25;
+	public const HOME_SECTION_LIMIT = 6;
+	public const RECENT_WINDOW_DAYS = 60;
+
+	/**
+	 * MIME-type groups exposed to the frontend as filter pills.
+	 *
+	 * The frontend sends the group key (e.g. "documents") and the service
+	 * narrows the search to that subset. Unknown values are ignored.
+	 */
+	public const TYPE_GROUPS = [
+		'documents' => [
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+			'application/vnd.oasis.opendocument.text',
+		],
+		'spreadsheets' => [
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+			'application/vnd.oasis.opendocument.spreadsheet',
+		],
+		'presentations' => [
+			'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+			'application/vnd.oasis.opendocument.presentation',
+		],
+		'pdfs' => [
+			'application/pdf',
+		],
+	];
+
+	/**
+	 * MIME types the overview surfaces (docx/xlsx/pptx/odt/ods/odp/pdf).
+	 * Built from TYPE_GROUPS so the two stay in sync by construction.
+	 *
+	 * @var list<string>
+	 */
+	public const ALLOWED_MIMETYPES = [
+		'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+		'application/vnd.oasis.opendocument.text',
+		'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+		'application/vnd.oasis.opendocument.spreadsheet',
+		'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+		'application/vnd.oasis.opendocument.presentation',
+		'application/pdf',
+	];
+
+	public function __construct(
+		private IRootFolder $rootFolder,
+		private IShareManager $shareManager,
+		private IUserManager $userManager,
+		private IURLGenerator $urlGenerator,
+		private TemplateManager $templateManager,
+		private IDBConnection $db,
+		private ITimeFactory $timeFactory,
+		private ITagManager $tagManager,
+	) {
+	}
+
+	/**
+	 * Files in the user's storage that the user owns and were modified
+	 * within the recent window.
+	 *
+	 * @return array{items: array<int, array<string, mixed>>, nextOffset: ?int}
+	 */
+	public function getRecent(string $userId, ?string $query, ?string $type, int $offset, int $limit): array {
+		return $this->getOwnedOrShared($userId, $query, $type, $offset, $limit, true);
+	}
+
+	/**
+	 * Files reachable through incoming shares (user/group/circle/federated)
+	 * that were modified within the recent window.
+	 *
+	 * @return array{items: array<int, array<string, mixed>>, nextOffset: ?int}
+	 */
+	public function getShared(string $userId, ?string $query, ?string $type, int $offset, int $limit): array {
+		return $this->getOwnedOrShared($userId, $query, $type, $offset, $limit, false);
+	}
+
+	/**
+	 * Templates the user has defined in their personal templates folder.
+	 *
+	 * @return array{items: array<int, array<string, mixed>>, nextOffset: ?int}
+	 */
+	public function getTemplates(string $userId, ?string $query, ?string $type, int $offset, int $limit): array {
+		$this->templateManager->setUserId($userId);
+		$templates = $this->templateManager->getUser();
+
+		// Allowed template mimes: the office mimes we surface plus their
+		// equivalent template mime types (.ott, .otp, ots, .dotx, .pptx-template, etc.)
+		$baseAllowed = array_merge(
+			self::ALLOWED_MIMETYPES,
+			TemplateManager::MIMES_DOCUMENTS,
+			TemplateManager::MIMES_SHEETS,
+			TemplateManager::MIMES_PRESENTATIONS,
+		);
+		$allowed = $this->resolveTemplateTypeFilter($type, $baseAllowed);
+
+		$templates = array_values(array_filter(
+			$templates,
+			fn (File $file): bool => in_array($file->getMimeType(), $allowed, true),
+		));
+
+		if ($query !== null && $query !== '') {
+			$needle = mb_strtolower($query);
+			$templates = array_values(array_filter($templates, function (File $file) use ($needle): bool {
+				return mb_strpos(mb_strtolower($file->getName()), $needle) !== false;
+			}));
+		}
+
+		// Sort by name asc for stable, browseable order.
+		usort($templates, fn (File $a, File $b): int => strnatcasecmp($a->getName(), $b->getName()));
+
+		$slice = array_slice($templates, $offset, $limit);
+		$items = array_map(fn (File $file): array => $this->serializeTemplate($file), $slice);
+
+		$nextOffset = ($offset + $limit) < count($templates) ? ($offset + $limit) : null;
+		return ['items' => $items, 'nextOffset' => $nextOffset];
+	}
+
+	/**
+	 * Resolve a template node by id. Used by the create-from-template
+	 * endpoint to validate that a template exists before copying.
+	 *
+	 * @throws NotFoundException
+	 */
+	public function getTemplateNode(string $userId, int $templateId): File {
+		$this->templateManager->setUserId($userId);
+		$file = $this->templateManager->get($templateId);
+		if (!($file instanceof File)) {
+			throw new NotFoundException();
+		}
+		return $file;
+	}
+
+	/**
+	 * Create a new file from a template by copying the template content
+	 * into the chosen folder, auto-resolving filename collisions.
+	 *
+	 * Returns the created file together with a frontend-ready open URL.
+	 *
+	 * @return array{fileid: int, name: string, path: string, openUrl: string}
+	 *
+	 * @throws NotFoundException             folder or template missing
+	 * @throws \OCP\Files\NotPermittedException no write permission
+	 */
+	public function createFromTemplate(
+		string $userId,
+		int $templateId,
+		string $filename,
+		string $folderPath,
+	): array {
+		$template = $this->getTemplateNode($userId, $templateId);
+		$userFolder = $this->rootFolder->getUserFolder($userId);
+
+		$folderPath = $folderPath === '' ? '/' : $folderPath;
+		$folder = $userFolder->get($folderPath);
+		if (!($folder instanceof Folder)) {
+			throw new NotFoundException('Target is not a folder');
+		}
+
+		// Build the full filename using the template's extension.
+		$extension = $this->extensionFromMime($template->getMimeType()) ?? pathinfo($template->getName(), PATHINFO_EXTENSION);
+		$basename = $this->sanitizeFilename($filename);
+		if ($basename === '') {
+			throw new \InvalidArgumentException('Empty filename');
+		}
+		$fullName = $extension !== '' ? $basename . '.' . $extension : $basename;
+		$fullName = $folder->getNonExistingName($fullName);
+
+		$newFile = $folder->newFile($fullName, $template->fopen('rb'));
+
+		return [
+			'fileid' => $newFile->getId(),
+			'name' => $newFile->getName(),
+			'path' => $userFolder->getRelativePath($newFile->getPath()),
+			'openUrl' => $this->urlGenerator->linkToRoute('richdocuments.document.index', [
+				'fileId' => $newFile->getId(),
+			]),
+		];
+	}
+
+	/**
+	 * Shared core: search the user's folder, partition by ownership.
+	 *
+	 * @return array{items: array<int, array<string, mixed>>, nextOffset: ?int}
+	 */
+	private function getOwnedOrShared(string $userId, ?string $query, ?string $type, int $offset, int $limit, bool $ownedOnly): array {
+		$userFolder = $this->rootFolder->getUserFolder($userId);
+
+		$cutoff = time() - (self::RECENT_WINDOW_DAYS * 86400);
+
+		$activeMimetypes = $this->resolveTypeFilter($type);
+
+		// Build the SearchQuery: mimetype IN (...) AND mtime >= cutoff [AND name|path LIKE ?].
+		$mimeOps = array_map(
+			fn (string $mime) => new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mimetype', $mime),
+			$activeMimetypes,
+		);
+		$conditions = [
+			new SearchBinaryOperator(SearchBinaryOperator::OPERATOR_OR, $mimeOps),
+			new SearchComparison(ISearchComparison::COMPARE_GREATER_THAN_EQUAL, 'mtime', $cutoff),
+		];
+
+		if ($query !== null && $query !== '') {
+			// Match against filename or path (both stored in oc_filecache).
+			$like = '%' . $this->escapeLike($query) . '%';
+			$conditions[] = new SearchBinaryOperator(SearchBinaryOperator::OPERATOR_OR, [
+				new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', $like),
+				new SearchComparison(ISearchComparison::COMPARE_LIKE, 'path', $like),
+			]);
+		}
+
+		// We need to over-fetch so we can post-filter by ownership and still
+		// fill the requested page. Cap the over-fetch to keep memory bounded.
+		$searchLimit = max($limit * 8, 200);
+		$searchOffset = $offset * 0; // We can't reliably translate offsets after partitioning; we re-scan.
+
+		/** @var \OCP\Files\Search\ISearchQuery $searchQuery */
+		$searchQuery = new SearchQuery(
+			new SearchBinaryOperator(SearchBinaryOperator::OPERATOR_AND, $conditions),
+			$searchLimit + $offset,
+			$searchOffset,
+			[new SearchOrder(ISearchOrder::DIRECTION_DESCENDING, 'mtime')],
+			$this->userManager->get($userId),
+		);
+
+		/** @var Node[] $results */
+		$results = $userFolder->search($searchQuery);
+
+		// Partition by ownership.
+		$matched = [];
+		foreach ($results as $node) {
+			if (!($node instanceof File)) {
+				continue;
+			}
+			try {
+				$ownerUid = $node->getOwner()?->getUID();
+			} catch (\Throwable) {
+				$ownerUid = null;
+			}
+			$isOwned = $ownerUid === $userId;
+			if ($ownedOnly === $isOwned) {
+				$matched[] = $node;
+			}
+		}
+
+		$total = count($matched);
+		$slice = array_slice($matched, $offset, $limit);
+
+		// Batch-load active editors and favourites for the page so we don't
+		// issue one query per row.
+		$fileIds = array_map(fn (File $node): int => $node->getId(), $slice);
+		$editorsByFileId = $this->getActiveEditors($fileIds);
+		$favouriteIds = $this->getFavouriteFileIds($userId, $fileIds);
+
+		$items = [];
+		foreach ($slice as $node) {
+			$items[] = $this->serializeNode(
+				$node,
+				$userId,
+				$userFolder,
+				!$ownedOnly,
+				$editorsByFileId[$node->getId()] ?? [],
+				in_array($node->getId(), $favouriteIds, true),
+			);
+		}
+
+		$nextOffset = ($offset + $limit) < $total ? ($offset + $limit) : null;
+
+		return ['items' => $items, 'nextOffset' => $nextOffset];
+	}
+
+	/**
+	 * Project a file node into the JSON shape consumed by the frontend.
+	 *
+	 * @param list<array{uid: ?string, displayName: string}> $currentEditors
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function serializeNode(File $node, string $userId, Folder $userFolder, bool $includeShareSource, array $currentEditors, bool $favorite): array {
+		$relPath = $userFolder->getRelativePath($node->getPath()) ?? $node->getName();
+		$folder = ltrim(dirname($relPath), '.');
+		if ($folder === '' || $folder === '/') {
+			$folder = '/';
+		}
+
+		$ownerUid = null;
+		$ownerDisplay = null;
+		try {
+			$owner = $node->getOwner();
+			if ($owner !== null) {
+				$ownerUid = $owner->getUID();
+				$ownerDisplay = $owner->getDisplayName();
+			}
+		} catch (\Throwable) {
+			// owner unavailable for some federated mounts
+		}
+
+		$shareSource = null;
+		if ($includeShareSource) {
+			$shareSource = $this->resolveShareSource($node, $userId);
+		}
+
+		return [
+			'fileid' => $node->getId(),
+			'name' => $node->getName(),
+			'path' => $relPath,
+			'folder' => $folder,
+			'mimetype' => $node->getMimeType(),
+			'size' => $node->getSize(),
+			'mtime' => $node->getMTime(),
+			'modifiedBy' => [
+				'uid' => $ownerUid,
+				'displayName' => $ownerDisplay ?? $ownerUid ?? '',
+			],
+			'thumbnailUrl' => $this->urlGenerator->linkToRoute('core.Preview.getPreviewByFileId', [
+				'fileId' => $node->getId(),
+				'x' => 64,
+				'y' => 64,
+				'a' => 1,
+				'forceIcon' => 1,
+			]),
+			'openUrl' => $this->urlGenerator->linkToRoute('richdocuments.document.index', [
+				'fileId' => $node->getId(),
+			]),
+			'shareSource' => $shareSource,
+			'currentEditors' => $currentEditors,
+			'favorite' => $favorite,
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function serializeTemplate(File $file): array {
+		return [
+			'fileid' => $file->getId(),
+			'name' => $file->getName(),
+			'mimetype' => $file->getMimeType(),
+			'extension' => pathinfo($file->getName(), PATHINFO_EXTENSION),
+			'thumbnailUrl' => $this->urlGenerator->linkToRoute('richdocuments.templates.getPreview', [
+				'fileId' => $file->getId(),
+				'x' => 96,
+				'y' => 96,
+			]),
+		];
+	}
+
+	/**
+	 * Toggle the user's "favourite" status for the given file. The frontend
+	 * uses this to pin documents to the top of the overview lists.
+	 *
+	 * Validates that the user can actually see the file before tagging,
+	 * to avoid letting one user mark another's file as a favourite via a
+	 * guessed file id.
+	 *
+	 * @throws NotFoundException when the file is not visible to this user
+	 */
+	public function setFavourite(string $userId, int $fileId, bool $favourite): void {
+		$userFolder = $this->rootFolder->getUserFolder($userId);
+		$node = $userFolder->getFirstNodeById($fileId);
+		if ($node === null) {
+			throw new NotFoundException();
+		}
+		$tags = $this->tagManager->load('files', [], false, $userId);
+		if ($favourite) {
+			$tags->addToFavorites($fileId);
+		} else {
+			$tags->removeFromFavorites($fileId);
+		}
+	}
+
+	/**
+	 * Filter the given file ids down to those tagged as favourite by the
+	 * current user.
+	 *
+	 * @param list<int> $fileIds
+	 * @return list<int>
+	 */
+	private function getFavouriteFileIds(string $userId, array $fileIds): array {
+		if ($fileIds === []) {
+			return [];
+		}
+		try {
+			$tags = $this->tagManager->load('files', [], false, $userId);
+			$favouriteIds = $tags->getFavorites();
+		} catch (\Throwable) {
+			return [];
+		}
+		return array_values(array_intersect($fileIds, array_map('intval', $favouriteIds)));
+	}
+
+	/**
+	 * Look up users currently holding a non-expired writable WOPI token for
+	 * each given file id. The richdocuments_wopi table grows on every open
+	 * and entries are aged out by `expiry`; a non-expired write token is the
+	 * best proxy we have for "someone is editing this right now."
+	 *
+	 * Edge cases: a user who closes their browser without an explicit
+	 * disconnect will still appear as an editor until the token expires.
+	 * That's accepted; the alternative (live presence pings) is out of
+	 * scope for v1 and would require an event channel.
+	 *
+	 * @param list<int> $fileIds
+	 * @return array<int, list<array{uid: ?string, displayName: string}>>
+	 */
+	private function getActiveEditors(array $fileIds): array {
+		if ($fileIds === []) {
+			return [];
+		}
+		$now = $this->timeFactory->getTime();
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->selectDistinct(['fileid', 'editor_uid', 'guest_displayname'])
+			->from('richdocuments_wopi')
+			->where($qb->expr()->in('fileid', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($qb->expr()->eq('canwrite', $qb->createNamedParameter(true, IQueryBuilder::PARAM_BOOL)))
+			->andWhere($qb->expr()->gt('expiry', $qb->createNamedParameter($now, IQueryBuilder::PARAM_INT)));
+
+		$result = $qb->executeQuery();
+
+		// Aggregate, deduping by uid (or by guest display name when uid is null).
+		/** @var array<int, array<string, array{uid: ?string, displayName: string}>> $byFile */
+		$byFile = [];
+		while ($row = $result->fetch()) {
+			$fileId = (int)$row['fileid'];
+			$editorUid = $row['editor_uid'] !== null && $row['editor_uid'] !== '' ? (string)$row['editor_uid'] : null;
+			$guestName = $row['guest_displayname'] !== null ? (string)$row['guest_displayname'] : '';
+			$key = $editorUid ?? ('guest:' . $guestName);
+			if ($key === 'guest:') {
+				continue;
+			}
+			$byFile[$fileId][$key] = [
+				'uid' => $editorUid,
+				'displayName' => $editorUid !== null
+					? ($this->userManager->get($editorUid)?->getDisplayName() ?? $editorUid)
+					: $guestName,
+			];
+		}
+		$result->closeCursor();
+
+		// Drop the dedup keys; preserve a stable, alphabetical order so the
+		// frontend renders consistently across reloads.
+		$out = [];
+		foreach ($byFile as $fileId => $editors) {
+			$values = array_values($editors);
+			usort($values, fn (array $a, array $b): int => strnatcasecmp($a['displayName'], $b['displayName']));
+			$out[$fileId] = $values;
+		}
+		return $out;
+	}
+
+	/**
+	 * Map a frontend filter key (e.g. "documents") to the mime list used in
+	 * the search predicate. Unknown / null falls back to the full set.
+	 *
+	 * @return list<string>
+	 */
+	private function resolveTypeFilter(?string $type): array {
+		if ($type === null || $type === '' || $type === 'all') {
+			return self::ALLOWED_MIMETYPES;
+		}
+		return self::TYPE_GROUPS[$type] ?? self::ALLOWED_MIMETYPES;
+	}
+
+	/**
+	 * Variant of resolveTypeFilter() for templates: extends each office
+	 * group with the matching .ott / .ots / .otp / .dotx etc. template
+	 * mime types so user-saved template files are included.
+	 *
+	 * @param list<string> $base full allowed mime list (no type filter)
+	 * @return list<string>
+	 */
+	private function resolveTemplateTypeFilter(?string $type, array $base): array {
+		if ($type === null || $type === '' || $type === 'all') {
+			return $base;
+		}
+		// Templates can never be PDF; gracefully ignore.
+		if ($type === 'pdfs') {
+			return [];
+		}
+		$mimes = self::TYPE_GROUPS[$type] ?? null;
+		if ($mimes === null) {
+			return $base;
+		}
+		return match ($type) {
+			'documents' => array_values(array_unique(array_merge($mimes, TemplateManager::MIMES_DOCUMENTS))),
+			'spreadsheets' => array_values(array_unique(array_merge($mimes, TemplateManager::MIMES_SHEETS))),
+			'presentations' => array_values(array_unique(array_merge($mimes, TemplateManager::MIMES_PRESENTATIONS))),
+			default => $base,
+		};
+	}
+
+	/**
+	 * Best-effort lookup of the share that brought a node into the user's
+	 * folder. Used to label "Shared with me" rows with share metadata.
+	 *
+	 * Federated remote-server detection is left null for v1 because the
+	 * IShare interface exposes the federated source only on dedicated
+	 * external-share entries; we surface what we have today and degrade
+	 * gracefully on missing fields.
+	 *
+	 * @return array{type: string, displayName: string, remoteServer: ?string}|null
+	 */
+	private function resolveShareSource(File $node, string $userId): ?array {
+		$types = [
+			IShare::TYPE_USER,
+			IShare::TYPE_GROUP,
+			IShare::TYPE_CIRCLE,
+			IShare::TYPE_REMOTE,
+			IShare::TYPE_REMOTE_GROUP,
+		];
+
+		foreach ($types as $type) {
+			try {
+				$shares = $this->shareManager->getSharedWith($userId, $type, $node, 1, 0);
+			} catch (\Throwable) {
+				continue;
+			}
+			foreach ($shares as $share) {
+				$ownerUid = $share->getShareOwner();
+				$ownerDisplay = $ownerUid;
+				$ownerUser = $this->userManager->get($ownerUid);
+				if ($ownerUser !== null) {
+					$ownerDisplay = $ownerUser->getDisplayName();
+				}
+				$remoteServer = null;
+				if ($type === IShare::TYPE_REMOTE || $type === IShare::TYPE_REMOTE_GROUP) {
+					// Federated share owners are stored as user@server.
+					if (str_contains((string)$ownerUid, '@')) {
+						$remoteServer = substr($ownerUid, strrpos($ownerUid, '@') + 1);
+					}
+				}
+				return [
+					'type' => $this->shareTypeLabel($type),
+					'displayName' => $ownerDisplay ?: (string)$ownerUid,
+					'remoteServer' => $remoteServer,
+				];
+			}
+		}
+		return null;
+	}
+
+	private function shareTypeLabel(int $type): string {
+		return match ($type) {
+			IShare::TYPE_USER => 'user',
+			IShare::TYPE_GROUP => 'group',
+			IShare::TYPE_CIRCLE => 'circle',
+			IShare::TYPE_REMOTE, IShare::TYPE_REMOTE_GROUP => 'federated',
+			default => 'user',
+		};
+	}
+
+	/**
+	 * Strip path separators / control characters / leading dots from a
+	 * user-supplied filename. The caller appends the extension separately.
+	 */
+	private function sanitizeFilename(string $name): string {
+		$name = trim($name);
+		// Disallow path traversal and shell-meta characters.
+		$name = preg_replace('#[\\\\/\\x00-\\x1F\\x7F]#u', '', $name) ?? '';
+		$name = ltrim($name, '.');
+		// Avoid Windows-reserved names just in case.
+		if (preg_match('/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i', $name)) {
+			$name = '_' . $name;
+		}
+		// Cap length so we never exceed OS / DB limits.
+		if (mb_strlen($name) > 200) {
+			$name = mb_substr($name, 0, 200);
+		}
+		return $name;
+	}
+
+	private function escapeLike(string $value): string {
+		// Backslash-escape the LIKE wildcards so user input can't broaden the search.
+		return addcslashes($value, '\\%_');
+	}
+
+	private function extensionFromMime(string $mime): ?string {
+		return match ($mime) {
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document' => 'docx',
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' => 'xlsx',
+			'application/vnd.openxmlformats-officedocument.presentationml.presentation' => 'pptx',
+			'application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.text-template' => 'odt',
+			'application/vnd.oasis.opendocument.spreadsheet', 'application/vnd.oasis.opendocument.spreadsheet-template' => 'ods',
+			'application/vnd.oasis.opendocument.presentation', 'application/vnd.oasis.opendocument.presentation-template' => 'odp',
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.template' => 'docx',
+			'application/vnd.openxmlformats-officedocument.spreadsheetml.template' => 'xlsx',
+			'application/vnd.openxmlformats-officedocument.presentationml.template' => 'pptx',
+			default => null,
+		};
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "@nextcloud/vue": "^8.33.0",
         "jquery": "^4.0.0",
         "vue": "^2.7.16",
-        "vue-material-design-icons": "^5.3.1"
+        "vue-material-design-icons": "^5.3.1",
+        "vue-router": "^3.6.5"
       },
       "devDependencies": {
         "@cypress/browserify-preprocessor": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@nextcloud/vue": "^8.33.0",
     "jquery": "^4.0.0",
     "vue": "^2.7.16",
-    "vue-material-design-icons": "^5.3.1"
+    "vue-material-design-icons": "^5.3.1",
+    "vue-router": "^3.6.5"
   },
   "browserslist": [
     "extends @nextcloud/browserslist-config"

--- a/src/overview.js
+++ b/src/overview.js
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import './init-shared.js'
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+import { generateUrl } from '@nextcloud/router'
+import { translate as t, translatePlural as n } from '@nextcloud/l10n'
+
+import OverviewApp from './views/Overview/OverviewApp.vue'
+import HomeView from './views/Overview/HomeView.vue'
+import RecentView from './views/Overview/RecentView.vue'
+import SharedView from './views/Overview/SharedView.vue'
+import TemplatesView from './views/Overview/TemplatesView.vue'
+import { mountHoverPreview } from './views/Overview/hoverPreviewMount.js'
+
+Vue.prototype.t = t
+Vue.prototype.n = n
+Vue.prototype.OC = OC
+Vue.prototype.OCA = OCA
+
+Vue.use(VueRouter)
+
+const router = new VueRouter({
+	mode: 'history',
+	// The Nextcloud route /apps/richdocuments/overview is the SPA shell;
+	// every sub-path (recent, shared, templates) is rendered client-side.
+	// No trailing slash here — vue-router 3 normalises base internally and
+	// matches the Files app pattern.
+	base: generateUrl('/apps/richdocuments/overview'),
+	routes: [
+		{ path: '/', name: 'home', component: HomeView },
+		{ path: '/recent', name: 'recent', component: RecentView },
+		{ path: '/shared', name: 'shared', component: SharedView },
+		{ path: '/templates', name: 'templates', component: TemplatesView },
+		{ path: '*', redirect: { name: 'home' } },
+	],
+})
+
+// Mount AT #content (replacing it) the same way the Files app does. NcContent
+// uses position:fixed and was designed to BE #content, so wrapping it inside
+// a child div makes it overlay the Nextcloud header / app menu instead of
+// sitting alongside them.
+const OverviewAppVue = Vue.extend(OverviewApp)
+new OverviewAppVue({
+	router,
+}).$mount('#content')
+
+// Singleton hover-preview popover lives directly under <body> so it
+// escapes the overflow:hidden / transform of cards and NcContent.
+mountHoverPreview()

--- a/src/views/Overview/CreateFromTemplateModal.vue
+++ b/src/views/Overview/CreateFromTemplateModal.vue
@@ -1,0 +1,328 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcDialog :open="true"
+		:name="t('richdocuments', 'New document from template')"
+		size="normal"
+		@update:open="onOpenUpdate">
+		<div class="create-modal">
+			<div class="create-modal__preview">
+				<img v-if="template.thumbnailUrl && !thumbErrored"
+					:src="template.thumbnailUrl"
+					:alt="''"
+					@error="thumbErrored = true">
+				<FileDocumentOutlineIcon v-else :size="64" />
+			</div>
+			<div class="create-modal__form">
+				<NcTextField :value.sync="filename"
+					:label="t('richdocuments', 'Filename')"
+					:placeholder="t('richdocuments', 'Filename')"
+					:error="!!filenameError"
+					:helper-text="filenameError || extensionLabel"
+					:disabled="busy"
+					@keydown.enter="submit" />
+
+				<div class="create-modal__folder">
+					<div class="create-modal__folder-label">
+						{{ t('richdocuments', 'Save to folder') }}
+					</div>
+					<button type="button"
+						class="create-modal__folder-button"
+						:disabled="busy"
+						@click="pickFolder">
+						<FolderIcon :size="20" />
+						<span class="create-modal__folder-path">{{ folderPath }}</span>
+					</button>
+				</div>
+
+				<div v-if="errorMessage" class="create-modal__error" role="alert">
+					{{ errorMessage }}
+				</div>
+			</div>
+		</div>
+
+		<template #actions>
+			<NcButton type="tertiary" :disabled="busy" @click="cancel">
+				{{ t('richdocuments', 'Cancel') }}
+			</NcButton>
+			<NcButton type="primary"
+				:disabled="!canSubmit"
+				@click="submit">
+				<template v-if="busy" #icon>
+					<NcLoadingIcon :size="20" />
+				</template>
+				{{ t('richdocuments', 'Create') }}
+			</NcButton>
+		</template>
+	</NcDialog>
+</template>
+
+<script>
+import NcDialog from '@nextcloud/vue/dist/Components/NcDialog.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import FolderIcon from 'vue-material-design-icons/Folder.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import { getFilePickerBuilder, FilePickerType, showSuccess } from '@nextcloud/dialogs'
+import moment from '@nextcloud/moment'
+import { createFromTemplate } from './api.js'
+import { fireConfetti } from './confetti.js'
+import { getDocumentUrlForFile } from '../../helpers/url.js'
+
+const STORAGE_KEY = 'richdocuments.overview.lastTemplateFolder'
+
+/**
+ * Default filename: template basename + current date.
+ * @param {object} template the template object
+ * @return {string} suggested filename
+ */
+function defaultFilename(template) {
+	const base = (template.name || '').replace(/\.[^.]+$/, '').trim() || t('richdocuments', 'New document')
+	return `${base} ${moment().format('YYYY-MM-DD')}`
+}
+
+/**
+ * Read the last-used target folder from localStorage.
+ * @return {string} folder path, defaulting to '/'
+ */
+function loadLastFolder() {
+	try {
+		const value = localStorage.getItem(STORAGE_KEY)
+		return value && typeof value === 'string' ? value : '/'
+	} catch {
+		return '/'
+	}
+}
+
+/**
+ * Persist the last-used target folder.
+ * @param {string} path absolute user-relative folder path
+ */
+function saveLastFolder(path) {
+	try {
+		localStorage.setItem(STORAGE_KEY, path)
+	} catch {
+		// localStorage may be disabled in private mode; non-fatal.
+	}
+}
+
+export default {
+	name: 'CreateFromTemplateModal',
+	components: { NcDialog, NcButton, NcTextField, NcLoadingIcon, FolderIcon, FileDocumentOutlineIcon },
+	props: {
+		template: { type: Object, required: true },
+	},
+	data() {
+		return {
+			filename: defaultFilename(this.template),
+			folderPath: loadLastFolder(),
+			busy: false,
+			errorMessage: '',
+			filenameError: '',
+			thumbErrored: false,
+		}
+	},
+	computed: {
+		extension() {
+			return this.template.extension || ''
+		},
+		extensionLabel() {
+			return this.extension
+				? t('richdocuments', 'Will be saved as .{ext}', { ext: this.extension })
+				: ''
+		},
+		canSubmit() {
+			return !this.busy && this.filename.trim().length > 0
+		},
+	},
+	watch: {
+		filename() {
+			this.filenameError = ''
+			this.errorMessage = ''
+		},
+	},
+	methods: {
+		onOpenUpdate(value) {
+			if (!value && !this.busy) {
+				this.cancel()
+			}
+		},
+		cancel() {
+			this.$emit('close')
+		},
+		async pickFolder() {
+			try {
+				const picker = getFilePickerBuilder(t('richdocuments', 'Select target folder'))
+					.startAt(this.folderPath || '/')
+					.setMultiSelect(false)
+					.setType(FilePickerType.Choose)
+					.allowDirectories(true)
+					.addMimeTypeFilter('httpd/unix-directory')
+					.build()
+				const result = await picker.pick()
+				const chosen = Array.isArray(result) ? result[0] : result
+				if (typeof chosen === 'string' && chosen.length > 0) {
+					this.folderPath = chosen
+				}
+			} catch {
+				// User cancelled — ignore.
+			}
+		},
+		validate() {
+			const trimmed = this.filename.trim()
+			if (!trimmed) {
+				this.filenameError = t('richdocuments', 'Filename is required')
+				return false
+			}
+			if (/[\\/]/.test(trimmed)) {
+				this.filenameError = t('richdocuments', 'Filename cannot contain slashes')
+				return false
+			}
+			if (trimmed.length > 200) {
+				this.filenameError = t('richdocuments', 'Filename is too long')
+				return false
+			}
+			return true
+		},
+		async submit() {
+			if (!this.validate() || !this.canSubmit) {
+				return
+			}
+			this.busy = true
+			this.errorMessage = ''
+			try {
+				const result = await createFromTemplate({
+					templateFileId: this.template.fileid,
+					filename: this.filename.trim(),
+					folderPath: this.folderPath || '/',
+				})
+				saveLastFolder(this.folderPath || '/')
+				// Tiny celebration before we hand off to the editor — the
+				// toast is announced to screen readers, the confetti is
+				// purely decorative and respects prefers-reduced-motion.
+				showSuccess(t('richdocuments', 'Created “{name}” — opening editor…', { name: result?.name ?? this.filename.trim() }))
+				fireConfetti()
+				if (result?.fileid) {
+					// Build the URL with the CSRF requesttoken; the
+					// document.index controller requires it on plain navigation.
+					const targetUrl = getDocumentUrlForFile(this.folderPath || '/', result.fileid)
+					// Brief delay so the user gets a glimpse of the celebration
+					// before the editor takes over.
+					window.setTimeout(() => {
+						window.location.href = targetUrl
+					}, 450)
+				}
+			} catch (e) {
+				const code = e?.response?.status
+				const remote = e?.response?.data?.ocs?.meta?.message
+				if (code === 403) {
+					this.errorMessage = t('richdocuments', 'No permission to create files in this folder.')
+				} else if (code === 404) {
+					this.errorMessage = t('richdocuments', 'The selected template or folder no longer exists.')
+				} else {
+					this.errorMessage = remote || t('richdocuments', 'Could not create the document. Please try again.')
+				}
+			} finally {
+				this.busy = false
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.create-modal {
+	display: flex;
+	gap: 24px;
+	align-items: flex-start;
+	padding: 8px 0 16px;
+
+	&__preview {
+		flex: 0 0 auto;
+		width: 96px;
+		height: 96px;
+		border-radius: var(--border-radius-large, 12px);
+		background-color: var(--color-background-dark);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--color-text-maxcontrast);
+		overflow: hidden;
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+	}
+
+	&__form {
+		flex: 1 1 auto;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+
+	&__folder {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	&__folder-label {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+	}
+	&__folder-button {
+		all: unset;
+		cursor: pointer;
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 8px 12px;
+		border-radius: var(--border-radius, 8px);
+		border: 1px solid var(--color-border);
+		color: var(--color-main-text);
+		min-width: 0;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: -2px;
+		}
+		&[disabled] {
+			cursor: not-allowed;
+			opacity: 0.6;
+		}
+	}
+	&__folder-path {
+		flex: 1 1 auto;
+		min-width: 0;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__error {
+		color: var(--color-error);
+		font-size: 0.9em;
+	}
+}
+
+@media (max-width: 540px) {
+	.create-modal {
+		flex-direction: column;
+		align-items: stretch;
+	}
+	.create-modal__preview {
+		align-self: center;
+	}
+}
+</style>

--- a/src/views/Overview/DocumentCard.vue
+++ b/src/views/Overview/DocumentCard.vue
@@ -1,0 +1,334 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<a class="doc-card"
+		:href="openUrl"
+		:style="typeStyles"
+		:title="document.name"
+		:aria-label="document.name"
+		@mouseenter="onHoverEnter"
+		@mouseleave="onHoverLeave"
+		@focus="onHoverLeave"
+		@blur="onHoverLeave">
+		<div class="doc-card__thumb">
+			<img v-if="!thumbErrored"
+				:src="thumbnailLargeUrl"
+				:alt="''"
+				loading="lazy"
+				@error="thumbErrored = true">
+			<component :is="fallbackIcon"
+				v-else
+				class="doc-card__thumb-icon"
+				:size="48" />
+			<EditorBadges v-if="hasEditors"
+				class="doc-card__editors"
+				:editors="document.currentEditors"
+				:size="22" />
+			<span v-if="extensionLabel" class="doc-card__type-badge">
+				{{ extensionLabel }}
+			</span>
+			<button class="doc-card__star"
+				type="button"
+				:class="{ 'doc-card__star--on': isFavorite }"
+				:aria-label="isFavorite
+					? t('richdocuments', 'Unpin from overview')
+					: t('richdocuments', 'Pin to overview')"
+				:title="isFavorite
+					? t('richdocuments', 'Unpin from overview')
+					: t('richdocuments', 'Pin to overview')"
+				@click.prevent.stop="toggleFavorite">
+				<StarIcon v-if="isFavorite" :size="18" />
+				<StarOutlineIcon v-else :size="18" />
+			</button>
+		</div>
+		<div class="doc-card__body">
+			<div class="doc-card__name">
+				{{ document.name }}
+			</div>
+			<div class="doc-card__meta">
+				<NcDateTime :timestamp="mtimeMs" :ignore-seconds="true" />
+				<span v-if="showOwner && ownerLabel" class="doc-card__owner">
+					· {{ ownerLabel }}
+				</span>
+			</div>
+		</div>
+
+	</a>
+</template>
+
+<script>
+import NcDateTime from '@nextcloud/vue/dist/Components/NcDateTime.js'
+import EditorBadges from './EditorBadges.vue'
+import hoverPreviewMixin from './hoverPreviewMixin.js'
+import { typeStyle } from './typeStyles.js'
+import { setFavourite } from './api.js'
+import { getDocumentUrlForFile } from '../../helpers/url.js'
+import StarIcon from 'vue-material-design-icons/Star.vue'
+import StarOutlineIcon from 'vue-material-design-icons/StarOutline.vue'
+import FileWordIcon from 'vue-material-design-icons/FileWord.vue'
+import FileExcelIcon from 'vue-material-design-icons/FileExcel.vue'
+import FilePresentationBoxIcon from 'vue-material-design-icons/FilePresentationBox.vue'
+import FilePdfBoxIcon from 'vue-material-design-icons/FilePdfBox.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+
+const ICON_BY_MIME = {
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': FileWordIcon,
+	'application/vnd.oasis.opendocument.text': FileWordIcon,
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': FileExcelIcon,
+	'application/vnd.oasis.opendocument.spreadsheet': FileExcelIcon,
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation': FilePresentationBoxIcon,
+	'application/vnd.oasis.opendocument.presentation': FilePresentationBoxIcon,
+	'application/pdf': FilePdfBoxIcon,
+}
+
+export default {
+	name: 'DocumentCard',
+	components: { NcDateTime, EditorBadges, StarIcon, StarOutlineIcon },
+	mixins: [hoverPreviewMixin],
+	props: {
+		document: { type: Object, required: true },
+		showOwner: { type: Boolean, default: false },
+	},
+	data() {
+		return {
+			thumbErrored: false,
+			localFavorite: !!this.document.favorite,
+			favoriteBusy: false,
+		}
+	},
+	computed: {
+		mtimeMs() {
+			return (this.document.mtime ?? 0) * 1000
+		},
+		fallbackIcon() {
+			return ICON_BY_MIME[this.document.mimetype] ?? FileDocumentOutlineIcon
+		},
+		hasEditors() {
+			return Array.isArray(this.document.currentEditors) && this.document.currentEditors.length > 0
+		},
+		typeStyles() {
+			return typeStyle(this.document.mimetype)
+		},
+		// Build the open URL with the CSRF requesttoken — the backend's
+		// document.index controller requires it on plain navigation.
+		openUrl() {
+			return getDocumentUrlForFile(this.document.folder ?? '/', this.document.fileid)
+		},
+		extensionLabel() {
+			const m = /\.([^.]+)$/.exec(this.document.name || '')
+			return m ? m[1].toUpperCase() : ''
+		},
+		isFavorite() {
+			return this.localFavorite
+		},
+		// Use a larger preview for the card surface — the URL is generated
+		// server-side; we adjust the x/y query params to ask for a bigger one.
+		thumbnailLargeUrl() {
+			if (!this.document.thumbnailUrl) {
+				return ''
+			}
+			return this.document.thumbnailUrl
+				.replace(/([?&])x=\d+/, '$1x=256')
+				.replace(/([?&])y=\d+/, '$1y=256')
+		},
+		// Even larger thumbnail used by the hover-preview popover.
+		largePreviewUrl() {
+			if (!this.document.thumbnailUrl) {
+				return ''
+			}
+			return this.document.thumbnailUrl
+				.replace(/([?&])x=\d+/, '$1x=480')
+				.replace(/([?&])y=\d+/, '$1y=480')
+		},
+		ownerLabel() {
+			const source = this.document.shareSource
+			const display = this.document.modifiedBy?.displayName
+				?? source?.displayName
+				?? ''
+			if (source && source.remoteServer) {
+				return t('richdocuments', '{name} ({server})', {
+					name: display,
+					server: source.remoteServer,
+				})
+			}
+			return display
+		},
+	},
+	watch: {
+		'document.favorite'(value) {
+			this.localFavorite = !!value
+		},
+	},
+	methods: {
+		async toggleFavorite() {
+			if (this.favoriteBusy) {
+				return
+			}
+			const next = !this.localFavorite
+			this.localFavorite = next
+			this.favoriteBusy = true
+			try {
+				await setFavourite(this.document.fileid, next)
+				this.$emit('favorite-changed', { fileid: this.document.fileid, favorite: next })
+			} catch (e) {
+				this.localFavorite = !next
+			} finally {
+				this.favoriteBusy = false
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.doc-card {
+	display: flex;
+	flex-direction: column;
+	border-radius: var(--border-radius-large, 12px);
+	overflow: hidden;
+	background-color: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	color: var(--color-main-text);
+	text-decoration: none;
+	transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+	animation: doc-card-enter 260ms ease-out backwards;
+	animation-delay: calc(min(var(--enter-index, 0), 12) * 35ms);
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+
+	&:hover, &:focus-visible {
+		transform: translateY(-2px);
+		box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+		border-color: var(--color-primary-element);
+		text-decoration: none;
+	}
+	&:focus-visible {
+		outline: 2px solid var(--color-primary-element);
+		outline-offset: 2px;
+	}
+	// Reveal the star on hover unless it's already pinned.
+	&:hover &__star,
+	&:focus-within &__star {
+		opacity: 1;
+	}
+
+	&__thumb {
+		position: relative;
+		aspect-ratio: 4 / 3;
+		background-color: var(--type-bg, var(--color-background-dark));
+		// 3px type-accent border carries the colour cue at the card level.
+		// Use box-shadow inset (instead of border) so the thumbnail keeps
+		// flush corners with the card's outer border-radius and the tint
+		// fill stays edge-to-edge.
+		box-shadow: inset 0 0 0 3px var(--type-accent, var(--color-border));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+		color: var(--type-accent, var(--color-text-maxcontrast));
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+	}
+
+	&__star {
+		all: unset;
+		cursor: pointer;
+		position: absolute;
+		top: 8px;
+		left: 8px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		background-color: rgba(255, 255, 255, 0.85);
+		backdrop-filter: blur(2px);
+		color: var(--color-text-maxcontrast);
+		opacity: 0;
+		transition: opacity 0.15s ease, transform 0.15s ease, color 0.15s ease;
+
+		&:hover {
+			transform: scale(1.06);
+		}
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: 2px;
+			opacity: 1;
+		}
+		&--on {
+			opacity: 1;
+			color: #f5b400;
+		}
+	}
+
+	&__type-badge {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+		padding: 2px 8px;
+		border-radius: var(--border-radius-element, 999px);
+		background-color: var(--type-accent, var(--color-background-dark));
+		color: #fff;
+		font-size: 0.72em;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.18);
+	}
+
+	&__editors {
+		position: absolute;
+		left: 8px;
+		bottom: 8px;
+		padding: 3px 8px 3px 6px;
+		border-radius: var(--border-radius-element, 999px);
+		background-color: var(--color-main-background);
+		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+	}
+
+	&__body {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 10px 12px 12px;
+		min-width: 0;
+	}
+	&__name {
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	&__meta {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	&__owner {
+		margin-left: 4px;
+	}
+}
+
+@keyframes doc-card-enter {
+	from {
+		opacity: 0;
+		transform: translateY(8px) scale(0.985);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+</style>

--- a/src/views/Overview/DocumentRow.vue
+++ b/src/views/Overview/DocumentRow.vue
@@ -1,0 +1,427 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<a class="doc-row"
+		:href="openUrl"
+		:style="typeStyles"
+		:title="document.name"
+		@mouseenter="onHoverEnter"
+		@mouseleave="onHoverLeave"
+		@focus="onHoverLeave"
+		@blur="onHoverLeave">
+		<div class="doc-row__thumb">
+			<img v-if="!thumbErrored"
+				:src="document.thumbnailUrl"
+				:alt="''"
+				loading="lazy"
+				@error="onThumbError">
+			<component :is="fallbackIcon"
+				v-else
+				class="doc-row__thumb-icon"
+				:size="32" />
+		</div>
+
+		<div class="doc-row__main">
+			<div class="doc-row__name">
+				{{ document.name }}
+			</div>
+			<div class="doc-row__path">
+				<FolderOutlineIcon class="doc-row__path-icon" :size="14" />
+				<span class="doc-row__folder">{{ folderLabel }}</span>
+			</div>
+		</div>
+
+		<div class="doc-row__col doc-row__col--owner">
+			<NcAvatar v-if="ownerUid"
+				:user="ownerUid"
+				:display-name="ownerDisplay"
+				:size="28"
+				:disable-menu="true"
+				:show-user-status="false" />
+			<div class="doc-row__owner-text">
+				<div class="doc-row__owner-name">{{ ownerLabel }}</div>
+				<div v-if="ownerSubline" class="doc-row__owner-sub">{{ ownerSubline }}</div>
+			</div>
+		</div>
+
+		<div class="doc-row__col doc-row__col--date">
+			<NcDateTime class="doc-row__date" :timestamp="mtimeMs" :ignore-seconds="true" />
+		</div>
+
+		<div class="doc-row__col doc-row__col--size">
+			{{ sizeLabel }}
+		</div>
+
+		<button class="doc-row__star"
+			type="button"
+			:class="{ 'doc-row__star--on': isFavorite }"
+			:aria-label="isFavorite
+				? t('richdocuments', 'Unpin from overview')
+				: t('richdocuments', 'Pin to overview')"
+			:title="isFavorite
+				? t('richdocuments', 'Unpin from overview')
+				: t('richdocuments', 'Pin to overview')"
+			@click.prevent.stop="toggleFavorite">
+			<StarIcon v-if="isFavorite" :size="20" />
+			<StarOutlineIcon v-else :size="20" />
+		</button>
+
+		<div class="doc-row__col doc-row__col--editors">
+			<EditorBadges v-if="hasEditors" :editors="document.currentEditors" :size="22" />
+		</div>
+
+	</a>
+</template>
+
+<script>
+import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
+import NcDateTime from '@nextcloud/vue/dist/Components/NcDateTime.js'
+import { formatFileSize } from '@nextcloud/files'
+import EditorBadges from './EditorBadges.vue'
+import hoverPreviewMixin from './hoverPreviewMixin.js'
+import { typeStyle } from './typeStyles.js'
+import { getDocumentUrlForFile } from '../../helpers/url.js'
+import FileWordIcon from 'vue-material-design-icons/FileWord.vue'
+import FileExcelIcon from 'vue-material-design-icons/FileExcel.vue'
+import FilePresentationBoxIcon from 'vue-material-design-icons/FilePresentationBox.vue'
+import FilePdfBoxIcon from 'vue-material-design-icons/FilePdfBox.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
+import StarIcon from 'vue-material-design-icons/Star.vue'
+import StarOutlineIcon from 'vue-material-design-icons/StarOutline.vue'
+import { setFavourite } from './api.js'
+
+const ICON_BY_MIME = {
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': FileWordIcon,
+	'application/vnd.oasis.opendocument.text': FileWordIcon,
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': FileExcelIcon,
+	'application/vnd.oasis.opendocument.spreadsheet': FileExcelIcon,
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation': FilePresentationBoxIcon,
+	'application/vnd.oasis.opendocument.presentation': FilePresentationBoxIcon,
+	'application/pdf': FilePdfBoxIcon,
+}
+
+export default {
+	name: 'DocumentRow',
+	components: { NcAvatar, NcDateTime, EditorBadges, FolderOutlineIcon, StarIcon, StarOutlineIcon },
+	mixins: [hoverPreviewMixin],
+	props: {
+		document: {
+			type: Object,
+			required: true,
+		},
+		showOwner: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			thumbErrored: false,
+			// Local favourite flag mirrors document.favorite so toggling
+			// updates instantly without a round-trip / list refresh.
+			localFavorite: !!this.document.favorite,
+			favoriteBusy: false,
+		}
+	},
+	computed: {
+		mtimeMs() {
+			return (this.document.mtime ?? 0) * 1000
+		},
+		fallbackIcon() {
+			return ICON_BY_MIME[this.document.mimetype] ?? FileDocumentOutlineIcon
+		},
+		hasEditors() {
+			return Array.isArray(this.document.currentEditors) && this.document.currentEditors.length > 0
+		},
+		typeStyles() {
+			return typeStyle(this.document.mimetype)
+		},
+		// The backend's openUrl lacks the CSRF requesttoken, which the
+		// document.index controller requires on plain navigation. Build
+		// the URL via the existing helper so it includes the token.
+		openUrl() {
+			return getDocumentUrlForFile(this.document.folder ?? '/', this.document.fileid)
+		},
+		ownerUid() {
+			return this.document.modifiedBy?.uid ?? this.document.shareSource?.uid ?? null
+		},
+		ownerDisplay() {
+			return this.document.modifiedBy?.displayName ?? this.document.shareSource?.displayName ?? ''
+		},
+		// Primary owner label visible on the row.
+		ownerLabel() {
+			return this.ownerDisplay || t('richdocuments', 'Unknown')
+		},
+		// Secondary line under the owner — used for federated source.
+		ownerSubline() {
+			const source = this.document.shareSource
+			if (source && source.remoteServer) {
+				return source.remoteServer
+			}
+			return ''
+		},
+		folderLabel() {
+			const folder = this.document.folder
+			if (!folder || folder === '/' || folder === '') {
+				return t('richdocuments', 'Home')
+			}
+			return folder
+		},
+		sizeLabel() {
+			const size = this.document.size
+			if (typeof size !== 'number' || size < 0) {
+				return ''
+			}
+			return formatFileSize(size, true)
+		},
+		largePreviewUrl() {
+			if (!this.document.thumbnailUrl) {
+				return ''
+			}
+			// Bump x/y so we get a sharp preview popover; the server-side URL
+			// already includes 64x64 — replace with 320x320.
+			return this.document.thumbnailUrl
+				.replace(/([?&])x=\d+/, '$1x=480')
+				.replace(/([?&])y=\d+/, '$1y=480')
+		},
+		isFavorite() {
+			return this.localFavorite
+		},
+	},
+	watch: {
+		'document.favorite'(value) {
+			this.localFavorite = !!value
+		},
+	},
+	methods: {
+		onThumbError() {
+			this.thumbErrored = true
+		},
+		async toggleFavorite() {
+			if (this.favoriteBusy) {
+				return
+			}
+			const next = !this.localFavorite
+			// Optimistic flip; revert on failure.
+			this.localFavorite = next
+			this.favoriteBusy = true
+			try {
+				await setFavourite(this.document.fileid, next)
+				this.$emit('favorite-changed', { fileid: this.document.fileid, favorite: next })
+			} catch (e) {
+				this.localFavorite = !next
+			} finally {
+				this.favoriteBusy = false
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.doc-row {
+	display: grid;
+	// Columns: thumb · name+path · owner · date · size · star · editors
+	grid-template-columns: auto minmax(0, 1fr) minmax(0, 200px) 130px 80px auto auto;
+	align-items: center;
+	gap: 16px;
+	padding: 10px 12px;
+	border-radius: var(--border-radius-large, 12px);
+	color: var(--color-main-text);
+	text-decoration: none;
+	transition: background-color 0.12s ease;
+	animation: doc-row-enter 240ms ease-out backwards;
+	animation-delay: calc(min(var(--enter-index, 0), 12) * 30ms);
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+
+	&:hover, &:focus-visible {
+		background-color: var(--color-background-hover);
+		text-decoration: none;
+	}
+	&:focus-visible {
+		outline: 2px solid var(--color-primary-element);
+		outline-offset: -2px;
+	}
+
+	&__thumb {
+		flex: 0 0 auto;
+		width: 48px;
+		height: 48px;
+		border-radius: var(--border-radius, 8px);
+		background-color: var(--type-bg, var(--color-background-dark));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+	}
+	&__thumb-icon {
+		color: var(--type-accent, var(--color-text-maxcontrast));
+	}
+
+	&__main {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+	&__name {
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	&__path {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		font-size: 0.82em;
+		color: var(--color-text-maxcontrast);
+		min-width: 0;
+	}
+	&__path-icon {
+		flex: 0 0 auto;
+		opacity: 0.7;
+	}
+	&__folder {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__col {
+		min-width: 0;
+		display: flex;
+		align-items: center;
+
+		&--owner {
+			gap: 10px;
+		}
+		&--date {
+			color: var(--color-text-maxcontrast);
+			font-size: 0.88em;
+			white-space: nowrap;
+		}
+		&--size {
+			color: var(--color-text-maxcontrast);
+			font-size: 0.88em;
+			justify-content: flex-end;
+			white-space: nowrap;
+			font-variant-numeric: tabular-nums;
+		}
+		&--editors {
+			justify-content: flex-end;
+			min-width: 24px;
+		}
+	}
+
+	&__owner-text {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		line-height: 1.25;
+	}
+	&__owner-name {
+		font-size: 0.9em;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	&__owner-sub {
+		font-size: 0.75em;
+		color: var(--color-text-maxcontrast);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	&__star {
+		all: unset;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		color: var(--color-text-maxcontrast);
+		opacity: 0;
+		transition: opacity 0.12s ease, background-color 0.12s ease, color 0.12s ease, transform 0.15s ease;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+			transform: scale(1.06);
+		}
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: 0;
+			opacity: 1;
+		}
+		&--on {
+			opacity: 1;
+			color: #f5b400;
+		}
+	}
+	// Reveal the star (when not active) on row hover/focus so it doesn't
+	// add visual noise to every row at rest.
+	&:hover &__star,
+	&:focus-within &__star {
+		opacity: 1;
+	}
+}
+
+// Progressive simplification: drop columns as the viewport narrows so the
+// row stays readable without horizontal scroll.
+@media (max-width: 1100px) {
+	.doc-row {
+		grid-template-columns: auto minmax(0, 1fr) minmax(0, 180px) 110px auto auto;
+	}
+	.doc-row__col--size {
+		display: none;
+	}
+}
+@media (max-width: 860px) {
+	.doc-row {
+		grid-template-columns: auto minmax(0, 1fr) auto auto auto;
+	}
+	.doc-row__col--owner {
+		// Avatar-only when space is tight.
+		max-width: 28px;
+	}
+	.doc-row__owner-text {
+		display: none;
+	}
+}
+@media (max-width: 600px) {
+	.doc-row {
+		grid-template-columns: auto minmax(0, 1fr) auto auto;
+	}
+	.doc-row__col--date {
+		display: none;
+	}
+}
+
+@keyframes doc-row-enter {
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+</style>

--- a/src/views/Overview/EditorBadges.vue
+++ b/src/views/Overview/EditorBadges.vue
@@ -1,0 +1,117 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div v-if="editors && editors.length"
+		class="editor-badges"
+		:title="title"
+		:aria-label="title">
+		<span class="editor-badges__pulse" aria-hidden="true" />
+		<div class="editor-badges__avatars">
+			<NcAvatar v-for="editor in shown"
+				:key="editor.uid || editor.displayName"
+				class="editor-badges__avatar"
+				:user="editor.uid || undefined"
+				:display-name="editor.displayName"
+				:size="size"
+				:disable-menu="true"
+				:show-user-status="false" />
+			<span v-if="overflow > 0"
+				class="editor-badges__overflow"
+				:style="{ width: `${size}px`, height: `${size}px`, fontSize: `${size * 0.4}px` }">
+				+{{ overflow }}
+			</span>
+		</div>
+	</div>
+</template>
+
+<script>
+import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
+
+const MAX_VISIBLE = 3
+
+export default {
+	name: 'EditorBadges',
+	components: { NcAvatar },
+	props: {
+		editors: { type: Array, default: () => [] },
+		size: { type: Number, default: 24 },
+	},
+	computed: {
+		shown() {
+			return (this.editors || []).slice(0, MAX_VISIBLE)
+		},
+		overflow() {
+			return Math.max(0, (this.editors || []).length - MAX_VISIBLE)
+		},
+		title() {
+			const names = (this.editors || []).map(e => e.displayName).filter(Boolean)
+			if (names.length === 0) {
+				return ''
+			}
+			if (names.length === 1) {
+				return t('richdocuments', '{name} is editing this document', { name: names[0] })
+			}
+			return t('richdocuments', '{count} people are editing this document: {names}', {
+				count: names.length,
+				names: names.join(', '),
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.editor-badges {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+
+	&__pulse {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background-color: var(--color-success, #46ba61);
+		box-shadow: 0 0 0 0 rgba(70, 186, 97, 0.6);
+		animation: editor-pulse 1.6s ease-out infinite;
+		flex: 0 0 auto;
+	}
+
+	&__avatars {
+		display: inline-flex;
+		align-items: center;
+	}
+
+	&__avatar {
+		// Overlap avatars slightly for a stacked look.
+		& + & {
+			margin-left: -8px;
+		}
+		// White ring so overlapping avatars stay visually distinct.
+		border: 2px solid var(--color-main-background);
+		border-radius: 50%;
+		background-color: var(--color-main-background);
+	}
+
+	&__overflow {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		margin-left: -8px;
+		border-radius: 50%;
+		background-color: var(--color-background-dark);
+		color: var(--color-text-maxcontrast);
+		border: 2px solid var(--color-main-background);
+		font-weight: 500;
+	}
+}
+
+@keyframes editor-pulse {
+	0% { box-shadow: 0 0 0 0 rgba(70, 186, 97, 0.55); }
+	70% { box-shadow: 0 0 0 6px rgba(70, 186, 97, 0); }
+	100% { box-shadow: 0 0 0 0 rgba(70, 186, 97, 0); }
+}
+</style>

--- a/src/views/Overview/EmptyIllustration.vue
+++ b/src/views/Overview/EmptyIllustration.vue
@@ -1,0 +1,271 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="empty-illustration">
+		<div class="empty-illustration__art" aria-hidden="true">
+			<svg viewBox="0 0 200 160" xmlns="http://www.w3.org/2000/svg">
+				<!-- Soft halo behind the illustration. -->
+				<ellipse cx="100"
+					cy="92"
+					rx="84"
+					ry="60"
+					class="empty-illustration__halo" />
+
+				<!-- recent: clock-on-document -->
+				<g v-if="kind === 'recent'" class="empty-illustration__line">
+					<path d="M64 30 L114 30 L134 50 L134 130 L64 130 Z" class="empty-illustration__paper" />
+					<path d="M114 30 L114 50 L134 50" />
+					<line x1="76"
+						y1="68"
+						x2="120"
+						y2="68"
+						class="empty-illustration__faded" />
+					<line x1="76"
+						y1="80"
+						x2="112"
+						y2="80"
+						class="empty-illustration__faded" />
+					<circle cx="124"
+						cy="106"
+						r="20"
+						class="empty-illustration__paper" />
+					<line x1="124"
+						y1="92"
+						x2="124"
+						y2="106" />
+					<line x1="124"
+						y1="106"
+						x2="135"
+						y2="113" />
+				</g>
+
+				<!-- shared: two friends + a doc -->
+				<g v-else-if="kind === 'shared'" class="empty-illustration__line">
+					<path d="M78 50 L122 50 L122 110 L78 110 Z" class="empty-illustration__paper" />
+					<line x1="86"
+						y1="68"
+						x2="114"
+						y2="68"
+						class="empty-illustration__faded" />
+					<line x1="86"
+						y1="80"
+						x2="106"
+						y2="80"
+						class="empty-illustration__faded" />
+					<circle cx="40"
+						cy="80"
+						r="14"
+						class="empty-illustration__paper" />
+					<circle cx="40"
+						cy="76"
+						r="4"
+						class="empty-illustration__fill" />
+					<path d="M30 92 a10 10 0 0 1 20 0" class="empty-illustration__faded" />
+					<circle cx="160"
+						cy="80"
+						r="14"
+						class="empty-illustration__paper" />
+					<circle cx="160"
+						cy="76"
+						r="4"
+						class="empty-illustration__fill" />
+					<path d="M150 92 a10 10 0 0 1 20 0" class="empty-illustration__faded" />
+					<line x1="54"
+						y1="80"
+						x2="78"
+						y2="80"
+						class="empty-illustration__dashed" />
+					<line x1="122"
+						y1="80"
+						x2="146"
+						y2="80"
+						class="empty-illustration__dashed" />
+				</g>
+
+				<!-- templates: paper with a + badge -->
+				<g v-else-if="kind === 'templates'" class="empty-illustration__line">
+					<path d="M58 28 L108 28 L128 48 L128 132 L58 132 Z" class="empty-illustration__paper" />
+					<path d="M108 28 L108 48 L128 48" />
+					<line x1="70"
+						y1="68"
+						x2="116"
+						y2="68"
+						class="empty-illustration__faded" />
+					<line x1="70"
+						y1="82"
+						x2="112"
+						y2="82"
+						class="empty-illustration__faded" />
+					<line x1="70"
+						y1="96"
+						x2="100"
+						y2="96"
+						class="empty-illustration__faded" />
+					<circle cx="138"
+						cy="124"
+						r="18"
+						class="empty-illustration__badge" />
+					<line x1="138"
+						y1="116"
+						x2="138"
+						y2="132"
+						class="empty-illustration__badge-stroke" />
+					<line x1="130"
+						y1="124"
+						x2="146"
+						y2="124"
+						class="empty-illustration__badge-stroke" />
+				</g>
+
+				<!-- decorative dots, identical across all kinds -->
+				<g class="empty-illustration__sparkles">
+					<circle cx="32" cy="48" r="2.5" />
+					<circle cx="170" cy="38" r="3" />
+					<circle cx="178" cy="118" r="2" />
+					<circle cx="22" cy="118" r="2" />
+				</g>
+			</svg>
+		</div>
+
+		<h3 class="empty-illustration__title">
+			{{ title }}
+		</h3>
+		<p v-if="description" class="empty-illustration__description">
+			{{ description }}
+		</p>
+		<div v-if="$slots.action" class="empty-illustration__action">
+			<slot name="action" />
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'EmptyIllustration',
+	props: {
+		kind: {
+			type: String,
+			required: true,
+			validator: v => ['recent', 'shared', 'templates'].includes(v),
+		},
+		title: { type: String, required: true },
+		description: { type: String, default: '' },
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.empty-illustration {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 32px 16px 8px;
+	text-align: center;
+
+	&__art {
+		width: 220px;
+		max-width: 80vw;
+		margin-bottom: 8px;
+		// Subtle entrance: float up + fade in.
+		animation: empty-illustration-rise 360ms cubic-bezier(0.16, 1, 0.3, 1) backwards;
+
+		@media (prefers-reduced-motion: reduce) {
+			animation: none;
+		}
+
+		svg {
+			display: block;
+			width: 100%;
+			height: auto;
+		}
+	}
+
+	&__halo {
+		fill: var(--color-primary-element-light, var(--color-background-dark));
+		// Use a tinted halo even when the brand variable isn't set.
+		opacity: 0.85;
+	}
+
+	&__line {
+		stroke: var(--color-primary-element, currentColor);
+		stroke-width: 2.5;
+		stroke-linecap: round;
+		stroke-linejoin: round;
+		fill: none;
+	}
+	&__paper {
+		fill: var(--color-main-background);
+	}
+	&__faded {
+		opacity: 0.5;
+		stroke-width: 2;
+	}
+	&__dashed {
+		stroke-dasharray: 3 3;
+		opacity: 0.6;
+		stroke-width: 2;
+	}
+	&__fill {
+		fill: var(--color-primary-element, currentColor);
+		opacity: 0.5;
+		stroke: none;
+	}
+	&__badge {
+		fill: var(--color-primary-element, currentColor);
+		stroke: var(--color-main-background);
+		stroke-width: 3;
+	}
+	&__badge-stroke {
+		stroke: var(--color-primary-element-text, #fff);
+		stroke-width: 2.5;
+		stroke-linecap: round;
+	}
+	&__sparkles {
+		fill: var(--color-primary-element, currentColor);
+		opacity: 0.55;
+		// Slow pulse keeps the page feeling alive without distracting.
+		animation: empty-illustration-twinkle 4s ease-in-out infinite;
+
+		@media (prefers-reduced-motion: reduce) {
+			animation: none;
+		}
+	}
+
+	&__title {
+		margin: 0;
+		font-size: 1.15em;
+		font-weight: 600;
+		color: var(--color-main-text);
+	}
+	&__description {
+		margin: 0;
+		max-width: 36ch;
+		color: var(--color-text-maxcontrast);
+		font-size: 0.95em;
+		line-height: 1.4;
+	}
+	&__action {
+		margin-top: 12px;
+	}
+}
+
+@keyframes empty-illustration-rise {
+	from {
+		opacity: 0;
+		transform: translateY(10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes empty-illustration-twinkle {
+	0%, 100% { opacity: 0.55; }
+	50% { opacity: 0.25; }
+}
+</style>

--- a/src/views/Overview/HomeSection.vue
+++ b/src/views/Overview/HomeSection.vue
@@ -1,0 +1,136 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<section class="section">
+		<header class="section__header">
+			<h2 class="section__title">
+				<slot name="icon" />
+				<span>{{ title }}</span>
+			</h2>
+			<router-link v-if="seeAll" :to="seeAll" class="section__see-all">
+				{{ t('richdocuments', 'See all') }}
+				<ChevronRightIcon :size="16" />
+			</router-link>
+		</header>
+
+		<div v-if="loading" class="section__skeletons" aria-hidden="true">
+			<div v-for="i in 4" :key="i" class="section__skeleton" />
+		</div>
+
+		<SubtleHint v-else-if="error"
+			:icon="errorIcon"
+			:text="t('richdocuments', 'Could not load this section.')">
+			<template #action>
+				<NcButton type="tertiary" @click="$emit('retry')">
+					{{ t('richdocuments', 'Retry') }}
+				</NcButton>
+			</template>
+		</SubtleHint>
+
+		<SubtleHint v-else-if="!hasItems"
+			:icon="emptyIconComponent"
+			:text="emptyName" />
+
+		<div v-else class="section__list">
+			<slot />
+		</div>
+	</section>
+</template>
+
+<script>
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import AlertCircleOutlineIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import SubtleHint from './SubtleHint.vue'
+
+export default {
+	name: 'HomeSection',
+	components: { NcButton, ChevronRightIcon, SubtleHint },
+	props: {
+		title: { type: String, required: true },
+		seeAll: { type: [Object, String], default: null },
+		loading: { type: Boolean, default: false },
+		error: { type: Boolean, default: false },
+		emptyName: { type: String, required: true },
+	},
+	computed: {
+		hasItems() {
+			return !!(this.$slots.default && this.$slots.default.length > 0)
+		},
+		errorIcon() {
+			return AlertCircleOutlineIcon
+		},
+		emptyIconComponent() {
+			return FileDocumentOutlineIcon
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+	}
+	&__title {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin: 0;
+		font-size: 1.1em;
+		font-weight: 600;
+	}
+	&__see-all {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		color: var(--color-primary-element);
+		font-size: 0.9em;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&__list {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	&__skeletons {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	&__skeleton {
+		height: 64px;
+		border-radius: var(--border-radius-large, 12px);
+		background: linear-gradient(
+			90deg,
+			var(--color-background-dark) 0%,
+			var(--color-background-hover) 50%,
+			var(--color-background-dark) 100%
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.4s ease-in-out infinite;
+	}
+}
+
+@keyframes shimmer {
+	from { background-position: 200% 0; }
+	to   { background-position: -200% 0; }
+}
+</style>

--- a/src/views/Overview/HomeView.vue
+++ b/src/views/Overview/HomeView.vue
@@ -1,0 +1,188 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="home">
+		<header class="home__header">
+			<h1 class="home__title">
+				<ViewDashboardOutlineIcon :size="32" />
+				<span>{{ t('richdocuments', 'Office overview') }}</span>
+			</h1>
+			<p class="home__subtitle">
+				{{ t('richdocuments', 'Recent documents and templates from the last {days} days', { days }) }}
+			</p>
+		</header>
+
+		<HomeSection :title="t('richdocuments', 'My recent documents')"
+			:see-all="{ name: 'recent' }"
+			:loading="recent.loading"
+			:error="recent.error"
+			:empty-name="t('richdocuments', 'No documents edited in the last {days} days', { days })"
+			@retry="loadRecent">
+			<template #icon>
+				<ClockOutlineIcon :size="24" />
+			</template>
+			<DocumentRow v-for="(item, i) in recent.items"
+				:key="`recent-${item.fileid}`"
+				:document="item"
+				:style="{ '--enter-index': i }" />
+		</HomeSection>
+
+		<HomeSection :title="t('richdocuments', 'Shared with me')"
+			:see-all="{ name: 'shared' }"
+			:loading="shared.loading"
+			:error="shared.error"
+			:empty-name="t('richdocuments', 'No shared documents edited in the last {days} days', { days })"
+			@retry="loadShared">
+			<template #icon>
+				<AccountMultipleIcon :size="24" />
+			</template>
+			<DocumentRow v-for="(item, i) in shared.items"
+				:key="`shared-${item.fileid}`"
+				:document="item"
+				:show-owner="true"
+				:style="{ '--enter-index': i }" />
+		</HomeSection>
+
+		<HomeSection :title="t('richdocuments', 'Create new document')"
+			:see-all="{ name: 'templates' }"
+			:loading="templates.loading"
+			:error="templates.error"
+			:empty-name="t('richdocuments', 'You haven\'t created any templates yet.')"
+			@retry="loadTemplates">
+			<template #icon>
+				<FileDocumentPlusIcon :size="24" />
+			</template>
+			<TemplateRow v-for="(item, i) in templates.items"
+				:key="`tpl-${item.fileid}`"
+				:template="item"
+				:style="{ '--enter-index': i }"
+				@select="onTemplateSelect" />
+		</HomeSection>
+
+		<CreateFromTemplateModal v-if="selectedTemplate"
+			:template="selectedTemplate"
+			@close="selectedTemplate = null" />
+	</div>
+</template>
+
+<script>
+import HomeSection from './HomeSection.vue'
+import DocumentRow from './DocumentRow.vue'
+import TemplateRow from './TemplateRow.vue'
+import CreateFromTemplateModal from './CreateFromTemplateModal.vue'
+import { fetchHome } from './api.js'
+import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
+import FileDocumentPlusIcon from 'vue-material-design-icons/FileDocumentPlus.vue'
+import ViewDashboardOutlineIcon from 'vue-material-design-icons/ViewDashboardOutline.vue'
+
+const RECENT_WINDOW_DAYS = 60
+
+/**
+ * Reactive shape for a Home section state.
+ * @return {{loading: boolean, error: boolean, items: Array}} initial state
+ */
+function emptySection() {
+	return { loading: true, error: false, items: [] }
+}
+
+export default {
+	name: 'HomeView',
+	components: {
+		HomeSection,
+		DocumentRow,
+		TemplateRow,
+		CreateFromTemplateModal,
+		ClockOutlineIcon,
+		AccountMultipleIcon,
+		FileDocumentPlusIcon,
+		ViewDashboardOutlineIcon,
+	},
+	data() {
+		return {
+			recent: emptySection(),
+			shared: emptySection(),
+			templates: emptySection(),
+			selectedTemplate: null,
+			days: RECENT_WINDOW_DAYS,
+			abortControllers: [],
+		}
+	},
+	mounted() {
+		this.loadRecent()
+		this.loadShared()
+		this.loadTemplates()
+	},
+	beforeDestroy() {
+		this.abortControllers.forEach(c => c.abort())
+	},
+	methods: {
+		async loadSection(kind, target) {
+			target.loading = true
+			target.error = false
+			const controller = new AbortController()
+			this.abortControllers.push(controller)
+			try {
+				const result = await fetchHome(kind, controller.signal)
+				target.items = result.items ?? []
+			} catch (e) {
+				if (e.name !== 'CanceledError' && e.name !== 'AbortError') {
+					target.error = true
+				}
+			} finally {
+				target.loading = false
+			}
+		},
+		loadRecent() {
+			this.loadSection('recent', this.recent)
+		},
+		loadShared() {
+			this.loadSection('shared', this.shared)
+		},
+		loadTemplates() {
+			this.loadSection('templates', this.templates)
+		},
+		onTemplateSelect(template) {
+			this.selectedTemplate = template
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.home {
+	display: flex;
+	flex-direction: column;
+	gap: 32px;
+	// Top padding matches --app-navigation-padding so the page heading is
+	// vertically aligned with the "hide navigation" toggle button rendered
+	// by NcAppNavigation.
+	padding: var(--app-navigation-padding, 8px) clamp(16px, 4vw, 48px) 64px;
+	max-width: 1200px;
+
+	&__header {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	&__title {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		font-size: 1.6em;
+		font-weight: 600;
+		margin: 0;
+		line-height: 1.2;
+		// Match the toggle button's clickable-area height so the heading
+		// shares its vertical baseline.
+		min-height: var(--default-clickable-area, 44px);
+	}
+	&__subtitle {
+		color: var(--color-text-maxcontrast);
+		margin: 0;
+	}
+}
+</style>

--- a/src/views/Overview/HoverPreview.vue
+++ b/src/views/Overview/HoverPreview.vue
@@ -1,0 +1,94 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="hover-preview"
+		:style="popoverStyle"
+		role="presentation">
+		<img v-if="!errored && src"
+			:src="src"
+			:alt="''"
+			class="hover-preview__image"
+			@error="$emit('error')">
+		<component :is="fallbackIcon"
+			v-else
+			class="hover-preview__icon"
+			:size="64" />
+		<div class="hover-preview__label">
+			{{ name }}
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'HoverPreview',
+	props: {
+		popoverStyle: { type: Object, required: true },
+		src: { type: String, default: '' },
+		name: { type: String, default: '' },
+		fallbackIcon: { type: [Object, Function], default: null },
+		errored: { type: Boolean, default: false },
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.hover-preview {
+	position: fixed;
+	width: 360px;
+	height: 320px;
+	border-radius: var(--border-radius-large, 12px);
+	background-color: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18), 0 2px 8px rgba(0, 0, 0, 0.08);
+	overflow: hidden;
+	z-index: 200;
+	display: flex;
+	flex-direction: column;
+	pointer-events: none;
+	animation: hover-preview-fade 160ms ease-out;
+
+	&__image {
+		flex: 1 1 auto;
+		width: 100%;
+		min-height: 0;
+		object-fit: contain;
+		background-color: var(--color-background-dark);
+	}
+	&__icon {
+		flex: 1 1 auto;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 0;
+		color: var(--color-text-maxcontrast);
+	}
+	&__label {
+		flex: 0 0 auto;
+		padding: 8px 12px;
+		font-size: 0.85em;
+		font-weight: 500;
+		color: var(--color-main-text);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		border-top: 1px solid var(--color-border);
+	}
+}
+
+// On narrow / touch viewports the floating preview is more annoying
+// than useful, and finger-pointer hovers are unreliable.
+@media (max-width: 860px) {
+	.hover-preview {
+		display: none;
+	}
+}
+
+@keyframes hover-preview-fade {
+	from { opacity: 0; transform: scale(0.96); }
+	to { opacity: 1; transform: scale(1); }
+}
+</style>

--- a/src/views/Overview/ListView.vue
+++ b/src/views/Overview/ListView.vue
@@ -1,0 +1,523 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="list-view">
+		<header class="list-view__header">
+			<div class="list-view__header-row">
+				<h1 class="list-view__title">
+					<slot name="icon" />
+					<span>{{ title }}</span>
+				</h1>
+				<ViewToggle :value="viewMode" @input="onViewModeChange" />
+			</div>
+			<p v-if="subtitle" class="list-view__subtitle">
+				{{ subtitle }}
+			</p>
+		</header>
+
+		<TypeFilter v-if="typeOptions && typeOptions.length"
+			:value="typeFilter"
+			:options="typeOptions"
+			:aria-controls="listAriaId"
+			@input="onTypeFilterChange" />
+
+		<SearchBar v-model="query" :placeholder="searchPlaceholder" />
+
+		<div v-if="initialLoading" class="list-view__skeletons" aria-hidden="true">
+			<div v-for="i in 8" :key="i" class="list-view__skeleton" />
+		</div>
+
+		<SubtleHint v-else-if="error && !items.length"
+			:icon="errorIcon"
+			:text="t('richdocuments', 'Could not load this list.')">
+			<template #action>
+				<NcButton type="tertiary" @click="reload">
+					{{ t('richdocuments', 'Retry') }}
+				</NcButton>
+			</template>
+		</SubtleHint>
+
+		<!-- Filtered / searched and got nothing: stay subtle, the user can fix it. -->
+		<SubtleHint v-else-if="!items.length && (query || typeFilter)"
+			:icon="emptyIcon"
+			:text="effectiveEmptyName" />
+
+		<!-- Genuinely empty list: friendly illustration as the first impression. -->
+		<EmptyIllustration v-else-if="!items.length"
+			:kind="illustrationKind"
+			:title="effectiveEmptyName"
+			:description="emptyDescription">
+			<template v-if="emptyAction" #action>
+				<NcButton :type="emptyAction.type" @click="emptyAction.handler">
+					<template v-if="emptyAction.icon" #icon>
+						<component :is="emptyAction.icon" :size="18" />
+					</template>
+					{{ emptyAction.label }}
+				</NcButton>
+			</template>
+		</EmptyIllustration>
+
+		<div v-else
+			:id="listAriaId"
+			:class="['list-view__items', viewMode === 'grid' ? 'list-view__items--grid' : 'list-view__items--list']">
+			<template v-if="dateGroups">
+				<template v-for="group in groupedItems">
+					<h2 :key="`title-${group.key}`" class="list-view__group-title">
+						{{ group.title }}
+						<span class="list-view__group-count">{{ group.items.length }}</span>
+					</h2>
+					<slot :items="group.items"
+						:view-mode="viewMode"
+						:on-favorite-changed="applyFavoriteChange" />
+				</template>
+			</template>
+			<slot v-else
+				:items="items"
+				:view-mode="viewMode"
+				:on-favorite-changed="applyFavoriteChange" />
+			<div ref="sentinel" class="list-view__sentinel" />
+			<div v-if="loadingMore" class="list-view__more">
+				<NcLoadingIcon :size="24" />
+			</div>
+			<div v-else-if="error && items.length" class="list-view__more list-view__more--error">
+				<NcButton type="tertiary" @click="loadMore">
+					{{ t('richdocuments', 'Failed to load more — retry') }}
+				</NcButton>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
+import { generateUrl } from '@nextcloud/router'
+import AlertCircleOutlineIcon from 'vue-material-design-icons/AlertCircleOutline.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import FileDocumentPlusIcon from 'vue-material-design-icons/FileDocumentPlus.vue'
+import FolderOpenIcon from 'vue-material-design-icons/FolderOpen.vue'
+import MagnifyCloseIcon from 'vue-material-design-icons/MagnifyClose.vue'
+import EmptyIllustration from './EmptyIllustration.vue'
+import SearchBar from './SearchBar.vue'
+import SubtleHint from './SubtleHint.vue'
+import TypeFilter from './TypeFilter.vue'
+import ViewToggle from './ViewToggle.vue'
+import { fetchList } from './api.js'
+import { groupItemsByDate } from './dateGrouping.js'
+
+const VIEW_MODE_STORAGE_KEY = 'richdocuments.overview.viewMode'
+
+/**
+ * Read the persisted view mode from localStorage, falling back to 'list'.
+ * @return {('list'|'grid')} stored view mode
+ */
+function loadViewMode() {
+	try {
+		const value = localStorage.getItem(VIEW_MODE_STORAGE_KEY)
+		return value === 'grid' ? 'grid' : 'list'
+	} catch {
+		return 'list'
+	}
+}
+
+/**
+ * Persist the user's view-mode choice across sessions.
+ * @param {string} mode 'list' or 'grid'
+ */
+function saveViewMode(mode) {
+	try {
+		localStorage.setItem(VIEW_MODE_STORAGE_KEY, mode)
+	} catch {
+		// localStorage may be disabled in private mode; non-fatal.
+	}
+}
+
+let listAriaCounter = 0
+
+export default {
+	name: 'ListView',
+	components: { NcButton, NcLoadingIcon, EmptyIllustration, SearchBar, SubtleHint, TypeFilter, ViewToggle },
+	props: {
+		kind: { type: String, required: true, validator: v => ['recent', 'shared', 'templates'].includes(v) },
+		title: { type: String, required: true },
+		subtitle: { type: String, default: '' },
+		searchPlaceholder: { type: String, required: true },
+		emptyName: { type: String, required: true },
+		emptySearchName: { type: String, default: '' },
+		typeOptions: { type: Array, default: () => [] },
+		// When true, the list is split into date sections (Today,
+		// Yesterday, …, Older). Disabled by default since it only makes
+		// sense for date-sorted lists (Recent / Shared) — the templates
+		// list is alphabetical.
+		dateGroups: { type: Boolean, default: false },
+	},
+	data() {
+		return {
+			query: '',
+			typeFilter: null,
+			viewMode: loadViewMode(),
+			items: [],
+			nextOffset: null,
+			initialLoading: true,
+			loadingMore: false,
+			error: false,
+			abortController: null,
+			observer: null,
+			listAriaId: `overview-list-${++listAriaCounter}`,
+		}
+	},
+	computed: {
+		effectiveEmptyName() {
+			if (this.query) {
+				return this.emptySearchName
+					|| t('richdocuments', 'No matches for "{query}"', { query: this.query })
+			}
+			if (this.typeFilter) {
+				return t('richdocuments', 'No documents of this type in the selected window')
+			}
+			return this.emptyName
+		},
+		emptyIcon() {
+			return this.query ? MagnifyCloseIcon : FileDocumentOutlineIcon
+		},
+		groupedItems() {
+			const pinned = this.items.filter(it => it.favorite)
+			const rest = this.items.filter(it => !it.favorite)
+			const groups = groupItemsByDate(rest)
+			if (pinned.length > 0) {
+				groups.unshift({
+					key: 'pinned',
+					title: t('richdocuments', 'Pinned'),
+					items: pinned,
+				})
+			}
+			return groups
+		},
+		errorIcon() {
+			return AlertCircleOutlineIcon
+		},
+		illustrationKind() {
+			// Maps the list-kind onto an EmptyIllustration variant.
+			// Templates list, when "create new document" is empty, gets the
+			// templates illustration; everything else uses kind directly.
+			return this.kind === 'templates' ? 'templates' : this.kind
+		},
+		emptyDescription() {
+			// One-line nudge under the heading on the genuinely-empty
+			// state. Filtered/searched empties don't show this at all.
+			if (this.kind === 'recent') {
+				return t('richdocuments', 'Documents you edit will show up here.')
+			}
+			if (this.kind === 'shared') {
+				return t('richdocuments', 'Files others share with you will appear here.')
+			}
+			if (this.kind === 'templates') {
+				return t('richdocuments', 'Save a document to your templates folder in Files to start.')
+			}
+			return ''
+		},
+		// Suggest a single, kind-appropriate next step when the list is
+		// empty AND the user isn't filtering / searching (in which case
+		// "clear search" is the natural next step and we keep the hint
+		// quiet). Returns null to render no action button.
+		emptyAction() {
+			if (this.query || this.typeFilter) {
+				return null
+			}
+			if (this.kind === 'recent' || this.kind === 'shared') {
+				return {
+					label: t('richdocuments', 'Create a new document'),
+					type: 'primary',
+					icon: FileDocumentPlusIcon,
+					handler: () => this.$router.push({ name: 'templates' }),
+				}
+			}
+			if (this.kind === 'templates') {
+				return {
+					label: t('richdocuments', 'Open Files'),
+					type: 'secondary',
+					icon: FolderOpenIcon,
+					handler: () => {
+						window.location.href = generateUrl('/apps/files')
+					},
+				}
+			}
+			return null
+		},
+	},
+	watch: {
+		query() {
+			this.reload()
+		},
+	},
+	mounted() {
+		this.reload()
+	},
+	updated() {
+		this.attachObserver()
+	},
+	beforeDestroy() {
+		this.cancel()
+		this.detachObserver()
+	},
+	methods: {
+		cancel() {
+			if (this.abortController) {
+				this.abortController.abort()
+				this.abortController = null
+			}
+		},
+		async reload() {
+			this.cancel()
+			this.detachObserver()
+			this.items = []
+			this.nextOffset = 0
+			this.error = false
+			this.initialLoading = true
+			await this.fetchPage(true)
+		},
+		async loadMore() {
+			if (this.loadingMore || this.nextOffset === null) {
+				return
+			}
+			await this.fetchPage(false)
+		},
+		async fetchPage(initial) {
+			const offset = this.nextOffset ?? 0
+			const requestedQuery = this.query || null
+			const requestedType = this.typeFilter
+			const controller = new AbortController()
+			this.abortController = controller
+			if (initial) {
+				this.initialLoading = true
+			} else {
+				this.loadingMore = true
+			}
+			this.error = false
+			try {
+				const result = await fetchList(this.kind, {
+					q: requestedQuery,
+					type: requestedType,
+					offset,
+					signal: controller.signal,
+				})
+				// Guard against late results from a stale query/filter.
+				if (this.abortController !== controller) {
+					return
+				}
+				if (this.query !== (requestedQuery ?? '')) {
+					return
+				}
+				if (this.typeFilter !== requestedType) {
+					return
+				}
+				this.items = initial ? (result.items ?? []) : this.items.concat(result.items ?? [])
+				this.nextOffset = result.nextOffset ?? null
+			} catch (e) {
+				if (e.name === 'CanceledError' || e.name === 'AbortError') {
+					return
+				}
+				this.error = true
+			} finally {
+				if (initial) {
+					this.initialLoading = false
+				} else {
+					this.loadingMore = false
+				}
+				// Rearm the IntersectionObserver — IO only fires on intersection
+				// transitions, so if the sentinel is still in view we need to
+				// disconnect + observe again to re-trigger the next page.
+				this.$nextTick(() => this.rearmObserver())
+			}
+		},
+		onTypeFilterChange(value) {
+			if (value === this.typeFilter) {
+				return
+			}
+			this.typeFilter = value
+			this.reload()
+		},
+		onViewModeChange(mode) {
+			if (mode !== 'list' && mode !== 'grid') {
+				return
+			}
+			this.viewMode = mode
+			saveViewMode(mode)
+		},
+		attachObserver() {
+			if (this.observer || !this.$refs.sentinel) {
+				return
+			}
+			this.observer = new IntersectionObserver(entries => {
+				const entry = entries[0]
+				if (entry && entry.isIntersecting) {
+					this.loadMore()
+				}
+			}, { rootMargin: '300px' })
+			this.observer.observe(this.$refs.sentinel)
+		},
+		rearmObserver() {
+			if (!this.$refs.sentinel || this.nextOffset === null) {
+				return
+			}
+			this.detachObserver()
+			this.attachObserver()
+		},
+		detachObserver() {
+			if (this.observer) {
+				this.observer.disconnect()
+				this.observer = null
+			}
+		},
+		// Called by row/card components when the user toggles a favourite.
+		// We mutate the in-memory items so the new pin instantly moves to
+		// the "Pinned" group without a full reload.
+		applyFavoriteChange({ fileid, favorite }) {
+			const idx = this.items.findIndex(it => it.fileid === fileid)
+			if (idx === -1) {
+				return
+			}
+			this.$set(this.items, idx, { ...this.items[idx], favorite: !!favorite })
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.list-view {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	// Top padding matches --app-navigation-padding so the page heading is
+	// vertically aligned with the "hide navigation" toggle button rendered
+	// by NcAppNavigation. Bottom padding stays generous for scroll comfort.
+	padding: var(--app-navigation-padding, 8px) clamp(16px, 4vw, 48px) 64px;
+	max-width: 1200px;
+
+	&__header {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	&__header-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+		// Match the toggle button's clickable-area height so the heading
+		// row and the toggle share the same baseline.
+		min-height: var(--default-clickable-area, 44px);
+	}
+	&__title {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin: 0;
+		font-size: 1.6em;
+		font-weight: 600;
+		line-height: 1.2;
+	}
+	&__subtitle {
+		color: var(--color-text-maxcontrast);
+		margin: 0;
+	}
+
+	&__items {
+		min-height: 0;
+	}
+	&__items--list {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	&__items--grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+		gap: 16px;
+	}
+
+	// The sentinel must always be the last child of the items container,
+	// regardless of layout — for grid mode, span the whole row so it doesn't
+	// fight the grid placement.
+	&__sentinel {
+		height: 1px;
+		grid-column: 1 / -1;
+	}
+
+	&__group-title {
+		// Span the full grid row so cards below flow under the heading.
+		grid-column: 1 / -1;
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin: 0;
+		padding: 12px 0 6px;
+		font-size: 0.95em;
+		font-weight: 600;
+		color: var(--color-text-maxcontrast);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+
+		// Stick the heading to the top of the scroll area while users
+		// scroll through that group. A solid background + a soft
+		// gradient fade hides the items scrolling under it.
+		position: sticky;
+		top: 0;
+		z-index: 4;
+		background: linear-gradient(
+			to bottom,
+			var(--color-main-background) 70%,
+			transparent
+		);
+		// Slight tint so the sticky heading is distinguishable from rows.
+		backdrop-filter: blur(2px);
+
+		&:first-child {
+			padding-top: 4px;
+		}
+	}
+	&__group-count {
+		font-size: 0.85em;
+		font-weight: 500;
+		color: var(--color-text-maxcontrast);
+		background-color: var(--color-background-dark);
+		padding: 1px 8px;
+		border-radius: var(--border-radius-element, 999px);
+		text-transform: none;
+		letter-spacing: 0;
+	}
+
+	&__more {
+		display: flex;
+		justify-content: center;
+		padding: 16px 0;
+		grid-column: 1 / -1;
+	}
+
+	&__skeletons {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	&__skeleton {
+		height: 64px;
+		border-radius: var(--border-radius-large, 12px);
+		background: linear-gradient(
+			90deg,
+			var(--color-background-dark) 0%,
+			var(--color-background-hover) 50%,
+			var(--color-background-dark) 100%
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.4s ease-in-out infinite;
+	}
+}
+
+@keyframes shimmer {
+	from { background-position: 200% 0; }
+	to   { background-position: -200% 0; }
+}
+</style>

--- a/src/views/Overview/OverviewApp.vue
+++ b/src/views/Overview/OverviewApp.vue
@@ -1,0 +1,101 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<NcContent app-name="richdocuments" class="overview">
+		<NcAppNavigation :aria-label="t('richdocuments', 'Office overview')">
+			<template #list>
+				<NcAppNavigationItem :name="t('richdocuments', 'Home')"
+					:to="{ name: 'home' }"
+					:exact="true">
+					<template #icon>
+						<HomeOutlineIcon :size="20" />
+					</template>
+				</NcAppNavigationItem>
+				<NcAppNavigationItem :name="t('richdocuments', 'My recent documents')"
+					:to="{ name: 'recent' }">
+					<template #icon>
+						<ClockOutlineIcon :size="20" />
+					</template>
+				</NcAppNavigationItem>
+				<NcAppNavigationItem :name="t('richdocuments', 'Shared with me')"
+					:to="{ name: 'shared' }">
+					<template #icon>
+						<AccountMultipleIcon :size="20" />
+					</template>
+				</NcAppNavigationItem>
+				<NcAppNavigationItem :name="t('richdocuments', 'Create new document')"
+					:to="{ name: 'templates' }">
+					<template #icon>
+						<FileDocumentPlusIcon :size="20" />
+					</template>
+				</NcAppNavigationItem>
+			</template>
+		</NcAppNavigation>
+		<NcAppContent>
+			<transition name="overview-route" mode="out-in">
+				<router-view :key="$route.name" />
+			</transition>
+		</NcAppContent>
+	</NcContent>
+</template>
+
+<script>
+import NcContent from '@nextcloud/vue/dist/Components/NcContent.js'
+import NcAppNavigation from '@nextcloud/vue/dist/Components/NcAppNavigation.js'
+import NcAppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
+import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
+import HomeOutlineIcon from 'vue-material-design-icons/HomeOutline.vue'
+import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
+import FileDocumentPlusIcon from 'vue-material-design-icons/FileDocumentPlus.vue'
+
+export default {
+	name: 'OverviewApp',
+	components: {
+		NcContent,
+		NcAppNavigation,
+		NcAppNavigationItem,
+		NcAppContent,
+		HomeOutlineIcon,
+		ClockOutlineIcon,
+		AccountMultipleIcon,
+		FileDocumentPlusIcon,
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.overview {
+	min-height: 100%;
+}
+
+// Smooth fade + slight upward slide between Home / Recent / Shared /
+// Templates so navigation feels intentional rather than snapping.
+::v-deep(.overview-route-enter-active),
+::v-deep(.overview-route-leave-active) {
+	transition: opacity 180ms ease, transform 180ms ease;
+}
+::v-deep(.overview-route-enter) {
+	opacity: 0;
+	transform: translateY(6px);
+}
+::v-deep(.overview-route-leave-to) {
+	opacity: 0;
+	transform: translateY(-4px);
+}
+
+// Honour reduced-motion: snap instead of slide.
+@media (prefers-reduced-motion: reduce) {
+	::v-deep(.overview-route-enter-active),
+	::v-deep(.overview-route-leave-active) {
+		transition: none;
+	}
+	::v-deep(.overview-route-enter),
+	::v-deep(.overview-route-leave-to) {
+		transform: none;
+	}
+}
+</style>

--- a/src/views/Overview/RecentView.vue
+++ b/src/views/Overview/RecentView.vue
@@ -1,0 +1,45 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<ListView kind="recent"
+		:title="t('richdocuments', 'My recent documents')"
+		:subtitle="t('richdocuments', 'Documents you own that have been edited in the last {days} days', { days })"
+		:search-placeholder="t('richdocuments', 'Search by name or folder')"
+		:empty-name="t('richdocuments', 'No documents edited in the last {days} days', { days })"
+		:type-options="typeOptions"
+		:date-groups="true">
+		<template #icon>
+			<ClockOutlineIcon :size="28" />
+		</template>
+		<template #default="{ items, viewMode, onFavoriteChanged }">
+			<component :is="viewMode === 'grid' ? 'DocumentCard' : 'DocumentRow'"
+				v-for="(item, i) in items"
+				:key="item.fileid"
+				:document="item"
+				:style="{ '--enter-index': i }"
+				@favorite-changed="onFavoriteChanged" />
+		</template>
+	</ListView>
+</template>
+
+<script>
+import ListView from './ListView.vue'
+import DocumentRow from './DocumentRow.vue'
+import DocumentCard from './DocumentCard.vue'
+import ClockOutlineIcon from 'vue-material-design-icons/ClockOutline.vue'
+import { buildTypeOptions } from './TypeFilter.vue'
+
+export default {
+	name: 'RecentView',
+	components: { ListView, DocumentRow, DocumentCard, ClockOutlineIcon },
+	data() {
+		return {
+			days: 60,
+			typeOptions: buildTypeOptions(),
+		}
+	},
+}
+</script>

--- a/src/views/Overview/SearchBar.vue
+++ b/src/views/Overview/SearchBar.vue
@@ -1,0 +1,123 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="search-bar">
+		<MagnifyIcon class="search-bar__icon" :size="20" />
+		<input ref="input"
+			class="search-bar__input"
+			type="search"
+			autocomplete="off"
+			:placeholder="placeholder"
+			:value="value"
+			:aria-label="placeholder"
+			@input="onInput($event.target.value)">
+		<button v-if="value"
+			type="button"
+			class="search-bar__clear"
+			:aria-label="t('richdocuments', 'Clear search')"
+			@click="clear">
+			<CloseIcon :size="18" />
+		</button>
+	</div>
+</template>
+
+<script>
+import MagnifyIcon from 'vue-material-design-icons/Magnify.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+
+const DEBOUNCE_MS = 250
+
+export default {
+	name: 'SearchBar',
+	components: { MagnifyIcon, CloseIcon },
+	props: {
+		value: { type: String, default: '' },
+		placeholder: { type: String, default: '' },
+	},
+	data() {
+		return { debounceTimer: null }
+	},
+	beforeDestroy() {
+		if (this.debounceTimer) {
+			clearTimeout(this.debounceTimer)
+		}
+	},
+	methods: {
+		onInput(next) {
+			if (this.debounceTimer) {
+				clearTimeout(this.debounceTimer)
+			}
+			this.debounceTimer = setTimeout(() => {
+				this.$emit('input', next)
+			}, DEBOUNCE_MS)
+		},
+		clear() {
+			if (this.debounceTimer) {
+				clearTimeout(this.debounceTimer)
+			}
+			this.$emit('input', '')
+			this.$nextTick(() => {
+				if (this.$refs.input) {
+					this.$refs.input.value = ''
+					this.$refs.input.focus()
+				}
+			})
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.search-bar {
+	position: sticky;
+	top: 0;
+	z-index: 5;
+	background-color: var(--color-main-background);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	border-radius: var(--border-radius-element, 999px);
+	border: 1px solid var(--color-border);
+
+	&:focus-within {
+		border-color: var(--color-primary-element);
+	}
+
+	&__icon {
+		color: var(--color-text-maxcontrast);
+		flex: 0 0 auto;
+	}
+	&__input {
+		flex: 1 1 auto;
+		min-width: 0;
+		border: 0;
+		background: transparent;
+		color: var(--color-main-text);
+		font-size: 1em;
+		padding: 4px 0;
+
+		&:focus {
+			outline: none;
+		}
+	}
+	&__clear {
+		all: unset;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		color: var(--color-text-maxcontrast);
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+	}
+}
+</style>

--- a/src/views/Overview/SharedView.vue
+++ b/src/views/Overview/SharedView.vue
@@ -1,0 +1,46 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<ListView kind="shared"
+		:title="t('richdocuments', 'Shared with me')"
+		:subtitle="t('richdocuments', 'Documents shared with you that have been edited in the last {days} days', { days })"
+		:search-placeholder="t('richdocuments', 'Search by name or folder')"
+		:empty-name="t('richdocuments', 'No shared documents edited in the last {days} days', { days })"
+		:type-options="typeOptions"
+		:date-groups="true">
+		<template #icon>
+			<AccountMultipleIcon :size="28" />
+		</template>
+		<template #default="{ items, viewMode, onFavoriteChanged }">
+			<component :is="viewMode === 'grid' ? 'DocumentCard' : 'DocumentRow'"
+				v-for="(item, i) in items"
+				:key="item.fileid"
+				:document="item"
+				:show-owner="true"
+				:style="{ '--enter-index': i }"
+				@favorite-changed="onFavoriteChanged" />
+		</template>
+	</ListView>
+</template>
+
+<script>
+import ListView from './ListView.vue'
+import DocumentRow from './DocumentRow.vue'
+import DocumentCard from './DocumentCard.vue'
+import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
+import { buildTypeOptions } from './TypeFilter.vue'
+
+export default {
+	name: 'SharedView',
+	components: { ListView, DocumentRow, DocumentCard, AccountMultipleIcon },
+	data() {
+		return {
+			days: 60,
+			typeOptions: buildTypeOptions(),
+		}
+	},
+}
+</script>

--- a/src/views/Overview/SubtleHint.vue
+++ b/src/views/Overview/SubtleHint.vue
@@ -1,0 +1,37 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="subtle-hint" role="status">
+		<component :is="icon" v-if="icon" :size="18" />
+		<span class="subtle-hint__text">{{ text }}</span>
+		<slot name="action" />
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'SubtleHint',
+	props: {
+		text: { type: String, required: true },
+		icon: { type: [Object, Function], default: null },
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.subtle-hint {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--color-text-maxcontrast);
+	font-size: 0.9em;
+	padding: 8px 4px;
+
+	&__text {
+		min-width: 0;
+	}
+}
+</style>

--- a/src/views/Overview/TemplateCard.vue
+++ b/src/views/Overview/TemplateCard.vue
@@ -1,0 +1,196 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<button class="tpl-card"
+		type="button"
+		:style="typeStyles"
+		:aria-label="t('richdocuments', 'Create new document from {template}', { template: template.name })"
+		@click="$emit('select', template)"
+		@mouseenter="onHoverEnter"
+		@mouseleave="onHoverLeave"
+		@focus="onHoverLeave"
+		@blur="onHoverLeave">
+		<div class="tpl-card__thumb">
+			<img v-if="!thumbErrored"
+				:src="template.thumbnailUrl"
+				:alt="''"
+				loading="lazy"
+				@error="thumbErrored = true">
+			<component :is="fallbackIcon" v-else :size="48" />
+		</div>
+		<div class="tpl-card__body">
+			<div class="tpl-card__name">
+				{{ template.name }}
+			</div>
+			<div class="tpl-card__ext">
+				{{ extensionLabel }}
+			</div>
+		</div>
+		<div class="tpl-card__overlay">
+			<PlusIcon :size="32" />
+		</div>
+	</button>
+</template>
+
+<script>
+import FileWordIcon from 'vue-material-design-icons/FileWord.vue'
+import FileExcelIcon from 'vue-material-design-icons/FileExcel.vue'
+import FilePresentationBoxIcon from 'vue-material-design-icons/FilePresentationBox.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import hoverPreviewMixin from './hoverPreviewMixin.js'
+import { typeStyle } from './typeStyles.js'
+
+const ICON_BY_MIME = {
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': FileWordIcon,
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.template': FileWordIcon,
+	'application/vnd.oasis.opendocument.text': FileWordIcon,
+	'application/vnd.oasis.opendocument.text-template': FileWordIcon,
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': FileExcelIcon,
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.template': FileExcelIcon,
+	'application/vnd.oasis.opendocument.spreadsheet': FileExcelIcon,
+	'application/vnd.oasis.opendocument.spreadsheet-template': FileExcelIcon,
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation': FilePresentationBoxIcon,
+	'application/vnd.openxmlformats-officedocument.presentationml.template': FilePresentationBoxIcon,
+	'application/vnd.oasis.opendocument.presentation': FilePresentationBoxIcon,
+	'application/vnd.oasis.opendocument.presentation-template': FilePresentationBoxIcon,
+}
+
+export default {
+	name: 'TemplateCard',
+	components: { PlusIcon },
+	mixins: [hoverPreviewMixin],
+	props: {
+		template: { type: Object, required: true },
+	},
+	data() {
+		return { thumbErrored: false }
+	},
+	computed: {
+		fallbackIcon() {
+			return ICON_BY_MIME[this.template.mimetype] ?? FileDocumentOutlineIcon
+		},
+		extensionLabel() {
+			return (this.template.extension || '').toUpperCase()
+		},
+		typeStyles() {
+			return typeStyle(this.template.mimetype)
+		},
+		largePreviewUrl() {
+			if (!this.template.thumbnailUrl) {
+				return ''
+			}
+			return this.template.thumbnailUrl
+				.replace(/([?&])x=\d+/, '$1x=480')
+				.replace(/([?&])y=\d+/, '$1y=480')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.tpl-card {
+	all: unset;
+	cursor: pointer;
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	border-radius: var(--border-radius-large, 12px);
+	overflow: hidden;
+	background-color: var(--color-main-background);
+	border: 1px solid var(--color-border);
+	color: var(--color-main-text);
+	transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+	animation: tpl-card-enter 260ms ease-out backwards;
+	animation-delay: calc(min(var(--enter-index, 0), 12) * 35ms);
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+
+	&:hover, &:focus-visible {
+		transform: translateY(-2px);
+		box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+		border-color: var(--color-primary-element);
+	}
+	&:focus-visible {
+		outline: 2px solid var(--color-primary-element);
+		outline-offset: 2px;
+	}
+
+	&__thumb {
+		aspect-ratio: 4 / 3;
+		background-color: var(--type-bg, var(--color-background-dark));
+		box-shadow: inset 0 0 0 3px var(--type-accent, var(--color-border));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+		color: var(--type-accent, var(--color-text-maxcontrast));
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+	}
+
+	&__body {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		padding: 10px 12px 12px;
+		min-width: 0;
+	}
+	&__name {
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	&__ext {
+		font-size: 0.8em;
+		color: var(--color-text-maxcontrast);
+		letter-spacing: 0.04em;
+	}
+
+	&__overlay {
+		position: absolute;
+		top: 8px;
+		right: 8px;
+		width: 40px;
+		height: 40px;
+		border-radius: 50%;
+		background-color: var(--type-accent, var(--color-primary-element));
+		color: #fff;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		opacity: 0;
+		transform: scale(0.8);
+		transition: opacity 0.15s ease, transform 0.15s ease;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+	}
+
+	&:hover &__overlay,
+	&:focus-visible &__overlay {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+@keyframes tpl-card-enter {
+	from {
+		opacity: 0;
+		transform: translateY(8px) scale(0.985);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+</style>

--- a/src/views/Overview/TemplateRow.vue
+++ b/src/views/Overview/TemplateRow.vue
@@ -1,0 +1,178 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<button class="tpl-row"
+		type="button"
+		:style="typeStyles"
+		@click="$emit('select', template)"
+		@mouseenter="onHoverEnter"
+		@mouseleave="onHoverLeave"
+		@focus="onHoverLeave"
+		@blur="onHoverLeave">
+		<div class="tpl-row__thumb">
+			<img v-if="!thumbErrored"
+				:src="template.thumbnailUrl"
+				:alt="''"
+				loading="lazy"
+				@error="thumbErrored = true">
+			<component :is="fallbackIcon" v-else :size="40" />
+		</div>
+		<div class="tpl-row__main">
+			<div class="tpl-row__name">
+				{{ template.name }}
+			</div>
+			<div class="tpl-row__ext">
+				{{ extensionLabel }}
+			</div>
+		</div>
+		<PlusIcon class="tpl-row__add" :size="20" />
+	</button>
+</template>
+
+<script>
+import FileWordIcon from 'vue-material-design-icons/FileWord.vue'
+import FileExcelIcon from 'vue-material-design-icons/FileExcel.vue'
+import FilePresentationBoxIcon from 'vue-material-design-icons/FilePresentationBox.vue'
+import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import hoverPreviewMixin from './hoverPreviewMixin.js'
+import { typeStyle } from './typeStyles.js'
+
+const ICON_BY_MIME = {
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': FileWordIcon,
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.template': FileWordIcon,
+	'application/vnd.oasis.opendocument.text': FileWordIcon,
+	'application/vnd.oasis.opendocument.text-template': FileWordIcon,
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': FileExcelIcon,
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.template': FileExcelIcon,
+	'application/vnd.oasis.opendocument.spreadsheet': FileExcelIcon,
+	'application/vnd.oasis.opendocument.spreadsheet-template': FileExcelIcon,
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation': FilePresentationBoxIcon,
+	'application/vnd.openxmlformats-officedocument.presentationml.template': FilePresentationBoxIcon,
+	'application/vnd.oasis.opendocument.presentation': FilePresentationBoxIcon,
+	'application/vnd.oasis.opendocument.presentation-template': FilePresentationBoxIcon,
+}
+
+export default {
+	name: 'TemplateRow',
+	components: { PlusIcon },
+	mixins: [hoverPreviewMixin],
+	props: {
+		template: { type: Object, required: true },
+	},
+	data() {
+		return { thumbErrored: false }
+	},
+	computed: {
+		fallbackIcon() {
+			return ICON_BY_MIME[this.template.mimetype] ?? FileDocumentOutlineIcon
+		},
+		extensionLabel() {
+			return (this.template.extension || '').toUpperCase()
+		},
+		typeStyles() {
+			return typeStyle(this.template.mimetype)
+		},
+		largePreviewUrl() {
+			if (!this.template.thumbnailUrl) {
+				return ''
+			}
+			return this.template.thumbnailUrl
+				.replace(/([?&])x=\d+/, '$1x=480')
+				.replace(/([?&])y=\d+/, '$1y=480')
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.tpl-row {
+	all: unset;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	padding: 10px 12px;
+	border-radius: var(--border-radius-large, 12px);
+	color: var(--color-main-text);
+	transition: background-color 0.12s ease;
+	animation: tpl-row-enter 240ms ease-out backwards;
+	animation-delay: calc(min(var(--enter-index, 0), 12) * 30ms);
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+
+	&:hover, &:focus-visible {
+		background-color: var(--color-background-hover);
+	}
+	&:focus-visible {
+		outline: 2px solid var(--color-primary-element);
+		outline-offset: -2px;
+	}
+
+	&__thumb {
+		flex: 0 0 auto;
+		width: 56px;
+		height: 56px;
+		border-radius: var(--border-radius, 8px);
+		background-color: var(--type-bg, var(--color-background-dark));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+		color: var(--type-accent, var(--color-text-maxcontrast));
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
+		}
+	}
+
+	&__main {
+		flex: 1 1 auto;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+	&__name {
+		font-weight: 500;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	&__ext {
+		font-size: 0.85em;
+		color: var(--color-text-maxcontrast);
+		letter-spacing: 0.04em;
+	}
+
+	&__add {
+		flex: 0 0 auto;
+		color: var(--type-accent, var(--color-primary-element));
+		opacity: 0;
+		transition: opacity 0.12s ease;
+	}
+	&:hover &__add,
+	&:focus-visible &__add {
+		opacity: 1;
+	}
+}
+
+@keyframes tpl-row-enter {
+	from {
+		opacity: 0;
+		transform: translateY(6px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+</style>

--- a/src/views/Overview/TemplatesView.vue
+++ b/src/views/Overview/TemplatesView.vue
@@ -1,0 +1,56 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div>
+		<ListView kind="templates"
+			:title="t('richdocuments', 'Create new document')"
+			:subtitle="t('richdocuments', 'Pick one of your personal templates to start a new document')"
+			:search-placeholder="t('richdocuments', 'Search templates')"
+			:empty-name="t('richdocuments', 'You haven\'t created any templates yet.')"
+			:type-options="typeOptions">
+			<template #icon>
+				<FileDocumentPlusIcon :size="28" />
+			</template>
+			<template #default="{ items, viewMode }">
+				<component :is="viewMode === 'grid' ? 'TemplateCard' : 'TemplateRow'"
+					v-for="(item, i) in items"
+					:key="item.fileid"
+					:template="item"
+					:style="{ '--enter-index': i }"
+					@select="onSelect" />
+			</template>
+		</ListView>
+		<CreateFromTemplateModal v-if="selected"
+			:template="selected"
+			@close="selected = null" />
+	</div>
+</template>
+
+<script>
+import ListView from './ListView.vue'
+import TemplateRow from './TemplateRow.vue'
+import TemplateCard from './TemplateCard.vue'
+import CreateFromTemplateModal from './CreateFromTemplateModal.vue'
+import FileDocumentPlusIcon from 'vue-material-design-icons/FileDocumentPlus.vue'
+import { buildTypeOptions } from './TypeFilter.vue'
+
+export default {
+	name: 'TemplatesView',
+	components: { ListView, TemplateRow, TemplateCard, CreateFromTemplateModal, FileDocumentPlusIcon },
+	data() {
+		return {
+			selected: null,
+			// Templates can never be PDF, so omit that pill on this view.
+			typeOptions: buildTypeOptions().filter(o => o.key !== 'pdfs'),
+		}
+	},
+	methods: {
+		onSelect(template) {
+			this.selected = template
+		},
+	},
+}
+</script>

--- a/src/views/Overview/TypeFilter.vue
+++ b/src/views/Overview/TypeFilter.vue
@@ -1,0 +1,115 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="type-filter" role="tablist" :aria-label="t('richdocuments', 'Filter by file type')">
+		<button v-for="option in options"
+			:key="option.value || 'all'"
+			type="button"
+			role="tab"
+			class="type-filter__pill"
+			:class="{ 'type-filter__pill--active': isActive(option.value) }"
+			:aria-selected="isActive(option.value)"
+			:aria-controls="ariaControls"
+			@click="$emit('input', option.value)">
+			<component :is="option.icon" v-if="option.icon" :size="16" />
+			<span>{{ option.label }}</span>
+		</button>
+	</div>
+</template>
+
+<script>
+import { translate as t } from '@nextcloud/l10n'
+import FileMultipleIcon from 'vue-material-design-icons/FileMultiple.vue'
+import FileWordIcon from 'vue-material-design-icons/FileWord.vue'
+import FileExcelIcon from 'vue-material-design-icons/FileExcel.vue'
+import FilePresentationBoxIcon from 'vue-material-design-icons/FilePresentationBox.vue'
+import FilePdfBoxIcon from 'vue-material-design-icons/FilePdfBox.vue'
+
+/**
+ * Build the canonical type-filter option list. Consumers can drop entries
+ * (e.g. omit "PDFs" on the templates view).
+ *
+ * @return {Array<{value: ?string, label: string, icon: object, key: string}>} fresh option list
+ */
+export function buildTypeOptions() {
+	return [
+		{ value: null, label: t('richdocuments', 'All'), icon: FileMultipleIcon, key: 'all' },
+		{ value: 'documents', label: t('richdocuments', 'Documents'), icon: FileWordIcon, key: 'documents' },
+		{ value: 'spreadsheets', label: t('richdocuments', 'Spreadsheets'), icon: FileExcelIcon, key: 'spreadsheets' },
+		{ value: 'presentations', label: t('richdocuments', 'Presentations'), icon: FilePresentationBoxIcon, key: 'presentations' },
+		{ value: 'pdfs', label: t('richdocuments', 'PDFs'), icon: FilePdfBoxIcon, key: 'pdfs' },
+	]
+}
+
+export default {
+	name: 'TypeFilter',
+	props: {
+		value: { type: String, default: null },
+		options: {
+			type: Array,
+			required: true,
+			validator: arr => arr.every(o => 'value' in o && 'label' in o),
+		},
+		ariaControls: { type: String, default: undefined },
+	},
+	methods: {
+		isActive(optionValue) {
+			return (this.value || null) === (optionValue || null)
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.type-filter {
+	display: flex;
+	gap: 8px;
+	overflow-x: auto;
+	scrollbar-width: thin;
+	padding: 2px 0;
+
+	&::-webkit-scrollbar {
+		height: 4px;
+	}
+	&::-webkit-scrollbar-thumb {
+		background: var(--color-border-dark);
+		border-radius: 2px;
+	}
+
+	&__pill {
+		all: unset;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 14px;
+		border-radius: var(--border-radius-element, 999px);
+		background-color: var(--color-background-dark);
+		color: var(--color-main-text);
+		font-size: 0.9em;
+		font-weight: 500;
+		white-space: nowrap;
+		transition: background-color 0.12s ease, color 0.12s ease;
+
+		&:hover {
+			background-color: var(--color-background-hover);
+		}
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: 2px;
+		}
+
+		&--active {
+			background-color: var(--color-primary-element);
+			color: var(--color-primary-element-text);
+
+			&:hover {
+				background-color: var(--color-primary-element-hover);
+			}
+		}
+	}
+}
+</style>

--- a/src/views/Overview/ViewToggle.vue
+++ b/src/views/Overview/ViewToggle.vue
@@ -1,0 +1,79 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="view-toggle" role="group" :aria-label="t('richdocuments', 'Switch view')">
+		<button type="button"
+			class="view-toggle__button"
+			:class="{ 'view-toggle__button--active': value === 'list' }"
+			:aria-pressed="value === 'list'"
+			:title="t('richdocuments', 'List view')"
+			@click="$emit('input', 'list')">
+			<ViewListIcon :size="20" />
+		</button>
+		<button type="button"
+			class="view-toggle__button"
+			:class="{ 'view-toggle__button--active': value === 'grid' }"
+			:aria-pressed="value === 'grid'"
+			:title="t('richdocuments', 'Grid view')"
+			@click="$emit('input', 'grid')">
+			<ViewGridIcon :size="20" />
+		</button>
+	</div>
+</template>
+
+<script>
+import ViewListIcon from 'vue-material-design-icons/ViewList.vue'
+import ViewGridIcon from 'vue-material-design-icons/ViewGrid.vue'
+
+export default {
+	name: 'ViewToggle',
+	components: { ViewListIcon, ViewGridIcon },
+	props: {
+		value: {
+			type: String,
+			default: 'list',
+			validator: v => ['list', 'grid'].includes(v),
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.view-toggle {
+	display: inline-flex;
+	border-radius: var(--border-radius-element, 999px);
+	background-color: var(--color-background-dark);
+	padding: 2px;
+	gap: 2px;
+
+	&__button {
+		all: unset;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 32px;
+		border-radius: var(--border-radius-element, 999px);
+		color: var(--color-text-maxcontrast);
+		transition: background-color 0.12s ease, color 0.12s ease;
+
+		&:hover {
+			color: var(--color-main-text);
+		}
+		&:focus-visible {
+			outline: 2px solid var(--color-primary-element);
+			outline-offset: 0;
+		}
+
+		&--active {
+			background-color: var(--color-main-background);
+			color: var(--color-primary-element);
+			box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+		}
+	}
+}
+</style>

--- a/src/views/Overview/api.js
+++ b/src/views/Overview/api.js
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+const HOME_LIMIT = 6
+const PAGE_LIMIT = 25
+
+const ocsUrl = path => generateOcsUrl('apps/richdocuments/api/v1/overview/' + path)
+
+// Standard headers for OCS endpoints. `OCS-APIRequest: true` makes the
+// request pass Nextcloud's CSRF check via the OCS-bypass branch in
+// IRequest::passesCSRFCheck() — necessary for POSTs in particular.
+const OCS_HEADERS = { 'OCS-APIRequest': 'true' }
+
+const unwrap = response => response.data?.ocs?.data ?? { items: [], nextOffset: null }
+
+/**
+ * Fetch one page of the recent / shared / templates list.
+ *
+ * @param {('recent'|'shared'|'templates')} kind which list to fetch
+ * @param {object} options request options
+ * @param {string|null} [options.q] search query
+ * @param {string|null} [options.type] mime-type filter group key
+ * @param {number} [options.offset] pagination offset
+ * @param {number} [options.limit] page size
+ * @param {AbortSignal} [options.signal] cancellation signal
+ * @return {Promise<{items: Array, nextOffset: ?number}>}
+ */
+export async function fetchList(kind, { q = null, type = null, offset = 0, limit = PAGE_LIMIT, signal } = {}) {
+	const params = { offset, limit }
+	if (q) {
+		params.q = q
+	}
+	if (type) {
+		params.type = type
+	}
+	const response = await axios.get(ocsUrl(kind), { params, signal, headers: OCS_HEADERS })
+	return unwrap(response)
+}
+
+/**
+ * Fetch the small "home" preview slice for a kind (no search, no offset).
+ *
+ * @param {('recent'|'shared'|'templates')} kind which list to fetch
+ * @param {AbortSignal} [signal] cancellation signal
+ * @return {Promise<{items: Array, nextOffset: ?number}>}
+ */
+export function fetchHome(kind, signal) {
+	return fetchList(kind, { offset: 0, limit: HOME_LIMIT, signal })
+}
+
+/**
+ * Create a new file from a template.
+ *
+ * @param {object} payload body
+ * @param {number} payload.templateFileId template node id
+ * @param {string} payload.filename desired filename (no extension)
+ * @param {string} payload.folderPath user-relative target folder
+ * @return {Promise<{fileid: number, name: string, path: string, openUrl: string}>}
+ */
+export async function createFromTemplate({ templateFileId, filename, folderPath }) {
+	const response = await axios.post(ocsUrl('create-from-template'), {
+		templateFileId,
+		filename,
+		folderPath,
+	}, { headers: OCS_HEADERS })
+	return response.data?.ocs?.data ?? null
+}
+
+/**
+ * Toggle the favourite (pinned) flag for a file. The backend wires through
+ * to Nextcloud's per-user favourites tagger so pins are also visible in
+ * the Files app's "Favorites" view.
+ *
+ * @param {number} fileid file node id
+ * @param {boolean} favorite desired flag
+ * @return {Promise<{fileid: number, favorite: boolean}>}
+ */
+export async function setFavourite(fileid, favorite) {
+	const response = await axios.post(ocsUrl('favourite'), { fileid, favorite }, { headers: OCS_HEADERS })
+	return response.data?.ocs?.data ?? { fileid, favorite }
+}
+
+export const PAGE_SIZE = PAGE_LIMIT
+export const HOME_SECTION_LIMIT = HOME_LIMIT

--- a/src/views/Overview/confetti.js
+++ b/src/views/Overview/confetti.js
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Tiny dependency-free confetti burst rendered into a fixed-position layer
+ * appended to <body>. Auto-cleans after the animation finishes.
+ *
+ * Honours `prefers-reduced-motion`: when the user has reduced motion
+ * enabled, returns immediately without rendering anything.
+ *
+ * @param {object} [options] burst options
+ * @param {number} [options.count] number of particles
+ * @param {number} [options.duration] total animation duration in ms
+ * @param {Array<string>} [options.colors] particle colours
+ * @param {{x: number, y: number}} [options.origin] viewport-relative origin in pixels
+ */
+export function fireConfetti({
+	count = 80,
+	duration = 900,
+	colors = ['#46ba61', '#2c73d2', '#d24726', '#f5b400', '#9b59b6', '#1abc9c'],
+	origin,
+} = {}) {
+	if (typeof window === 'undefined' || typeof document === 'undefined') {
+		return
+	}
+	const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+	if (reduce) {
+		return
+	}
+
+	const ox = origin?.x ?? window.innerWidth / 2
+	const oy = origin?.y ?? window.innerHeight / 2
+
+	const layer = document.createElement('div')
+	layer.setAttribute('aria-hidden', 'true')
+	layer.style.cssText = [
+		'position:fixed',
+		'inset:0',
+		'pointer-events:none',
+		'overflow:hidden',
+		'z-index:99999',
+	].join(';')
+	document.body.appendChild(layer)
+
+	for (let i = 0; i < count; i++) {
+		const piece = document.createElement('span')
+		const angle = Math.random() * Math.PI * 2
+		const speed = 120 + Math.random() * 220
+		const dx = Math.cos(angle) * speed
+		const dy = Math.sin(angle) * speed - 80 // slight upward bias
+		const rotation = (Math.random() * 720 - 360).toFixed(0)
+		const color = colors[i % colors.length]
+		const size = 6 + Math.random() * 6
+		const lifetime = duration * (0.7 + Math.random() * 0.3)
+		piece.style.cssText = [
+			'position:absolute',
+			`left:${ox}px`,
+			`top:${oy}px`,
+			`width:${size}px`,
+			`height:${size * 0.6}px`,
+			`background:${color}`,
+			'border-radius:1px',
+			`transform:translate(-50%, -50%) rotate(${(Math.random() * 360).toFixed(0)}deg)`,
+			'will-change:transform, opacity',
+			`animation:confetti-piece ${lifetime}ms cubic-bezier(0.16, 1, 0.3, 1) forwards`,
+			`--dx:${dx.toFixed(0)}px`,
+			`--dy:${dy.toFixed(0)}px`,
+			`--rot:${rotation}deg`,
+		].join(';')
+		layer.appendChild(piece)
+	}
+
+	// Inject the keyframes once.
+	if (!document.getElementById('overview-confetti-keyframes')) {
+		const style = document.createElement('style')
+		style.id = 'overview-confetti-keyframes'
+		style.textContent = `
+			@keyframes confetti-piece {
+				0% {
+					opacity: 1;
+					transform: translate(-50%, -50%) rotate(0deg);
+				}
+				100% {
+					opacity: 0;
+					transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--rot));
+				}
+			}
+		`
+		document.head.appendChild(style)
+	}
+
+	// Clean up the layer once the longest animation finishes.
+	window.setTimeout(() => layer.remove(), duration + 200)
+}

--- a/src/views/Overview/dateGrouping.js
+++ b/src/views/Overview/dateGrouping.js
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { translate as t } from '@nextcloud/l10n'
+
+/**
+ * Bucket a list of items into date groups based on each item's `mtime`.
+ *
+ * Buckets, in order:
+ *   - today
+ *   - yesterday
+ *   - this-week (the rest of the current week up to last Monday)
+ *   - this-month (the rest of the current month)
+ *   - older
+ *
+ * Empty buckets are filtered out so the consumer can iterate the result
+ * directly without rendering empty section headers.
+ *
+ * @param {Array<{mtime?: number}>} items document items, each with a unix mtime
+ * @param {number} [now] override "now" for testing (ms epoch)
+ * @return {Array<{key: string, title: string, items: Array}>} ordered, non-empty groups
+ */
+export function groupItemsByDate(items, now = Date.now()) {
+	const today = new Date(now)
+	today.setHours(0, 0, 0, 0)
+
+	const yesterday = new Date(today)
+	yesterday.setDate(yesterday.getDate() - 1)
+
+	// Start of the ISO-ish week — last Monday.
+	const dow = today.getDay() // 0 (Sun) .. 6 (Sat)
+	const daysSinceMonday = dow === 0 ? 6 : dow - 1
+	const weekStart = new Date(today)
+	weekStart.setDate(weekStart.getDate() - daysSinceMonday)
+
+	const monthStart = new Date(today.getFullYear(), today.getMonth(), 1)
+
+	const buckets = {
+		today: { key: 'today', title: t('richdocuments', 'Today'), items: [] },
+		yesterday: { key: 'yesterday', title: t('richdocuments', 'Yesterday'), items: [] },
+		week: { key: 'week', title: t('richdocuments', 'Earlier this week'), items: [] },
+		month: { key: 'month', title: t('richdocuments', 'Earlier this month'), items: [] },
+		older: { key: 'older', title: t('richdocuments', 'Older'), items: [] },
+	}
+
+	for (const item of items) {
+		const ms = (item.mtime ?? 0) * 1000
+		const itemDay = new Date(ms)
+		itemDay.setHours(0, 0, 0, 0)
+		const dayMs = itemDay.getTime()
+
+		if (dayMs >= today.getTime()) {
+			buckets.today.items.push(item)
+		} else if (dayMs >= yesterday.getTime()) {
+			buckets.yesterday.items.push(item)
+		} else if (dayMs >= weekStart.getTime()) {
+			buckets.week.items.push(item)
+		} else if (dayMs >= monthStart.getTime()) {
+			buckets.month.items.push(item)
+		} else {
+			buckets.older.items.push(item)
+		}
+	}
+
+	return Object.values(buckets).filter(b => b.items.length > 0)
+}

--- a/src/views/Overview/hoverPreviewMixin.js
+++ b/src/views/Overview/hoverPreviewMixin.js
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { openHoverPreview, closeHoverPreview } from './hoverPreviewState.js'
+
+const HOVER_DELAY_MS = 400
+
+/**
+ * Mixin that wires `mouseenter` / `mouseleave` (and focus / blur) handlers
+ * on a row or card to the singleton hover-preview popover.
+ *
+ * Components mixing this in must expose:
+ *   - `largePreviewUrl` (computed): high-res thumbnail URL
+ *   - `fallbackIcon` (computed): icon component for missing previews
+ *
+ * The component name is derived from `this.document.name` or
+ * `this.template.name`, whichever is present.
+ */
+export default {
+	data() {
+		return { hoverTimer: null }
+	},
+	beforeDestroy() {
+		this.cancelHoverPreview()
+		closeHoverPreview()
+	},
+	methods: {
+		onHoverEnter(event) {
+			this.cancelHoverPreview()
+			const target = event.currentTarget
+			this.hoverTimer = window.setTimeout(() => {
+				openHoverPreview(target, {
+					src: this.largePreviewUrl,
+					name: this.document?.name ?? this.template?.name ?? '',
+					fallbackIcon: this.fallbackIcon,
+				})
+			}, HOVER_DELAY_MS)
+		},
+		onHoverLeave() {
+			this.cancelHoverPreview()
+			closeHoverPreview()
+		},
+		cancelHoverPreview() {
+			if (this.hoverTimer) {
+				clearTimeout(this.hoverTimer)
+				this.hoverTimer = null
+			}
+		},
+	},
+}

--- a/src/views/Overview/hoverPreviewMount.js
+++ b/src/views/Overview/hoverPreviewMount.js
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import Vue from 'vue'
+import HoverPreview from './HoverPreview.vue'
+import { hoverPreviewState, markHoverPreviewError } from './hoverPreviewState.js'
+
+let mounted = false
+
+/**
+ * Mount a singleton hover-preview popover directly under <body>.
+ *
+ * Mounting outside the SPA's NcContent root sidesteps two browser
+ * behaviours that would otherwise hide the popover inside grid cards:
+ *   - NcContent has `overflow: hidden`, which clips fixed-position
+ *     descendants in some engines.
+ *   - Cards have `transform` on hover, which makes them the containing
+ *     block for any fixed-position descendants AND clips them via
+ *     `overflow: hidden`.
+ *
+ * The popover reads from the shared `hoverPreviewState` so any row or
+ * card across the app can drive it from anywhere in the tree.
+ */
+export function mountHoverPreview() {
+	if (mounted || typeof document === 'undefined') {
+		return
+	}
+	mounted = true
+
+	const el = document.createElement('div')
+	el.setAttribute('data-richdocuments-hover-preview', '')
+	document.body.appendChild(el)
+
+	/* eslint-disable-next-line no-new */
+	new Vue({
+		render(h) {
+			if (!hoverPreviewState.open) {
+				// Render nothing while hidden — Vue still tracks the
+				// `open` read so the next mutation re-runs render().
+				return h()
+			}
+			return h(HoverPreview, {
+				props: {
+					popoverStyle: hoverPreviewState.style,
+					src: hoverPreviewState.src,
+					name: hoverPreviewState.name,
+					fallbackIcon: hoverPreviewState.fallbackIcon,
+					errored: hoverPreviewState.errored,
+				},
+				on: {
+					error: markHoverPreviewError,
+				},
+			})
+		},
+	}).$mount(el)
+}

--- a/src/views/Overview/hoverPreviewState.js
+++ b/src/views/Overview/hoverPreviewState.js
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import Vue from 'vue'
+
+const PREVIEW_WIDTH = 360
+const PREVIEW_HEIGHT = 320
+const VIEWPORT_MARGIN = 12
+
+/**
+ * Singleton reactive state for the hover-preview popover.
+ *
+ * The popover lives once at the SPA root (OverviewApp) so it escapes any
+ * `transform` / `overflow:hidden` ancestor — grid cards have both, which
+ * would otherwise clip a popover rendered inside them.
+ *
+ * @type {{open: boolean, style: object, src: string, name: string, fallbackIcon: ?(object|Function), errored: boolean}} reactive popover state
+ */
+export const hoverPreviewState = Vue.observable({
+	open: false,
+	style: {},
+	src: '',
+	name: '',
+	fallbackIcon: null,
+	errored: false,
+})
+
+/**
+ * Show the popover anchored to the given target element. No-ops on
+ * `prefers-reduced-motion` so users who opt out of motion don't see
+ * surprise popovers.
+ *
+ * @param {HTMLElement} target hovered element
+ * @param {object} payload preview content
+ * @param {string} [payload.src] thumbnail URL
+ * @param {string} [payload.name] file or template name
+ * @param {?(object|Function)} [payload.fallbackIcon] icon component for missing previews
+ */
+export function openHoverPreview(target, { src = '', name = '', fallbackIcon = null } = {}) {
+	if (typeof window === 'undefined' || !target) {
+		return
+	}
+	if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+		return
+	}
+
+	const rect = target.getBoundingClientRect()
+
+	let left = rect.left
+	const maxLeft = window.innerWidth - PREVIEW_WIDTH - VIEWPORT_MARGIN
+	left = Math.max(VIEWPORT_MARGIN, Math.min(left, maxLeft))
+
+	let top = rect.bottom + VIEWPORT_MARGIN
+	if (top + PREVIEW_HEIGHT > window.innerHeight - VIEWPORT_MARGIN) {
+		const above = rect.top - PREVIEW_HEIGHT - VIEWPORT_MARGIN
+		if (above >= VIEWPORT_MARGIN) {
+			top = above
+		} else {
+			top = Math.max(VIEWPORT_MARGIN, window.innerHeight - PREVIEW_HEIGHT - VIEWPORT_MARGIN)
+		}
+	}
+
+	hoverPreviewState.style = {
+		left: `${Math.round(left)}px`,
+		top: `${Math.round(top)}px`,
+	}
+	hoverPreviewState.src = src
+	hoverPreviewState.name = name
+	hoverPreviewState.fallbackIcon = fallbackIcon
+	hoverPreviewState.errored = false
+	hoverPreviewState.open = true
+}
+
+/**
+ * Hide the popover. Safe to call repeatedly.
+ */
+export function closeHoverPreview() {
+	hoverPreviewState.open = false
+	hoverPreviewState.errored = false
+}
+
+/**
+ * Mark the current preview as errored so the consumer renders a fallback
+ * icon rather than a broken image.
+ */
+export function markHoverPreviewError() {
+	hoverPreviewState.errored = true
+}

--- a/src/views/Overview/typeStyles.js
+++ b/src/views/Overview/typeStyles.js
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Map a mimetype to one of the four type-color families used throughout
+ * the overview UI. Returns null for anything we don't surface.
+ *
+ * @param {string} mimetype the file's mimetype
+ * @return {('document'|'spreadsheet'|'presentation'|'pdf'|null)} type family
+ */
+export function familyFor(mimetype) {
+	switch (mimetype) {
+	case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+	case 'application/vnd.openxmlformats-officedocument.wordprocessingml.template':
+	case 'application/vnd.oasis.opendocument.text':
+	case 'application/vnd.oasis.opendocument.text-template':
+		return 'document'
+	case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
+	case 'application/vnd.openxmlformats-officedocument.spreadsheetml.template':
+	case 'application/vnd.oasis.opendocument.spreadsheet':
+	case 'application/vnd.oasis.opendocument.spreadsheet-template':
+		return 'spreadsheet'
+	case 'application/vnd.openxmlformats-officedocument.presentationml.presentation':
+	case 'application/vnd.openxmlformats-officedocument.presentationml.template':
+	case 'application/vnd.oasis.opendocument.presentation':
+	case 'application/vnd.oasis.opendocument.presentation-template':
+		return 'presentation'
+	case 'application/pdf':
+		return 'pdf'
+	default:
+		return null
+	}
+}
+
+/**
+ * Type-family palette. Each entry exposes:
+ *   bg: 12% tinted background (for thumbnail surface when no preview)
+ *   accent: solid accent (for icon stroke and corner badge)
+ *
+ * Hues chosen to roughly match the office suite conventions while
+ * staying readable in both light and dark themes.
+ */
+export const TYPE_PALETTE = {
+	document: { bg: 'rgba(44, 115, 210, 0.14)', accent: '#2c73d2' },
+	spreadsheet: { bg: 'rgba(31, 122, 61, 0.14)', accent: '#1f7a3d' },
+	presentation: { bg: 'rgba(210, 71, 38, 0.14)', accent: '#d24726' },
+	pdf: { bg: 'rgba(196, 51, 51, 0.14)', accent: '#c43333' },
+}
+
+/**
+ * Resolve the per-mimetype CSS custom-property bag to set on a row/card
+ * root element. Returns an object suitable for `:style="..."`.
+ *
+ * Components reference the variables (`--type-bg`, `--type-accent`)
+ * inside scoped styles so themes can still override them via inheritance.
+ *
+ * @param {string} mimetype the file's mimetype
+ * @return {{'--type-bg': string, '--type-accent': string}} CSS custom-property bag
+ */
+export function typeStyle(mimetype) {
+	const family = familyFor(mimetype)
+	const palette = (family && TYPE_PALETTE[family]) || {
+		bg: 'var(--color-background-dark)',
+		accent: 'var(--color-text-maxcontrast)',
+	}
+	return {
+		'--type-bg': palette.bg,
+		'--type-accent': palette.accent,
+	}
+}

--- a/templates/overview.php
+++ b/templates/overview.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+\OCP\Util::addScript('richdocuments', 'richdocuments-overview');
+\OCP\Util::addStyle('richdocuments', 'overview');
+// The Vue app mounts at #content (replacing it) — matching the pattern
+// used by the Files app. Mounting inside a wrapper div would cause
+// NcContent's position:fixed layout to overlay the Nextcloud chrome.
+?>

--- a/webpack.js
+++ b/webpack.js
@@ -17,6 +17,7 @@ webpackConfig.entry = {
 	personal: path.join(__dirname, 'src', 'personal.js'),
 	reference: path.join(__dirname, 'src', 'reference.js'),
 	public: path.join(__dirname, 'src', 'public.js'),
+	overview: path.join(__dirname, 'src', 'overview.js'),
 }
 
 webpackRules.RULE_JS.test = /\.m?js$/


### PR DESCRIPTION
Adds a new top-level "Office" entry to the app menu that opens a Vue SPA at /apps/richdocuments/overview, providing a single landing page for the user's office work.

Features:
- Home with three sections: My recent docs, Shared with me, Templates
- Dedicated views for each, with date grouping (Today / Yesterday / Earlier this week / Earlier this month / Older) and sticky headers
- Type filter pills (Documents / Spreadsheets / Presentations / PDFs)
- List and grid view toggle, persisted in localStorage
- Hover quick-preview popover (mounted at <body> via singleton)
- Active-editor badges with pulsing live indicator (WOPI tokens)
- Pinning / favourites integrated with Nextcloud's per-user tags so pins also appear in the Files app's Favorites view
- Type-coloured thumbnails with frame on grid cards
- Friendly empty-state illustrations with calls to action
- Confetti + showSuccess toast on document creation
- Smooth fade/slide route transitions, all motion respects prefers-reduced-motion

Backend:
- OverviewService runs an indexed user-folder SearchQuery (mime IN + 60-day mtime window), partitions by ownership for recent vs shared, and batch-loads active editors and favourites per page
- OverviewController renders the SPA shell as RENDER_AS_USER
- OverviewApiController exposes paginated OCS endpoints, plus create-from-template and favourite-toggle, with strict input validation and OCS-bypass CSRF handling

Frontend:
- Vue 2 + vue-router 3 SPA mounted at #content (Files-app pattern)
- Reuses Nextcloud's design system primitives (NcContent, NcAppNavigation, NcAvatar, NcDateTime, NcDialog, NcEmptyContent, NcLoadingIcon, NcButton, NcTextField)
- Optimistic UI for pin toggling


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required


<img width="2871" height="1560" alt="20260506_215621" src="https://github.com/user-attachments/assets/db3aefec-4a6d-4ffc-ace9-05750ecef6aa" />
<img width="2871" height="1560" alt="20260506_215546" src="https://github.com/user-attachments/assets/6f6c1bfc-3b32-4615-a310-7fd7e0f04fbb" />
<img width="2871" height="1560" alt="20260506_215521" src="https://github.com/user-attachments/assets/204e573c-d379-48ef-8124-f473ee1df27c" />

