### PR TITLE
Fix overlapping buttons in header

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -676,6 +676,7 @@ export default {
 	height: 100dvh;
 	top: -50px;
 	position: absolute;
+	z-index: 10001;
 }
 
 [data-handler="richdocuments"] .modal-header {


### PR DESCRIPTION
* Resolves: #5538 
* Target version: main

### Summary

The bug was probably introduced in https://github.com/nextcloud/richdocuments/pull/5496

Fixes this button overlap:

<img width="760" height="69" alt="Screenshot from 2026-04-27 16-06-50" src="https://github.com/user-attachments/assets/66cea548-3399-4245-a4e2-ccb520703856" />

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
