### PR TITLE
fix(wopi): stable guest UserId and correct IsAnonymousUser for named guests

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -485,7 +485,7 @@ class WopiController extends Controller {
 			}
 
 			$isPublic = empty($wopi->getEditorUid());
-			$guestUserId = 'Guest-' . substr(hash('sha256', $wopi->getToken()), 0, 8);
+			$guestUserId = 'Guest-' . substr(hash('sha256', $wopi->getToken()), 0, 16);
 			$userId = !$isPublic ? $wopi->getEditorUid() : $guestUserId;
 
 			$userConfig = $this->settingsService->generateSettingsConfig($type, $userId);

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -161,7 +161,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$guestUserId = 'Guest-' . \OCP\Server::get(\OCP\Security\ISecureRandom::class)->generate(8);
+		$guestUserId = 'Guest-' . substr(hash('sha256', $wopi->getToken()), 0, 16);
 		$user = $this->userManager->get($wopi->getEditorUid());
 		$userDisplayName = $user !== null && !$isPublic ? $user->getDisplayName() : $wopi->getGuestDisplayname();
 		$isSmartPickerEnabled = (bool)$wopi->getCanwrite() && !$isPublic && !$wopi->getDirect();
@@ -293,7 +293,7 @@ class WopiController extends Controller {
 
 		if ($isPublic) {
 			$response['UserExtraInfo']['is_guest'] = true; // DEPRECATED
-			$response['IsAnonymousUser'] = true;
+			$response['IsAnonymousUser'] = empty($wopi->getGuestDisplayname());
 		} else {
 			$response['IsAnonymousUser'] = false;
 		}
@@ -485,7 +485,7 @@ class WopiController extends Controller {
 			}
 
 			$isPublic = empty($wopi->getEditorUid());
-			$guestUserId = 'Guest-' . \OCP\Server::get(\OCP\Security\ISecureRandom::class)->generate(8);
+			$guestUserId = 'Guest-' . substr(hash('sha256', $wopi->getToken()), 0, 8);
 			$userId = !$isPublic ? $wopi->getEditorUid() : $guestUserId;
 
 			$userConfig = $this->settingsService->generateSettingsConfig($type, $userId);


### PR DESCRIPTION
## Problem

Two bugs in `WopiController::checkFileInfo()` prevent cursor presence from working when a named guest edits a document via a public link alongside a logged-in user.

### Bug 1 — Guest `UserId` is randomly generated on every WOPI call

```php
// Before (broken)
$guestUserId = 'Guest-' . \OCP\Server::get(\OCP\Security\ISecureRandom::class)->generate(8);
```

The WOPI protocol requires `UserId` to be stable for the duration of a session. Collabora calls `CheckFileInfo` multiple times (e.g. on token refresh), and each call returned a *different* random ID for the same guest. Collabora treats each new ID as a new user, breaking cursor tracking and view presence entirely.

### Bug 2 — `IsAnonymousUser` is unconditionally `true` for all public link users

```php
// Before (broken)
if ($isPublic) {
    $response['IsAnonymousUser'] = true; // set even when guest has a display name
}
```

Collabora interprets `IsAnonymousUser = true` as a privacy signal and hides that user's cursor from other editors. This is correct for a truly anonymous viewer (no name entered), but wrong for a guest who has explicitly entered a display name in the Nextcloud sharing prompt.

## Fix

1. Derive `UserId` deterministically from the WOPI token using SHA-256, so the same guest token always maps to the same identity within a session.
2. Only set `IsAnonymousUser = true` when the guest has *no* display name. Named guests get `false`, enabling cursor visibility.

```php
// After
$guestUserId = 'Guest-' . substr(hash('sha256', $wopi->getToken()), 0, 8);

$response['IsAnonymousUser'] = empty($wopi->getGuestDisplayname());
```

## Steps to reproduce

1. Share a document with a public edit link
2. Open the document as a logged-in admin
3. Open the public link in another browser / incognito window, enter a name when prompted
4. Both users type — the logged-in user cannot see the guest's cursor or writing indicator

## Expected behaviour

Named guests have a visible, coloured cursor indicator, just like any other named collaborator.

## Tested on

- Nextcloud 33
- richdocuments 10.1.2
- Collabora Online CODE 25.04.9.4