### PR TITLE
refactor(Helper,TokenManager): migrate guest cookie access to IRequest add typing throughout

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -594,7 +594,7 @@ class WopiController extends Controller {
 			if ($isPutRelative) {
 				// the new file needs to be installed in the current user dir
 				$userFolder = $this->rootFolder->getUserFolder($wopi->getEditorUid());
-				$file = $userFolder->getFirstNodeById($fileId);
+				$file = $userFolder->getFirstNodeById((int)$fileId);
 				if ($file === null) {
 					return new JSONResponse([], Http::STATUS_NOT_FOUND);
 				}

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -25,20 +25,18 @@ class Helper {
 	}
 
 	/**
-	 * Parse the WOPI/richdocuments file identifier string.
+	 * Parse a WOPI file identifier string into its components.
 	 *
-	 * Breaks the WOPI-encoded file identifier into Nextcloud fileId and optional instanceId, version, and template parts.
-	 *
-	 * Format examples:
+	 * Supports standard and template-based identifiers. Standard formats include:
 	 * - {fileId}
 	 * - {fileId}_{instanceId}
 	 * - {fileId}_{instanceId}_{version}
 	 *
-	 * For template-based documents, the file part contains a template marker and may be
+	 * For template-based documents, the file part contains a template marker and is expected to be
 	 * encoded as "{fileId}/{templateId}".
 	 *
-	 * @param string $fileId WOPI-encoded file identifier.
-	 * @return array{0: string, 1: string, 2: string, 3: string|null}
+	 * @param string $fileId The WOPI-encoded file identifier string to parse.
+	 * @return array{0: string, 1: string, 2: string, 3: string|null} [fileId, instanceId, version, templateId]
 	 * @throws \InvalidArgumentException If the identifier does not match the expected format.
 	 */
 	public static function parseFileId(string $fileId): array {

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -81,13 +81,6 @@ class Helper {
 		return $filename;
 	}
 
-	public function getGuestNameFromCookie() {
-		if ($this->userId !== null || !isset($_COOKIE['guestUser']) || $_COOKIE['guestUser'] === '') {
-			return null;
-		}
-		return $_COOKIE['guestUser'];
-	}
-
 	public function getShareFromNode(Node $node): ?IShare {
 		try {
 			$storage = $node->getStorage();

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -25,38 +25,40 @@ class Helper {
 	}
 
 	/**
-	 * Parse the WOPI file identifier string.
+	 * Parse the WOPI/richdocuments file identifier string.
+	 *
+	 * Breaks the WOPI-encoded file identifier into Nextcloud fileId and optional instanceId, version, and template parts.
+	 *
+	 * Format examples:
+	 * - {fileId}
+	 * - {fileId}_{instanceId}
+	 * - {fileId}_{instanceId}_{version}
+	 *
+	 * For template-based documents, the file part contains a template marker and may be
+	 * encoded as "{fileId}/{templateId}".
 	 *
 	 * @param string $fileId WOPI-encoded file identifier.
 	 * @return array{0: string, 1: string, 2: string, 3: string|null}
-	 * @throws \Exception If the identifier does not match the expected format.
+	 * @throws \InvalidArgumentException If the identifier does not match the expected format.
 	 */
 	public static function parseFileId(string $fileId): array {
-		$arr = explode('_', $fileId);
+		$parts = explode('_', $fileId);
+
+		if (count($parts) > 3) {
+			throw new \InvalidArgumentException('$fileId does not match the expected format');
+		}
+
+		$fileIdPart = $parts[0];
+		$instanceId = $parts[1] ?? '';
+		$version = $parts[2] ?? '0';
 		$templateId = null;
-		if (count($arr) === 1) {
-			$fileId = $arr[0];
-			$instanceId = '';
-			$version = '0';
-		} elseif (count($arr) === 2) {
-			[$fileId, $instanceId] = $arr;
-			$version = '0';
-		} elseif (count($arr) === 3) {
-			[$fileId, $instanceId, $version] = $arr;
-		} else {
-			throw new \Exception('$fileId has not the expected format');
+
+		$hasTemplateMarker = str_contains($fileIdPart, '-');
+		if ($hasTemplateMarker) {
+			[$fileIdPart, $templateId] = array_pad(explode('/', $fileIdPart, 2), 2, null);
 		}
 
-		if (str_contains($fileId, '-')) {
-			[$fileId, $templateId] = array_pad(explode('/', $fileId), 2, null);
-		}
-
-		return [
-			$fileId,
-			$instanceId,
-			$version,
-			$templateId,
-		];
+		return [$fileIdPart, $instanceId, $version, $templateId];
 	}
 
 	/**

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -1,6 +1,6 @@
 <?php
-declare(strict_types=1);
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -66,6 +66,9 @@ class Helper {
 	 * @return string|false Formatted timestamp, or false if conversion fails.
 	 */
 	public static function toISO8601(int $time): string|false {
+		// TODO: Be more precise and don't ignore milli, micro seconds?
+		// 		 e.g. Accept float|DateTimeInterface to support sub-second precision
+		//		 (.u is always 000000 with int input).
 		$datetime = DateTime::createFromFormat('U', (string)$time, new DateTimeZone('UTC'));
 		if ($datetime) {
 			return $datetime->format('Y-m-d\TH:i:s.u\Z');

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
@@ -16,19 +17,21 @@ use OCP\Share\IShare;
 
 class Helper {
 	/**
-	 * @param string|null $userId
+	 * @param string|null $userId Current user ID, or null for guest sessions.
 	 */
 	public function __construct(
-		private $userId,
+		private ?string $userId,
 	) {
 	}
 
 	/**
-	 * @param string $fileId
-	 * @return array
-	 * @throws \Exception
+	 * Parse the WOPI file identifier string.
+	 *
+	 * @param string $fileId WOPI-encoded file identifier.
+	 * @return array{0: string, 1: string, 2: string, 3: string|null}
+	 * @throws \Exception If the identifier does not match the expected format.
 	 */
-	public static function parseFileId(string $fileId) {
+	public static function parseFileId(string $fileId): array {
 		$arr = explode('_', $fileId);
 		$templateId = null;
 		if (count($arr) === 1) {
@@ -52,17 +55,18 @@ class Helper {
 			$fileId,
 			$instanceId,
 			$version,
-			$templateId
+			$templateId,
 		];
 	}
 
 	/**
-	 * WOPI helper function to convert to ISO 8601 round-trip format.
-	 * @param integer $time Must be seconds since unix epoch
+	 * Convert a Unix timestamp to WOPI's ISO 8601 round-trip format.
+	 *
+	 * @param int $time Seconds since the Unix epoch.
+	 * @return string|false Formatted timestamp, or false if conversion fails.
 	 */
-	public static function toISO8601($time) {
-		// TODO: Be more precise and don't ignore milli, micro seconds ?
-		$datetime = DateTime::createFromFormat('U', $time, new DateTimeZone('UTC'));
+	public static function toISO8601(int $time): string|false {
+		$datetime = DateTime::createFromFormat('U', (string)$time, new DateTimeZone('UTC'));
 		if ($datetime) {
 			return $datetime->format('Y-m-d\TH:i:s.u\Z');
 		}
@@ -70,17 +74,40 @@ class Helper {
 		return false;
 	}
 
-	public static function getNewFileName(Folder $folder, $filename) {
+	/**
+	 * Return a unique file name by appending an incrementing suffix if needed.
+	 *
+	 * @param Folder $folder Folder to check for name collisions.
+	 * @param string $filename Proposed file name.
+	 * @return string Collision-free file name.
+	 * @throws \RuntimeException If regex/PCRE outright fails (unlikely).
+	 */
+	public static function getNewFileName(Folder $folder, string $filename): string {
 		$fileNum = 1;
 
 		while ($folder->nodeExists($filename)) {
 			$fileNum++;
-			$filename = preg_replace('/(\.| \(\d+\)\.)([^.]*)$/', ' (' . $fileNum . ').$2', $filename);
+			$newFilename = preg_replace('/(\.| \(\d+\)\.)([^.]*)$/', ' (' . $fileNum . ').$2', $filename);
+
+			if ($newFilename === null) {
+				// unlikely unless regex is broken
+				throw new \RuntimeException('Failed to generate a unique filename');
+			}
+
+			$filename = $newFilename;
 		}
 
 		return $filename;
 	}
 
+	/**
+	 * Resolve the share associated with a node from shared storage.
+	 *
+	 * TODO: Put this elsewhere.
+	 *
+	 * @param Node $node File node to inspect.
+	 * @return IShare|null The share backing the node, or null if it is not shared.
+	 */
 	public function getShareFromNode(Node $node): ?IShare {
 		try {
 			$storage = $node->getStorage();

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -102,7 +102,7 @@ class TokenManager {
 		}
 
 		/** @var File $file */
-		$file = $userFolder->getFirstNodeById($fileId);
+		$file = $userFolder->getFirstNodeById((int)$fileId);
 
 		// Check node readability (for storage wrapper overwrites like terms of services)
 		if ($file === null || !$file->isReadable()) {
@@ -133,7 +133,7 @@ class TokenManager {
 		$guestName = $editoruid === null ? $this->prepareGuestName($this->getGuestNameFromCookie()) : null;
 
 		return $this->wopiMapper->generateFileToken(
-			$fileId,
+			(int)$fileId,
 			$owneruid,
 			$editoruid,
 			$version,

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -21,6 +21,7 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
@@ -40,13 +41,19 @@ class TokenManager {
 		private PermissionManager $permissionManager,
 		private IEventDispatcher $eventDispatcher,
 		private LoggerInterface $logger,
+		private IRequest $request,
 	) {
 	}
 
 	/**
 	 * @throws Exception
 	 */
-	public function generateWopiToken(string $fileId, ?string $shareToken = null, ?string $editoruid = null, bool $direct = false): Wopi {
+	public function generateWopiToken(
+		string $fileId,
+		?string $shareToken = null,
+		?string $editoruid = null,
+		bool $direct = false,
+	): Wopi {
 		[$fileId, , $version] = Helper::parseFileId($fileId);
 		$owneruid = null;
 		$hideDownload = false;
@@ -121,15 +128,45 @@ class TokenManager {
 		$this->eventDispatcher->dispatchTyped(new BeforeNodeReadEvent($file));
 
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
-		$guestName = $editoruid === null ? $this->prepareGuestName($this->helper->getGuestNameFromCookie()) : null;
-		return $this->wopiMapper->generateFileToken($fileId, $owneruid, $editoruid, $version, $updatable, $serverHost, $guestName, $hideDownload, $direct, 0, $shareToken);
+
+		$guestName = $editoruid === null ? $this->prepareGuestName($this->getGuestNameFromCookie()) : null;
+
+		return $this->wopiMapper->generateFileToken(
+			$fileId,
+			$owneruid,
+			$editoruid,
+			$version,
+			$updatable,
+			$serverHost,
+			$guestName,
+			$hideDownload,
+			$direct,
+			0,
+			$shareToken
+		);
+	}
+
+	private function getGuestNameFromCookie(): ?string {
+		$guestUser = $this->request->getCookie('guestUser');
+
+		if ($guestUser === '' || $guestUser === null) {
+			return null;
+		}
+
+		return $guestUser;
 	}
 
 	/**
 	 * This method is receiving the results from the TOKEN_TYPE_FEDERATION generated on the opener server
 	 * that is created in {@link newInitiatorToken}
 	 */
-	public function upgradeToRemoteToken(Wopi $wopi, Wopi $remoteWopi, string $shareToken, string $remoteServer, string $remoteServerToken): Wopi {
+	public function upgradeToRemoteToken(
+		Wopi $wopi,
+		Wopi $remoteWopi,
+		string $shareToken,
+		string $remoteServer,
+		string $remoteServerToken,
+	): Wopi {
 		if ($remoteWopi->getTokenType() !== Wopi::TOKEN_TYPE_INITIATOR) {
 			return $wopi;
 		}
@@ -150,7 +187,7 @@ class TokenManager {
 		return $wopi;
 	}
 
-	public function upgradeFromDirectInitiator(Direct $direct, Wopi $wopi) {
+	public function upgradeFromDirectInitiator(Direct $direct, Wopi $wopi): Wopi {
 		$wopi->setTokenType(Wopi::TOKEN_TYPE_REMOTE_GUEST);
 		$wopi->setEditorUid(null);
 		$wopi->setRemoteServer($direct->getInitiatorHost());
@@ -207,7 +244,13 @@ class TokenManager {
 		);
 	}
 
-	public function newInitiatorToken($sourceServer, ?Node $node = null, $shareToken = null, bool $direct = false, $userId = null): Wopi {
+	public function newInitiatorToken(
+		string $sourceServer,
+		?Node $node = null,
+		?string $shareToken = null,
+		bool $direct = false,
+		?string $userId = null
+	): Wopi {
 		if ($node !== null) {
 			$wopi = $this->generateWopiToken((string)$node->getId(), $shareToken, $userId, $direct);
 			$wopi->setServerHost($sourceServer);
@@ -226,7 +269,7 @@ class TokenManager {
 		return $wopi;
 	}
 
-	public function prepareGuestName(?string $guestName = null) {
+	public function prepareGuestName(?string $guestName = null): string {
 		if (empty($guestName)) {
 			return $this->trans->t('Anonymous guest');
 		}
@@ -244,13 +287,10 @@ class TokenManager {
 	}
 
 	/**
-	 * @param string $accessToken
-	 * @param string $guestName
-	 * @return void
 	 * @throws Exceptions\ExpiredTokenException
 	 * @throws Exceptions\UnknownTokenException
 	 */
-	public function updateGuestName(string $accessToken, string $guestName) {
+	public function updateGuestName(string $accessToken, string $guestName): void {
 		$wopi = $this->wopiMapper->getWopiForToken($accessToken);
 		$wopi->setGuestDisplayname($this->prepareGuestName($guestName));
 		$this->wopiMapper->update($wopi);

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1)
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -255,7 +255,7 @@ class TokenManager {
 		?Node $node = null,
 		?string $shareToken = null,
 		bool $direct = false,
-		?string $userId = null
+		?string $userId = null,
 	): Wopi {
 		if ($node !== null) {
 			$wopi = $this->generateWopiToken((string)$node->getId(), $shareToken, $userId, $direct);

--- a/lib/TokenManager.php
+++ b/lib/TokenManager.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1)
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -147,6 +148,11 @@ class TokenManager {
 	}
 
 	private function getGuestNameFromCookie(): ?string {
+		// prevent a logged-in user from being treated as a guest via the cookie
+		if ($this->userId === null) {
+			return null;
+		}
+
 		$guestUser = $this->request->getCookie('guestUser');
 
 		if ($guestUser === '' || $guestUser === null) {

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -80,11 +80,6 @@
       <code><![CDATA[putContent]]></code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="lib/Helper.php">
-    <InvalidScalarArgument>
-      <code><![CDATA[$time]]></code>
-    </InvalidScalarArgument>
-  </file>
   <file src="lib/PermissionManager.php">
     <RedundantCondition>
       <code><![CDATA[$share && method_exists($share, 'getAttributes')]]></code>


### PR DESCRIPTION
* Target version: main

### Summary

Moves guest-name cookie access off the `$_COOKIE` superglobal and onto the injected `IRequest` service, and modernizes `Helper` and `TokenManager` with new typing/docs/etc.

### Changes

**`lib/Helper.php`**
- Add `declare(strict_types=1)`
- Add type hints to constructor (`?string $userId`) and all method signatures
- Refactor `parseFileId()`: cleaner logic, throw `\InvalidArgumentException` instead of `\Exception` (all call sites either already capture this via "catch-all" `\Exception` handling or already let it bubble up so should be a non-issue) , add `explode` limit for correctness, add typed array shape to `@return`
- Null-check `preg_replace` result in `getNewFileName()` to avoid silent failure
- Remove `getGuestNameFromCookie()` (moved to `TokenManager` which was the only caller anyway)
- Add/improve docblocks throughout

**`lib/TokenManager.php`**
- Inject `IRequest` via constructor
- Move `getGuestNameFromCookie()` here as a private method using `IRequest::getCookie()` instead of `$_COOKIE`
- Add missing return types (`Wopi`, `string`, `void`)
- Reformat long method signatures (one parameter per line)
- Clean up redundant docblock tags where type hints are now explicit

### TODO

- [x] Test / see what I broke

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
