### PR TITLE
fix(settings): only allow setting auth token types to request config access

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -8,6 +8,7 @@ namespace OCA\Richdocuments\Controller;
 
 use OCA\Richdocuments\AppConfig;
 use OCA\Richdocuments\Capabilities;
+use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Service\CapabilitiesService;
 use OCA\Richdocuments\Service\ConnectivityService;
@@ -490,6 +491,9 @@ class SettingsController extends Controller {
 	public function getSettingsFile(string $type, string $token, string $category, string $name) {
 		try {
 			$wopi = $this->wopiMapper->getWopiForToken($token);
+			if ($wopi->getTokenType() !== Wopi::TOKEN_TYPE_SETTING_AUTH) {
+				throw new NotPermittedException();
+			}
 			$userId = $wopi->getEditorUid() ?: $wopi->getOwnerUid();
 			if ($type === 'userconfig') {
 				$type = $type . '/' . $userId;
@@ -511,6 +515,8 @@ class SettingsController extends Controller {
 					'Content-Type' => $systemFile->getMimeType() ?: 'application/octet-stream'
 				]
 			);
+		} catch (NotPermittedException $e) {
+			return new DataDisplayResponse('Forbidden.', Http::STATUS_FORBIDDEN);
 		} catch (NotFoundException $e) {
 			return new DataDisplayResponse('File not found.', 404);
 		} catch (\Exception $e) {

--- a/tests/features/bootstrap/SettingsContext.php
+++ b/tests/features/bootstrap/SettingsContext.php
@@ -19,6 +19,9 @@ class SettingsContext implements Context {
 	/** @var ServerContext */
 	private $serverContext;
 
+	/** @var WopiContext */
+	private $wopiContext;
+
 	/** @var GuzzleHttp\Client */
 	private $http;
 
@@ -32,6 +35,7 @@ class SettingsContext implements Context {
 	#[BeforeScenario]
 	public function gatherContexts(BeforeScenarioScope $scope) {
 		$this->serverContext = $scope->getEnvironment()->getContext(ServerContext::class);
+		$this->wopiContext = $scope->getEnvironment()->getContext(WopiContext::class);
 
 		$this->http = new GuzzleHttp\Client([
 			'base_uri' => $this->serverContext->getBaseUrl() . 'index.php/apps/richdocuments/',
@@ -130,6 +134,43 @@ class SettingsContext implements Context {
 		});
 	}
 
+	#[When('user :user uploads a user configuration file')]
+	public function userUploadsUserConfigFile(string $user) {
+		$this->serverContext->actingAsUser($user);
+
+		$settingsAccessToken = $this->getSettingsAccessToken('user');
+		$postOptions = [
+			'query' => [
+				'access_token' => $settingsAccessToken,
+				'fileId' => '/settings/userconfig/wordbook/poc.dic',
+			],
+			'body' => 'fake dictionary',
+		];
+
+		$options = array_merge($this->serverContext->getWebOptions(), $postOptions);
+		$this->http->post('wopi/settings/upload', $options);
+	}
+
+	#[When('user :user requests their own user configuration file')]
+	public function userRequestsOwnUserConfigFile(string $user) {
+		$this->serverContext->actingAsUser($user);
+
+		$token = $this->getSettingsAccessToken('user');
+		$this->httpResponse = $this->http->get(
+			"settings/userconfig/$token/wordbook/poc.dic",
+			$this->serverContext->getWebOptions()
+		);
+	}
+
+	#[When('the guest uses the share token to request the user configuration file')]
+	public function guestRequestsUserConfigFileWithShareToken() {
+		$guestToken = $this->wopiContext->getWopiToken();
+
+		$this->httpResponse = $this->http->get(
+			"settings/userconfig/$guestToken/wordbook/poc.dic"
+		);
+	}
+
 	#[Then('the admin settings are forbidden')]
 	public function adminSettingsRequestForbidden() {
 		Assert::assertEquals(403, $this->httpResponse->getStatusCode());
@@ -167,6 +208,16 @@ class SettingsContext implements Context {
 	#[Then('the system configuration deletion is allowed')]
 	public function systemConfigDeletionAllowed() {
 		Assert::assertEquals(200, $this->httpResponse->getStatusCode());
+	}
+
+	#[Then('the user configuration file is returned')]
+	public function userConfigFileRequestIsSuccessful() {
+		Assert::assertEquals(200, $this->httpResponse->getStatusCode());
+	}
+
+	#[Then('the user configuration file is forbidden')]
+	public function userConfigFileAccessIsForbidden() {
+		Assert::assertEquals(403, $this->httpResponse->getStatusCode());
 	}
 
 	private function getSettingsAccessToken(string $type) {

--- a/tests/features/user-settings.feature
+++ b/tests/features/user-settings.feature
@@ -1,0 +1,21 @@
+Feature: User Settings
+
+  Background:
+    Given user "user1" exists
+
+  Scenario: A user can retrieve their own user configuration file
+    When user "user1" uploads a user configuration file
+    And user "user1" requests their own user configuration file
+    Then the user configuration file is returned
+
+  Scenario: A guest cannot access a user's configuration file using a public share token
+    Given as user "user1"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/test.odt"
+    And as "user1" create a share with
+      | path        | /test.odt |
+      | shareType   | 3         |
+      | permissions | 1         |
+    When user "user1" uploads a user configuration file
+    And A guest opens the file "test.odt" in the last share link through direct editing
+    And the guest uses the share token to request the user configuration file
+    Then the user configuration file is forbidden


### PR DESCRIPTION
Enforce a check in `SettingsController` to ensure only tokens of type `Wopi::TOKEN_TYPE_SETTING_AUTH` can access user configuration files, returning a 403 Forbidden response for unauthorized attempts.

Also includes tests to verify this behavior.