### PR TITLE
fix(wopi): properly validate old timestamp

### DIFF
--- a/lib/Middleware/WOPIMiddleware.php
+++ b/lib/Middleware/WOPIMiddleware.php
@@ -88,7 +88,8 @@ class WOPIMiddleware extends Middleware {
 
 				if ($hasProofKey) {
 					$wopiTimestamp = $this->request->getHeader('X-WOPI-TimeStamp');
-					$wopiTimestampIsOld = $this->proofKeyService->isOldTimestamp((int)$wopiTimestamp);
+					$unixTimestamp = $this->proofKeyService->ticksToUnixTimestamp((int)$wopiTimestamp);
+					$wopiTimestampIsOld = $this->proofKeyService->isOldTimestamp($unixTimestamp);
 
 					if ($wopiTimestampIsOld) {
 						throw new WopiException('X-WOPI-TimeStamp header is older than 20 minutes');

--- a/lib/Service/ProofKeyService.php
+++ b/lib/Service/ProofKeyService.php
@@ -17,11 +17,10 @@ use phpseclib3\Math\BigInteger;
 use Throwable;
 
 class ProofKeyService {
-	// The Windows epoch is used for WOPI timestamps (as it is a MS protocol)
-	//     Notes: According to the MS documentation it begins on 01-01-0001
-	//            but all evidence in practice points to 01-01-1601
-	private const WINDOWS_EPOCH = '01-01-1601 00:00:00';
-	private const UNIX_EPOCH = '01-01-1970 00:00:00';
+	// Offset between the .NET epoch (01-01-0001 00:00:00 UTC)
+	// and the Unix epoch (01-01-1970 00:00:00 UTC)
+	// in 100-nanosecond intervals
+	private const EPOCH_OFFSET = 621355968000000000;
 
 	public function __construct(
 		private DiscoveryService $discoveryService,
@@ -48,27 +47,20 @@ class ProofKeyService {
 		return $isValid;
 	}
 
-	public function windowsToUnixTimestamp(string $windowsTimestamp): string {
-		// Convert the epochs to timestamps
-		$windowsEpoch = strtotime(self::WINDOWS_EPOCH);
-		$unixEpoch = strtotime(self::UNIX_EPOCH);
+	public function ticksToUnixTimestamp(int $ticks): int {
+		// Subtract the epoch offset from the .NET ticks
+		$unixTicks = $ticks - self::EPOCH_OFFSET;
 
-		// Calculate the difference between the Unix and Windows epochs in seconds
-		$epochOffset = (float)($unixEpoch - $windowsEpoch);
+		// Divide that by 1e7 to convert from 100ns intervals to seconds
+		$unixTimestamp = intdiv($unixTicks, 10000000);
 
-		// Convert the Windows timestamp from 100-nanoseconds intervals to seconds
-		$windowsTimestampSeconds = ((float)$windowsTimestamp) / 1e7;
-
-		// Finally, subtract the number of seconds between the Windows and Unix epochs
-		// from the number of seconds in the given Windows timestamp
-		$convertedWindowsTimestamp = (int)($windowsTimestampSeconds - $epochOffset);
-
-		return (string)$convertedWindowsTimestamp;
+		// That leaves us with the Unix timestamp
+		return $unixTimestamp;
 	}
 
-	public function isOldTimestamp(int $timestamp): bool {
+	public function isOldTimestamp(int $unixTimestamp): bool {
 		$timestampDateTime = new DateTime();
-		$timestampDateTime->setTimestamp($timestamp);
+		$timestampDateTime->setTimestamp($unixTimestamp);
 
 		$now = new DateTimeImmutable();
 		$controlDateTime = $now->modify('-20 minutes');

--- a/tests/lib/Service/ProofKeyServiceTest.php
+++ b/tests/lib/Service/ProofKeyServiceTest.php
@@ -56,12 +56,14 @@ class ProofKeyServiceTest extends TestCase {
 		$this->proofKeyService = new ProofKeyService($this->discoveryService);
 	}
 
-	public function testWindowsToUnixTimestamp(): void {
-		// Timestamps representing 15 February, 2024 00:00:00
-		$windowsTimestamp = '133524468000000000';
-		$expectedUnixTimestamp = '1707973200';
+	public function testTicksToUnixTimestamp(): void {
+		// .NET ticks representing the Unix epoch
+		$ticksUnixEpoch = 621355968000000000;
 
-		$unixTimestamp = $this->proofKeyService->windowsToUnixTimestamp($windowsTimestamp);
+		// The conversion should result in a Unix timestamp of 0
+		$expectedUnixTimestamp = 0;
+
+		$unixTimestamp = $this->proofKeyService->ticksToUnixTimestamp($ticksUnixEpoch);
 
 		$this->assertEquals($expectedUnixTimestamp, $unixTimestamp);
 	}


### PR DESCRIPTION
Firstly, the timestamp age validation was not even being used -- so we call that method. Then, the conversion was incorrect, so that needed to be fixed. In any case, the logic seems much clearer and I have renamed some methods and variables to make things easier to reason about.