### PR TITLE
fix: Make preview timeout an info log instead of error

### DIFF
--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -101,7 +101,7 @@ class RemoteService {
 
 			return $body;
 		} catch (\Exception $e) {
-			$this->logger->error('Failed to convert preview: ' . $e->getMessage(), ['exception' => $e]);
+			$this->logger->info('Failed to convert preview: ' . $e->getMessage(), ['exception' => $e]);
 			throw $e;
 		}
 	}


### PR DESCRIPTION
Align with the similar error message in in lib/Preview/Office.php

* Target version: main

### Summary

Align with the similar error message in in lib/Preview/Office.php

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
