### PR TITLE
fix(richdocuments): gate conversion with SecureViewService check

### DIFF
--- a/lib/Conversion/ConversionProvider.php
+++ b/lib/Conversion/ConversionProvider.php
@@ -152,6 +152,7 @@ class ConversionProvider implements IConversionProvider {
 				$secured = $this->secureViewService->shouldSecure(
 					$file->getInternalPath(),
 					$file->getStorage(),
+					false,
 				);
 			} catch (NotFoundException $e) {
 				$this->logger->warning('Could not determine Secure View status for conversion target', ['exception' => $e]);

--- a/lib/Conversion/ConversionProvider.php
+++ b/lib/Conversion/ConversionProvider.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 namespace OCA\Richdocuments\Conversion;
 
 use OCA\Richdocuments\Service\RemoteService;
+use OCA\Richdocuments\Service\SecureViewService;
 use OCP\Files\Conversion\ConversionMimeProvider;
 use OCP\Files\Conversion\IConversionProvider;
 use OCP\Files\File;
+use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
@@ -53,6 +55,7 @@ class ConversionProvider implements IConversionProvider {
 		private RemoteService $remoteService,
 		private LoggerInterface $logger,
 		IFactory $l10nFactory,
+		private SecureViewService $secureViewService,
 	) {
 		$this->l10n = $l10nFactory->get('richdocuments');
 	}
@@ -142,6 +145,23 @@ class ConversionProvider implements IConversionProvider {
 				'Unable to determine the proper file extension for %1$s',
 				[$targetMimeType]
 			));
+		}
+
+		if ($this->secureViewService->isEnabled()) {
+			try {
+				$secured = $this->secureViewService->shouldSecure(
+					$file->getInternalPath(),
+					$file->getStorage(),
+				);
+			} catch (NotFoundException $e) {
+				$this->logger->warning('Could not determine Secure View status for conversion target', ['exception' => $e]);
+				throw new \Exception($this->l10n->t('Conversion is unavailable for this file.'));
+			}
+			if ($secured) {
+				throw new \Exception($this->l10n->t(
+					'Conversion is blocked because the file is protected by Secure View.'
+				));
+			}
 		}
 
 		return $this->remoteService->convertFileTo($file, $targetFileExtension);


### PR DESCRIPTION
Server-side conversion bypassed the Secure View / watermark restriction that the viewer enforces, allowing a user with view-only secure access to download a clean copy via the conversion API. Reuse SecureViewService (same logic the viewer uses) to deny conversion for files that should be secured. Handle the documented NotFoundException so a cache miss surfaces as a clear, translated error instead of a 500.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ x] If the file is secured, the "Save as..." is not possible because this could bypass the security. We could hide the menu entry in this case. Would need changes in `apps/files/src/actions/convertAction.ts`

### Checklist

- [x] Code is properly formatted
- [x ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
