### PR TITLE
test: use correct app content selector

### DIFF
--- a/cypress/e2e/settings.spec.js
+++ b/cypress/e2e/settings.spec.js
@@ -20,10 +20,10 @@ describe('Office admin settings', function() {
 	})
 
 	it('Error for invalid url', function() {
-		cy.get('#app-content')
+		cy.get('#app-content-vue')
 			.scrollTo('topLeft')
 
-		cy.get('#app-content')
+		cy.get('#app-content-vue')
 			.scrollIntoView()
 			.should('be.visible')
 		cy.screenshot()
@@ -40,10 +40,10 @@ describe('Office admin settings', function() {
 	})
 
 	it('Opens settings and configure a valid url', function() {
-		cy.get('#app-content')
+		cy.get('#app-content-vue')
 			.scrollTo('topLeft')
 
-		cy.get('#app-content')
+		cy.get('#app-content-vue')
 			.scrollIntoView()
 			.should('be.visible')
 		cy.screenshot()


### PR DESCRIPTION
* Target version: main

### Summary
Ever since https://github.com/nextcloud/server/pull/60236 was merged, `settings.spec.js` fails because it is trying to select `#app-content` instead of `#app-content-vue`

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
