### PR TITLE
fix: mention snap install command for CODE

### DIFF
--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -56,6 +56,7 @@ class Admin implements ISettings {
 					'web_server' => strtolower($_SERVER['SERVER_SOFTWARE']),
 					'os_family' => PHP_VERSION_ID >= 70200 ? PHP_OS_FAMILY : PHP_OS,
 					'platform' => php_uname('m'),
+					'is_snap' => $this->isSnapInstallation(),
 					'fonts' => $this->fontService->getFontFileNames(),
 					'esignature_base_url' => $this->config->getAppValue('richdocuments', 'esignature_base_url'),
 					'esignature_client_id' => $this->config->getAppValue('richdocuments', 'esignature_client_id'),
@@ -76,5 +77,14 @@ class Admin implements ISettings {
 	#[\Override]
 	public function getPriority(): int {
 		return 0;
+	}
+
+	private function isSnapInstallation(): bool {
+		$snap = getenv('SNAP');
+		if ($snap !== false && $snap !== '') {
+			return true;
+		}
+
+		return str_starts_with((string)$this->config->getSystemValue('datadirectory', ''), '/var/snap/nextcloud/');
 	}
 }

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -125,7 +125,10 @@
 						</p>
 						<p class="option-inline-emphasized">
 							{{ t('richdocuments', 'If the installation from the App Store fails, you can still do that manually using this command:') }}
-							<tt>php -d memory_limit=512M occ app:install {{ CODEAppID }}</tt>
+							<tt>{{ manualCODEInstallCommand }}</tt>
+							<br>
+							{{ t('richdocuments', 'For Nextcloud Snap installations, use:') }}
+							<tt>{{ snapCODEInstallCommand }}</tt>
 						</p>
 					</div>
 				</div>
@@ -571,6 +574,12 @@ export default {
 		},
 		callbackUrl() {
 			return this.settings.wopi_callback_url ? this.settings.wopi_callback_url : getCallbackBaseUrl()
+		},
+		manualCODEInstallCommand() {
+			return `php -d memory_limit=512M occ app:install ${this.CODEAppID}`
+		},
+		snapCODEInstallCommand() {
+			return `sudo nextcloud.occ app:install ${this.CODEAppID}`
 		},
 	},
 	watch: {

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -125,10 +125,7 @@
 						</p>
 						<p class="option-inline-emphasized">
 							{{ t('richdocuments', 'If the installation from the App Store fails, you can still do that manually using this command:') }}
-							<tt>{{ manualCODEInstallCommand }}</tt>
-							<br>
-							{{ t('richdocuments', 'For Nextcloud Snap installations, use:') }}
-							<tt>{{ snapCODEInstallCommand }}</tt>
+							<tt>{{ CODEInstallCommand }}</tt>
 						</p>
 					</div>
 				</div>
@@ -494,6 +491,7 @@ export default {
 			errorMessage: null,
 			hostErrors: [window.location.host === 'localhost' || window.location.host === '127.0.0.1', window.location.protocol !== 'https:', false],
 			demoServers: null,
+			isSnap: false,
 			CODEInstalled: 'richdocumentscode' in OC.appswebroots,
 			CODECompatible: true,
 			CODEAppID: 'richdocumentscode',
@@ -575,6 +573,9 @@ export default {
 		callbackUrl() {
 			return this.settings.wopi_callback_url ? this.settings.wopi_callback_url : getCallbackBaseUrl()
 		},
+		CODEInstallCommand() {
+			return this.isSnap ? this.snapCODEInstallCommand : this.manualCODEInstallCommand
+		},
 		manualCODEInstallCommand() {
 			return `php -d memory_limit=512M occ app:install ${this.CODEAppID}`
 		},
@@ -632,6 +633,7 @@ export default {
 		this.uiVisible.external_apps = !!(this.settings.external_apps && this.settings.external_apps !== '')
 
 		this.demoServers = this.initial.demo_servers
+		this.isSnap = this.initial.is_snap === true
 
 		if (this.initial.web_server && this.initial.web_server.length > 0) {
 			this.isNginx = this.initial.web_server.indexOf('nginx') !== -1


### PR DESCRIPTION
## Summary
- keep the existing manual occ install command for CODE
- add the corresponding Nextcloud Snap command for admins using Snap installations

Fixes #1179

## Tests
- npx eslint src/components/AdminSettings.vue