### PR TITLE
chore/smaller bundles

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -8,7 +8,7 @@ import './init-shared.js'
 import Vue from 'vue'
 import { translate as t } from '@nextcloud/l10n'
 
-import { registerCustomPickerElement, NcCustomPickerRenderResult } from '@nextcloud/vue/dist/Components/NcRichText.js'
+import { registerCustomPickerElement, NcCustomPickerRenderResult } from '@nextcloud/vue/dist/Functions/registerReference.js'
 
 import DocumentTargetPicker from './view/DocumentTargetPicker.vue'
 

--- a/src/services/builtInCode.ts
+++ b/src/services/builtInCode.ts
@@ -6,7 +6,6 @@
 import { generateUrl } from '@nextcloud/router'
 import { getCapabilities, capabilitiesService } from './capabilities'
 import axios from '@nextcloud/axios'
-import { showError } from '@nextcloud/dialogs'
 
 const wopiUrl = getCapabilities()?.config?.wopi_url
 const isConfigured = wopiUrl !== ''
@@ -23,6 +22,7 @@ const autoSetupBuiltInCodeServerIfNeeded = async () => {
 	if (result?.data?.capabilities) {
 		capabilitiesService.setCapabilities(result?.data?.capabilities)
 	} else {
+		const { showError } = await import('@nextcloud/dialogs')
 		showError('Could not autoconfigure built-in CODE server, click to open the admin settings for further details: ' + result?.data?.message, {
 			onClick: () => {
 				window.location.href = generateUrl('settings/admin/richdocuments')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 		"sourceMap": false,
 		"noImplicitAny": false,
 		"moduleResolution": "node",
-		"module": "es6",
+		"module": "es2020",
 		"target": "es5",
 		"jsx": "react",
 		"allowJs": true


### PR DESCRIPTION
- **chore(config): use ES2020 for typescript modules**
- **chore(import): use async import for showError**
- **chore(import): from @nextcloud/vue functions**
