### PR TITLE
Office overview design pass

### DIFF
--- a/cypress/e2e/overview.spec.js
+++ b/cypress/e2e/overview.spec.js
@@ -102,8 +102,8 @@ describe('Office overview page', function() {
 				cy.get('.file-card__preview img')
 					.should('exist')
 
-				cy.get('.input-field__label')
-					.should('contain', `Search ${category}`)
+				cy.get('.app-navigation-search input[type="search"]')
+					.should('have.attr', 'aria-label', `Search ${category}`)
 			})
 
 			it(`Opens the viewer when clicking a ${category} file card`, function() {
@@ -130,7 +130,7 @@ describe('Office overview page', function() {
 
 			cy.contains('.app-navigation-entry', category).click()
 
-			cy.get('.office-overview__search [type="search"]').type(stem)
+			cy.get('.app-navigation-search input[type="search"]').type(stem)
 			cy.contains('.file-card__name', fixture).should('be.visible')
 		})
 
@@ -139,7 +139,7 @@ describe('Office overview page', function() {
 
 			cy.contains('.app-navigation-entry', category).click()
 
-			cy.get('.office-overview__search [type="search"]').type('xyz123noresults')
+			cy.get('.app-navigation-search input[type="search"]').type('xyz123noresults')
 			cy.get('.empty-content').should('be.visible')
 		})
 
@@ -147,11 +147,11 @@ describe('Office overview page', function() {
 			const [first, second] = CATEGORY_FILES
 
 			cy.contains('.app-navigation-entry', first.category).click()
-			cy.get('.office-overview__search [type="search"]').type('xyz123noresults')
+			cy.get('.app-navigation-search input[type="search"]').type('xyz123noresults')
 
 			cy.contains('.app-navigation-entry', second.category).click()
 
-			cy.get('.office-overview__search [type="search"]').should('have.value', '')
+			cy.get('.app-navigation-search input[type="search"]').should('have.value', '')
 			cy.contains('.file-card__name', second.fixture).should('be.visible')
 		})
 	})

--- a/src/components/FileCard.vue
+++ b/src/components/FileCard.vue
@@ -9,11 +9,16 @@
 			<slot name="preview" />
 		</div>
 		<div class="file-card__content">
-			<div class="file-card__name">
-				<slot name="name" />
-			</div>
-			<div v-if="$slots.subname" class="file-card__subname">
-				<slot name="subname" />
+			<span v-if="$slots.icon" class="file-card__icon">
+				<slot name="icon" />
+			</span>
+			<div class="file-card__text">
+				<div class="file-card__name">
+					<slot name="name" />
+				</div>
+				<div v-if="$slots.subname" class="file-card__subname">
+					<slot name="subname" />
+				</div>
 			</div>
 		</div>
 	</button>
@@ -31,42 +36,48 @@ export default {
 	flex-direction: column;
 	width: 100%;
 	aspect-ratio: 2 / 3;
-	border: var(--border-width-input) solid var(--color-border);
+	/* !important overrides the legacy global button border styles. */
+	border: 2px solid var(--color-border) !important;
 	border-radius: var(--border-radius-element);
-	padding: calc(var(--default-grid-baseline) * 3);
+	padding: calc(var(--default-grid-baseline) * 2);
 	cursor: pointer;
 	box-sizing: border-box;
 	background: none;
 	text-align: start;
-	transition: box-shadow 0.2s ease, transform 0.2s ease;
-
-	&:focus-visible {
-		outline: 2px solid var(--color-primary-element);
-		outline-offset: 2px;
-	}
+	transition: border-color var(--animation-quick) ease;
 }
 
-.file-card:hover {
-	background-color: var(--color-background-hover);
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-	transform: translateY(-2px);
+.file-card:focus-visible {
+	border-color: var(--color-primary-element) !important;
 }
 
 .file-card__preview {
 	flex: 1;
 	min-height: 0;
 	display: flex;
-	border-radius: var(--border-radius-element);
+	border-radius: 4px;
 	overflow: hidden;
-	margin-bottom: calc(var(--default-grid-baseline) * 3);
+	margin-bottom: calc(var(--default-grid-baseline) * 1);
 }
 
 .file-card__content {
 	flex-shrink: 0;
+	display: flex;
+	align-items: center;
 	overflow: hidden;
 }
 
+.file-card__icon {
+	display: flex;
+	flex-shrink: 0;
+}
+
+.file-card__text {
+	min-width: 0;
+}
+
 .file-card__name {
+	color: var(--color-main-text);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/src/components/TemplateSection.vue
+++ b/src/components/TemplateSection.vue
@@ -36,23 +36,29 @@
 				:key="item.blank ? 'blank' : item.fileid"
 				class="template-section__item">
 				<!-- Blank file card -->
-				<button v-if="item.blank" class="template-card" @click="$emit('select', creator, null)">
-					<span class="template-card__preview template-card__preview--blank" :style="previewStyle">
-						<NcIconSvgWrapper :svg="creator.iconSvgInline" class="template-card__icon" />
+				<button v-if="item.blank"
+					class="template-card"
+					:style="cardStyle"
+					@click="$emit('select', creator, null)">
+					<span class="template-card__preview">
+						<NcIconSvgWrapper :svg="creator.iconSvgInline" :size="32" />
 					</span>
 					<span class="template-card__name">{{ t('richdocuments', 'Blank') }}</span>
 				</button>
 
 				<!-- Template card -->
-				<button v-else class="template-card" @click="$emit('select', creator, item)">
-					<span class="template-card__preview" :style="previewStyle">
+				<button v-else
+					class="template-card"
+					:style="cardStyle"
+					@click="$emit('select', creator, item)">
+					<span class="template-card__preview">
 						<img v-if="item.hasPreview && !failedPreviews[item.fileid]"
 							:src="templatePreviewUrl(item)"
 							:alt="nameWithoutExt(item.basename)"
 							loading="lazy"
 							class="template-card__image"
 							@error="failedPreviews = { ...failedPreviews, [item.fileid]: true }">
-						<NcIconSvgWrapper v-else :svg="creator.iconSvgInline" class="template-card__icon" />
+						<NcIconSvgWrapper v-else :svg="creator.iconSvgInline" :size="48" />
 					</span>
 					<span class="template-card__name">{{ nameWithoutExt(item.basename) }}</span>
 				</button>
@@ -75,8 +81,8 @@ const THEME_PALETTES = {
 	drawing: ['hsl(47 80% 62%)', 'hsl(47 80% 39%)', 'hsl(47 82% 28%)', 'hsl(47 85% 18%)'],
 }
 
-// Card width and inter-card gap (calc(baseline * 3), baseline = 4px), used to
-// size the scroll step so a card of context stays visible after each jump.
+// Inter-card gap (calc(baseline * 3), baseline = 4px) and a representative card
+// width, used to size the scroll step so a card of context stays visible.
 const CARD_WIDTH = 160
 const CARD_GAP = 12
 
@@ -117,10 +123,16 @@ export default {
 			return 'document'
 		},
 
-		previewStyle() {
-			return this.themeType === 'presentation'
-				? { 'aspect-ratio': '16 / 9' }
-				: {}
+		// Preview tiles have a per-type height; the width follows the type's
+		// aspect ratio so each thumbnail scales without distortion.
+		cardStyle() {
+			const isPresentation = this.themeType === 'presentation'
+			const height = isPresentation ? 150 : 200
+			const ratio = isPresentation ? 16 / 9 : 2 / 3
+			return {
+				width: `${Math.round(height * ratio)}px`,
+				'--tpl-preview-height': `${height}px`,
+			}
 		},
 
 		sectionStyle() {
@@ -207,7 +219,7 @@ export default {
 
 <style scoped>
 .template-section {
-	padding: calc(var(--default-grid-baseline) * 4);
+	padding: calc(var(--default-grid-baseline) * 4) 0;
 	margin: calc(var(--default-grid-baseline) * 4) calc(var(--default-grid-baseline) * 4) 0;
 	background:
 		radial-gradient(78% 82% at 14% 2%,
@@ -228,13 +240,15 @@ export default {
 	justify-content: space-between;
 	gap: calc(var(--default-grid-baseline) * 2);
 	margin-bottom: calc(var(--default-grid-baseline) * 2);
+	padding-inline: calc(var(--default-grid-baseline) * 4);
 }
 
 .template-section__heading {
-	margin: 0 0 calc(var(--default-grid-baseline) * 2);
-	font-size: var(--default-font-size);
+	/* !important overrides the global heading top margin from server styles. */
+	margin: 0 !important;
+	font-size: 24px;
 	font-weight: 600;
-	color: var(--color-text-maxcontrast);
+	color: var(--color-main-text);
 }
 
 .template-section__nav {
@@ -246,11 +260,10 @@ export default {
 .template-section__list {
 	display: flex;
 	gap: calc(var(--default-grid-baseline) * 3);
-	overflow-x: auto;
-	padding-bottom: calc(var(--default-grid-baseline) * 2);
 	list-style: none;
+	padding: calc(var(--default-grid-baseline) * 1) 0 0;
 	margin: 0;
-	padding-inline-start: 0;
+	overflow-x: auto;
 	/* The arrow buttons are the scroll affordance — hide the native scrollbar. */
 	scrollbar-width: none;
 
@@ -263,35 +276,52 @@ export default {
 	flex: 0 0 auto;
 }
 
+.template-section__item:first-child {
+	margin-inline-start: calc(var(--default-grid-baseline) * 4);
+}
+
+.template-section__item:last-child {
+	margin-inline-end: calc(var(--default-grid-baseline) * 4);
+}
+
 .template-card {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	width: 160px;
+	/* Width is set inline (cardStyle) from the type's aspect ratio. */
 	padding: 0;
 	border: none;
 	background: none;
 	cursor: pointer;
 	border-radius: var(--border-radius-large);
 
+	&:hover,
+	&:focus-visible {
+		background: none;
+	}
+
 	&:hover .template-card__preview,
 	&:focus-visible .template-card__preview {
-		border-color: var(--color-primary-element);
+		/* Inset-style ring replaces the resting border on hover. */
+		box-shadow:
+			0 0 0 2px var(--color-primary-element),
+			0 4px 6px rgba(0, 0, 0, 0.28);
 	}
 }
 
 .template-card__preview {
 	position: relative;
 	width: 100%;
-	aspect-ratio: 2 / 3;
+	height: var(--tpl-preview-height);
 	overflow: hidden;
-	border: 2px solid var(--color-border);
 	border-radius: var(--border-radius-large);
 	background-color: var(--color-main-background);
 	box-sizing: border-box;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+	transition: box-shadow var(--animation-quick) ease;
 }
 
 .template-card__image {
@@ -302,22 +332,10 @@ export default {
 	object-fit: cover;
 }
 
-.template-card__icon {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 48px;
-	height: 48px;
-
-	:deep(svg) {
-		width: 100%;
-		height: 100%;
-	}
-}
-
 .template-card__name {
-	margin-top: calc(var(--default-grid-baseline) * 1);
-	font-size: var(--font-size-small, 12px);
+	margin-top: calc(var(--default-grid-baseline) * 2);
+	font-size: var(--font-size-small, 13px);
+	color: var(--color-main-text);
 	text-align: center;
 	max-width: 100%;
 	overflow: hidden;

--- a/src/components/TemplateSection.vue
+++ b/src/components/TemplateSection.vue
@@ -4,36 +4,55 @@
 -->
 <template>
 	<section class="template-section" aria-labelledby="template-section-heading">
-		<h2 id="template-section-heading" class="template-section__heading">
-			{{ t('richdocuments', 'Create new') }}
-		</h2>
+		<div class="template-section__header">
+			<h2 id="template-section-heading" class="template-section__heading">
+				{{ t('richdocuments', 'Create new') }}
+			</h2>
 
-		<ul class="template-section__list">
-			<!-- Blank file card -->
-			<li class="template-section__item">
-				<button class="template-card" @click="$emit('select', creator, null)">
+			<div v-if="canScroll" class="template-section__nav">
+				<NcButton variant="tertiary"
+					:aria-label="t('richdocuments', 'Scroll left')"
+					:disabled="!canScrollLeft"
+					@click="scrollByStep(-1)">
+					<template #icon>
+						<ChevronLeft :size="20" />
+					</template>
+				</NcButton>
+				<NcButton variant="tertiary"
+					:aria-label="t('richdocuments', 'Scroll right')"
+					:disabled="!canScrollRight"
+					@click="scrollByStep(1)">
+					<template #icon>
+						<ChevronRight :size="20" />
+					</template>
+				</NcButton>
+			</div>
+		</div>
+
+		<ul ref="list" class="template-section__list" @scroll="updateArrows">
+			<li v-for="item in items"
+				:key="item.blank ? 'blank' : item.fileid"
+				class="template-section__item">
+				<!-- Blank file card -->
+				<button v-if="item.blank" class="template-card" @click="$emit('select', creator, null)">
 					<span class="template-card__preview template-card__preview--blank" :style="previewStyle">
 						<NcIconSvgWrapper :svg="creator.iconSvgInline" class="template-card__icon" />
 					</span>
 					<span class="template-card__name">{{ t('richdocuments', 'Blank') }}</span>
 				</button>
-			</li>
 
-			<!-- Template cards -->
-			<li v-for="template in creator.templates"
-				:key="template.fileid"
-				class="template-section__item">
-				<button class="template-card" @click="$emit('select', creator, template)">
+				<!-- Template card -->
+				<button v-else class="template-card" @click="$emit('select', creator, item)">
 					<span class="template-card__preview" :style="previewStyle">
-						<img v-if="template.hasPreview && !failedPreviews[template.fileid]"
-							:src="templatePreviewUrl(template)"
-							:alt="nameWithoutExt(template.basename)"
+						<img v-if="item.hasPreview && !failedPreviews[item.fileid]"
+							:src="templatePreviewUrl(item)"
+							:alt="nameWithoutExt(item.basename)"
 							loading="lazy"
 							class="template-card__image"
-							@error="failedPreviews = { ...failedPreviews, [template.fileid]: true }">
+							@error="failedPreviews = { ...failedPreviews, [item.fileid]: true }">
 						<NcIconSvgWrapper v-else :svg="creator.iconSvgInline" class="template-card__icon" />
 					</span>
-					<span class="template-card__name">{{ nameWithoutExt(template.basename) }}</span>
+					<span class="template-card__name">{{ nameWithoutExt(item.basename) }}</span>
 				</button>
 			</li>
 		</ul>
@@ -41,13 +60,24 @@
 </template>
 
 <script>
+import { translate as t } from '@nextcloud/l10n'
 import { generateUrl } from '@nextcloud/router'
-import { NcIconSvgWrapper } from '@nextcloud/vue'
+import { NcButton, NcIconSvgWrapper } from '@nextcloud/vue'
+import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
+import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
+
+// Card width and inter-card gap (calc(baseline * 3), baseline = 4px), used to
+// size the scroll step so a card of context stays visible after each jump.
+const CARD_WIDTH = 160
+const CARD_GAP = 12
 
 export default {
 	name: 'TemplateSection',
 
 	components: {
+		ChevronLeft,
+		ChevronRight,
+		NcButton,
 		NcIconSvgWrapper,
 	},
 
@@ -60,6 +90,15 @@ export default {
 
 	emits: ['select'],
 
+	data() {
+		return {
+			failedPreviews: {},
+			canScrollLeft: false,
+			canScrollRight: false,
+			resizeObserver: null,
+		}
+	},
+
 	computed: {
 		previewStyle() {
 			const presentationMimes = [
@@ -71,15 +110,64 @@ export default {
 				? { 'aspect-ratio': '16 / 9' }
 				: {}
 		},
+
+		// True when the row overflows in either direction — the scroll arrows
+		// are only shown then.
+		canScroll() {
+			return this.canScrollLeft || this.canScrollRight
+		},
+
+		// Blank card sentinel followed by the creator's templates.
+		items() {
+			return [{ blank: true }, ...(this.creator.templates ?? [])]
+		},
 	},
 
-	data() {
-		return {
-			failedPreviews: {},
-		}
+	watch: {
+		creator() {
+			// New creator means a different template count — jump back to the start.
+			this.$nextTick(() => {
+				if (this.$refs.list) {
+					this.$refs.list.scrollLeft = 0
+				}
+				this.updateArrows()
+			})
+		},
+	},
+
+	mounted() {
+		// Overflow can appear or disappear as the row is resized.
+		this.resizeObserver = new ResizeObserver(() => this.updateArrows())
+		this.resizeObserver.observe(this.$refs.list)
+		this.$nextTick(() => this.updateArrows())
+	},
+
+	beforeUnmount() {
+		this.resizeObserver?.disconnect()
 	},
 
 	methods: {
+		updateArrows() {
+			const list = this.$refs.list
+			if (!list) {
+				return
+			}
+			const { scrollLeft, scrollWidth, clientWidth } = list
+			this.canScrollLeft = scrollLeft > 0
+			// 1px tolerance absorbs sub-pixel rounding at the far end.
+			this.canScrollRight = scrollLeft + clientWidth < scrollWidth - 1
+		},
+
+		scrollByStep(direction) {
+			const list = this.$refs.list
+			if (!list) {
+				return
+			}
+			// Scroll a viewport minus one card so a card of context carries over.
+			const step = Math.max(CARD_WIDTH + CARD_GAP, list.clientWidth - (CARD_WIDTH + CARD_GAP))
+			list.scrollBy({ left: direction * step, behavior: 'smooth' })
+		},
+
 		nameWithoutExt(basename) {
 			const dot = basename.lastIndexOf('.')
 			return dot > 0 ? basename.slice(0, dot) : basename
@@ -106,11 +194,25 @@ export default {
 	border-radius: var(--border-radius-large);
 }
 
+.template-section__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: calc(var(--default-grid-baseline) * 2);
+	margin-bottom: calc(var(--default-grid-baseline) * 2);
+}
+
 .template-section__heading {
 	margin: 0 0 calc(var(--default-grid-baseline) * 2);
 	font-size: var(--default-font-size);
 	font-weight: 600;
 	color: var(--color-text-maxcontrast);
+}
+
+.template-section__nav {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 1);
 }
 
 .template-section__list {
@@ -121,6 +223,12 @@ export default {
 	list-style: none;
 	margin: 0;
 	padding-inline-start: 0;
+	/* The arrow buttons are the scroll affordance — hide the native scrollbar. */
+	scrollbar-width: none;
+
+	&::-webkit-scrollbar {
+		display: none;
+	}
 }
 
 .template-section__item {

--- a/src/components/TemplateSection.vue
+++ b/src/components/TemplateSection.vue
@@ -3,7 +3,9 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<section class="template-section" aria-labelledby="template-section-heading">
+	<section class="template-section"
+		:style="sectionStyle"
+		aria-labelledby="template-section-heading">
 		<div class="template-section__header">
 			<h2 id="template-section-heading" class="template-section__heading">
 				{{ t('richdocuments', 'Create new') }}
@@ -66,6 +68,13 @@ import { NcButton, NcIconSvgWrapper } from '@nextcloud/vue'
 import ChevronLeft from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRight from 'vue-material-design-icons/ChevronRight.vue'
 
+const THEME_PALETTES = {
+	document: ['hsl(203 79% 78%)', 'hsl(203 79% 60%)', 'hsl(203 70% 42%)', 'hsl(203 65% 26%)'],
+	spreadsheet: ['hsl(79 46% 70%)', 'hsl(79 46% 52%)', 'hsl(79 50% 38%)', 'hsl(79 55% 24%)'],
+	presentation: ['hsl(23 83% 80%)', 'hsl(23 83% 66%)', 'hsl(23 75% 48%)', 'hsl(23 70% 32%)'],
+	drawing: ['hsl(47 80% 62%)', 'hsl(47 80% 39%)', 'hsl(47 82% 28%)', 'hsl(47 85% 18%)'],
+}
+
 // Card width and inter-card gap (calc(baseline * 3), baseline = 4px), used to
 // size the scroll step so a card of context stays visible after each jump.
 const CARD_WIDTH = 160
@@ -100,15 +109,28 @@ export default {
 	},
 
 	computed: {
+		themeType() {
+			const mimes = (this.creator.mimetypes ?? []).join(' ')
+			if (/presentation|powerpoint/.test(mimes)) return 'presentation'
+			if (/spreadsheet|ms-excel/.test(mimes)) return 'spreadsheet'
+			if (/graphics|drawing/.test(mimes)) return 'drawing'
+			return 'document'
+		},
+
 		previewStyle() {
-			const presentationMimes = [
-				'application/vnd.oasis.opendocument.presentation',
-				'application/vnd.oasis.opendocument.presentation-template',
-				'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-			]
-			return this.creator.mimetypes?.some(m => presentationMimes.includes(m))
+			return this.themeType === 'presentation'
 				? { 'aspect-ratio': '16 / 9' }
 				: {}
+		},
+
+		sectionStyle() {
+			const [glow1, glow2, glow3, glow4] = THEME_PALETTES[this.themeType]
+			return {
+				'--tpl-glow-1': glow1,
+				'--tpl-glow-2': glow2,
+				'--tpl-glow-3': glow3,
+				'--tpl-glow-4': glow4,
+			}
 		},
 
 		// True when the row overflows in either direction — the scroll arrows
@@ -187,10 +209,16 @@ export default {
 .template-section {
 	padding: calc(var(--default-grid-baseline) * 4);
 	margin: calc(var(--default-grid-baseline) * 4) calc(var(--default-grid-baseline) * 4) 0;
-	/* Layer the frosted-glass colour over the same fixed background image the nav uses */
 	background:
-		linear-gradient(var(--color-main-background-blur), var(--color-main-background-blur)),
-		var(--image-background, none) center / cover fixed;
+		radial-gradient(78% 82% at 14% 2%,
+			color-mix(in srgb, var(--tpl-glow-1) 28%, transparent), transparent 66%),
+		radial-gradient(72% 76% at 102% -2%,
+			color-mix(in srgb, var(--tpl-glow-2) 24%, transparent), transparent 64%),
+		radial-gradient(82% 88% at 20% 114%,
+			color-mix(in srgb, var(--tpl-glow-3) 22%, transparent), transparent 68%),
+		radial-gradient(88% 94% at 98% 104%,
+			color-mix(in srgb, var(--tpl-glow-4) 26%, transparent), transparent 70%),
+		color-mix(in srgb, var(--tpl-glow-2) 8%, var(--color-main-background));
 	border-radius: var(--border-radius-large);
 }
 

--- a/src/views/OfficeOverview.vue
+++ b/src/views/OfficeOverview.vue
@@ -111,6 +111,10 @@
 										:size="48" />
 								</template>
 
+								<template v-if="activeCreator" #icon>
+									<NcIconSvgWrapper :svg="activeCreator.iconSvgInline" :size="20" />
+								</template>
+
 								<template #name>
 									{{ file.basename }}
 								</template>

--- a/src/views/OfficeOverview.vue
+++ b/src/views/OfficeOverview.vue
@@ -5,6 +5,9 @@
 <template>
 	<NcContent app-name="richdocuments">
 		<NcAppNavigation>
+			<template #search>
+				<NcAppNavigationSearch v-model="searchQuery" :label="searchLabel" />
+			</template>
 			<template #list>
 				<NcAppNavigationItem v-for="creator in creators"
 					:key="creator.app + '-' + creator.extension"
@@ -18,7 +21,7 @@
 			</template>
 		</NcAppNavigation>
 
-		<NcAppContent>
+		<NcAppContent class="office-overview__content">
 			<NcLoadingIcon v-if="loading" class="office-overview__loading" />
 
 			<template v-else>
@@ -30,12 +33,6 @@
 				</NcEmptyContent>
 
 				<template v-else>
-					<div class="office-overview__search">
-						<NcTextField v-model="searchQuery"
-							:label="t('richdocuments', 'Search {category}', { category: categoryName(activeCreator) })"
-							type="search" />
-					</div>
-
 					<TemplateSection v-if="!searchQuery && activeCreator"
 						:creator="activeCreator"
 						@select="onTemplateSelect" />
@@ -52,6 +49,32 @@
 							<h2 id="files-section-heading" class="office-overview__files-title">
 								{{ t('richdocuments', 'Recent {category}', { category: categoryName(activeCreator) }) }}
 							</h2>
+						</div>
+
+						<div class="office-overview__controls">
+							<div class="office-overview__filters"
+								role="group"
+								:aria-label="t('richdocuments', 'Filter files')">
+								<NcButton size="small"
+									:variant="activeFilter === 'all' ? 'primary' : 'secondary'"
+									:aria-pressed="activeFilter === 'all'"
+									@click="activeFilter = 'all'">
+									{{ t('richdocuments', 'All') }}
+								</NcButton>
+								<NcButton size="small"
+									:variant="activeFilter === 'mine' ? 'primary' : 'secondary'"
+									:aria-pressed="activeFilter === 'mine'"
+									@click="activeFilter = 'mine'">
+									{{ t('richdocuments', 'Mine') }}
+								</NcButton>
+								<NcButton size="small"
+									:variant="activeFilter === 'shared' ? 'primary' : 'secondary'"
+									:aria-pressed="activeFilter === 'shared'"
+									@click="activeFilter = 'shared'">
+									{{ t('richdocuments', 'Shared with me') }}
+								</NcButton>
+							</div>
+
 							<NcButton :aria-label="viewMode === 'list' ? t('richdocuments', 'Switch to grid view') : t('richdocuments', 'Switch to list view')"
 								variant="tertiary"
 								@click="toggleViewMode">
@@ -59,29 +82,6 @@
 									<ViewGrid v-if="viewMode === 'list'" :size="20" />
 									<ViewList v-else :size="20" />
 								</template>
-							</NcButton>
-						</div>
-
-						<div class="office-overview__filters"
-							role="group"
-							:aria-label="t('richdocuments', 'Filter files')">
-							<NcButton size="small"
-								:variant="activeFilter === 'all' ? 'primary' : 'secondary'"
-								:aria-pressed="activeFilter === 'all'"
-								@click="activeFilter = 'all'">
-								{{ t('richdocuments', 'All') }}
-							</NcButton>
-							<NcButton size="small"
-								:variant="activeFilter === 'mine' ? 'primary' : 'secondary'"
-								:aria-pressed="activeFilter === 'mine'"
-								@click="activeFilter = 'mine'">
-								{{ t('richdocuments', 'Mine') }}
-							</NcButton>
-							<NcButton size="small"
-								:variant="activeFilter === 'shared' ? 'primary' : 'secondary'"
-								:aria-pressed="activeFilter === 'shared'"
-								@click="activeFilter = 'shared'">
-								{{ t('richdocuments', 'Shared with me') }}
 							</NcButton>
 						</div>
 
@@ -179,7 +179,7 @@ import { getCurrentUser } from '@nextcloud/auth'
 import { sortNodes } from '@nextcloud/files'
 import { loadState } from '@nextcloud/initial-state'
 import { generateUrl } from '@nextcloud/router'
-import { NcAppContent, NcAppNavigation, NcAppNavigationItem, NcButton, NcContent, NcDateTime, NcDialog, NcEmptyContent, NcIconSvgWrapper, NcListItem, NcLoadingIcon, NcTextField } from '@nextcloud/vue'
+import { NcAppContent, NcAppNavigation, NcAppNavigationItem, NcAppNavigationSearch, NcButton, NcContent, NcDateTime, NcDialog, NcEmptyContent, NcIconSvgWrapper, NcListItem, NcLoadingIcon, NcTextField } from '@nextcloud/vue'
 import FileDocumentOutline from 'vue-material-design-icons/FileDocumentOutline.vue'
 import OpenInNew from 'vue-material-design-icons/OpenInNew.vue'
 import Star from 'vue-material-design-icons/Star.vue'
@@ -202,6 +202,7 @@ export default {
 		NcAppContent,
 		NcAppNavigation,
 		NcAppNavigationItem,
+		NcAppNavigationSearch,
 		NcButton,
 		NcContent,
 		NcDateTime,
@@ -258,6 +259,12 @@ export default {
 				'application/vnd.oasis.opendocument.graphics': t('richdocuments', 'Diagrams'),
 				'application/vnd.oasis.opendocument.graphics-template': t('richdocuments', 'Diagrams'),
 			}
+		},
+
+		searchLabel() {
+			return this.activeCreator
+				? t('richdocuments', 'Search {category}', { category: this.categoryName(this.activeCreator) })
+				: t('richdocuments', 'Search')
 		},
 
 		filteredFiles() {
@@ -435,19 +442,21 @@ export default {
 	margin: auto;
 }
 
-.office-overview__loading {
-	margin: 32px auto;
+.office-overview__content {
+	/* Safe area so content never sits under the app navigation toggle. */
+	padding-top: var(--default-clickable-area);
 }
 
-.office-overview__search {
-	display: flex;
-	justify-content: center;
-	padding: calc(var(--default-grid-baseline) * 4) calc(var(--default-grid-baseline) * 4) 0;
+/* NcAppNavigationSearch always renders its clear button; hide it while the
+   field is empty (input showing its placeholder).
+   TODO: fix this in the NcAppNavigationSearch component itself — the trailing
+   clear button should only show when the field has a value. */
+:deep(.app-navigation-search .input-field__input:placeholder-shown ~ .input-field__trailing-button) {
+	display: none;
+}
 
-	> * {
-		width: 100%;
-		max-width: 400px;
-	}
+.office-overview__loading {
+	margin: 32px auto;
 }
 
 .office-overview__files-header {
@@ -459,15 +468,22 @@ export default {
 
 .office-overview__files-title {
 	margin: 0;
-	font-size: var(--default-font-size);
+	font-size: 24px;
 	font-weight: 600;
-	color: var(--color-text-maxcontrast);
+	color: var(--color-main-text);
+}
+
+.office-overview__controls {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: calc(var(--default-grid-baseline) * 2);
+	padding: 0 calc(var(--default-grid-baseline) * 4) calc(var(--default-grid-baseline) * 2);
 }
 
 .office-overview__filters {
 	display: flex;
 	gap: calc(var(--default-grid-baseline) * 1);
-	padding: 0 calc(var(--default-grid-baseline) * 4) calc(var(--default-grid-baseline) * 2);
 
 	:deep(.button-vue) {
 		--button-radius: var(--border-radius-pill, 100px);


### PR DESCRIPTION
Design pass on the Office overview page:

- Document-type themed gradient background on the template section
- Scrollable template row with arrow navigation
- Restyled template and gallery file cards (borders, shadows, mime icon)
- Search moved into the app navigation
<img width="1495" height="938" alt="Screenshot 2026-05-22 at 20 11 44" src="https://github.com/user-attachments/assets/51df20bc-a9e3-4c12-96f5-436a4f5cfb25" />
