### PR TITLE
fix: Save as works with encrpytion

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -191,7 +191,7 @@ class WopiController extends Controller {
 			'UserExtraInfo' => [],
 			'UserPrivateInfo' => [],
 			'UserCanWrite' => $canWriteThroughLock && (bool)$wopi->getCanwrite(),
-			'UserCanNotWriteRelative' => $isPublic || $this->encryptionManager->isEnabled() || $wopi->getHideDownload() || $wopi->isRemoteToken() || $shouldUseSecureView,
+			'UserCanNotWriteRelative' => $isPublic || $wopi->getHideDownload() || $wopi->isRemoteToken() || $shouldUseSecureView,
 			'PostMessageOrigin' => $wopi->getServerHost(),
 			'LastModifiedTime' => Helper::toISO8601($file->getMTime()),
 			'SupportsRename' => !$isVersion && !$wopi->isRemoteToken(),


### PR DESCRIPTION
There is no reason encryption would be blocking the save as operation.

I tested it on a setup with encryption and works fine