### PR TITLE
fix: Set preview flag for file templates that have a URL

### DIFF
--- a/lib/Template/CollaboraTemplateProvider.php
+++ b/lib/Template/CollaboraTemplateProvider.php
@@ -49,6 +49,7 @@ class CollaboraTemplateProvider implements ICustomTemplateProvider {
 		return array_map(function (File $file) {
 			$template = new Template(CollaboraTemplateProvider::class, (string)$file->getId(), $file);
 			$template->setCustomPreviewUrl($this->urlGenerator->linkToRouteAbsolute('richdocuments.templates.getPreview', ['fileId' => $file->getId(), 'a' => true]));
+			$template->setHasPreview(true);
 			return $template;
 		}, $collaboraTemplates);
 	}


### PR DESCRIPTION
Found when reviewing the office overview, we have a URL already defined but the object did not have the boolean flag set true to show the previews.