### PR TITLE
fix: only bump file mtime when document transitions from modified to saved

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -533,7 +533,7 @@ export default {
 				this.buttonClicked(args)
 				break
 			case 'Doc_ModifiedStatus':
-				if (args.Modified !== this.modified && !this.openingLocally) {
+				if (this.modified && !args.Modified && !this.openingLocally) {
 					FilesAppIntegration.updateFileInfo(undefined, Date.now())
 				}
 				this.modified = args.Modified


### PR DESCRIPTION

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Opening a file (e.g. a presentation) and closing it without making any edits was bumping the modified date in the Files listing to "seconds ago". A refresh reset it to the real mtime, since the file on disk was never touched.

Cause: the `Doc_ModifiedStatus` post-message handler updated the UI's mtime whenever `args.Modified !== this.modified`, which fires on both `false → true` (doc becomes dirty) and `true → false` (saved). For presentations, Collabora emits `Modified: true` shortly after open, triggering a spurious mtime bump.

Fix: only call `FilesAppIntegration.updateFileInfo` on the `true → false` transition, matching the original intent of the handler ("Update file metadata after save", f227260fd).

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required