### PR TITLE
 fix(frontend): retry built-in CODE cold starts and show startup status in Office viewer

### DIFF
--- a/src/services/collabora.js
+++ b/src/services/collabora.js
@@ -10,6 +10,12 @@ export const LOADING_ERROR = {
 	PROXY_FAILED: 2,
 }
 
+const PROXY_STARTING_STATES = new Set(['starting', 'stopped', 'restarting'])
+const PROXY_POLL_INTERVAL_MS = 1500
+const PROXY_POLL_TIMEOUT_MS = 30000
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
 export const isCollaboraConfigured = () => {
 	const collaboraCapabilities = getCapabilities()?.collabora
 	return isBuiltinCodeServerUsed() || collaboraCapabilities.length !== 0
@@ -26,8 +32,7 @@ export const checkCollaboraConfiguration = async () => {
 	}
 }
 
-let proxyStatusCheckRetry = 0
-export const checkProxyStatus = async (_resolve, _reject) => {
+export const checkProxyStatus = async () => {
 	const wopiUrl = getCapabilities()?.config?.wopi_url
 	if (wopiUrl.indexOf('proxy.php') === -1) {
 		return true
@@ -35,34 +40,38 @@ export const checkProxyStatus = async (_resolve, _reject) => {
 
 	const url = wopiUrl.slice(0, wopiUrl.indexOf('proxy.php') + 'proxy.php'.length)
 	const proxyStatusUrl = url + '?status'
+	const deadline = Date.now() + PROXY_POLL_TIMEOUT_MS
 
-	const checkProxyStatusCallback = async (resolve, reject) => {
-		const result = await axios.get(proxyStatusUrl)
-		if (!result || !result?.data?.status) {
-			reject('Failed to contact status endpoint')
+	while (Date.now() < deadline) {
+		let result
+		try {
+			result = await axios.get(proxyStatusUrl)
+		} catch (e) {
+			await sleep(PROXY_POLL_INTERVAL_MS)
+			continue
 		}
 
-		if (result.data.status === 'OK') {
-			return resolve(true)
-		}
-		if (result.data.status === 'error') {
-			return reject(t('richdocuments', 'Built-in CODE server failed to start'))
-		}
-
-		if (proxyStatusCheckRetry < 3 && (result.data.status === 'starting' || result.data.status === 'stopped' || result.data.status === 'restarting')) {
-			setTimeout(() => {
-				proxyStatusCheckRetry++
-				checkProxyStatus(resolve, reject)
-			})
-		} else {
-			reject('Maximum retries reached')
+		const status = result?.data?.status
+		if (!status) {
+			await sleep(PROXY_POLL_INTERVAL_MS)
+			continue
 		}
 
+		if (status === 'OK') {
+			return true
+		}
+
+		if (status === 'error') {
+			throw Error(LOADING_ERROR.PROXY_FAILED)
+		}
+
+		if (PROXY_STARTING_STATES.has(status)) {
+			await sleep(PROXY_POLL_INTERVAL_MS)
+			continue
+		}
+
+		await sleep(PROXY_POLL_INTERVAL_MS)
 	}
 
-	if (_reject && _resolve) {
-		return checkProxyStatusCallback(_reject, _resolve)
-	} else {
-		return new Promise(checkProxyStatusCallback)
-	}
+	throw Error(t('richdocuments', 'Starting the built-in CODE server is taking longer than expected'))
 }

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -100,7 +100,12 @@ import {
 } from '../helpers/url.js'
 import PostMessageService from '../services/postMessage.tsx'
 import FilesAppIntegration from './FilesAppIntegration.js'
-import { LOADING_ERROR, checkCollaboraConfiguration, checkProxyStatus } from '../services/collabora.js'
+import {
+	LOADING_ERROR,
+	checkCollaboraConfiguration,
+	checkProxyStatus,
+	isBuiltinCodeServerUsed,
+} from '../services/collabora.js'
 import { enableScrollLock, disableScrollLock } from '../helpers/mobileFixer.js'
 import axios from '@nextcloud/axios'
 import {
@@ -277,7 +282,11 @@ export default {
 		})
 		try {
 			await checkCollaboraConfiguration()
+			if (isBuiltinCodeServerUsed()) {
+				this.loadingMsg = t('richdocuments', 'Starting the built-in CODE server …')
+			}
 			await checkProxyStatus()
+			this.loadingMsg = null
 		} catch (e) {
 			this.error = e.message
 			this.loading = LOADING_STATE.FAILED
@@ -408,16 +417,16 @@ export default {
 					this.documentReady()
 
 					if (loadState('richdocuments', 'open_local_editor', true) && !this.isEmbedded) {
-				        this.sendPostMessage('Insert_Button', {
-					        id: 'Open_Local_Editor',
-					        imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
-					        mobile: false,
-					        label: t('richdocuments', 'Open in local editor'),
-					        hint: t('richdocuments', 'Open in local editor'),
-					        insertBefore: 'print',
-					        accessKey: '2',
-				        })
-			        }
+						this.sendPostMessage('Insert_Button', {
+							id: 'Open_Local_Editor',
+							imgurl: window.location.protocol + '//' + getNextcloudUrl() + imagePath('richdocuments', 'launch.svg'),
+							mobile: false,
+							label: t('richdocuments', 'Open in local editor'),
+							hint: t('richdocuments', 'Open in local editor'),
+							insertBefore: 'print',
+							accessKey: '2',
+						})
+					}
 
 					if (this.isEmbedded && this.hasWidgetEditingEnabled) {
 						this.sendPostMessage('Hide_Sidebar')


### PR DESCRIPTION
* Resolves: # <!-- related github issue --> (likely various bug and trouble reports; improves UX with Built-in CODE)
* Target version: main

## Summary

Improve the Nextcloud Office frontend experience when using the built-in CODE server during cold start.

Previously, opening a document against the built-in CODE proxy could fail too quickly during startup:
- `checkProxyStatus()` only retried a few times
- retries happened almost immediately
- users could remain stuck on the generic loading overlay and often had to retry manually

This change makes the frontend treat built-in CODE startup as a normal temporary state:
- poll the proxy status endpoint for longer during cold start
- retry at a controlled interval instead of using a tiny fixed retry count
- keep the Office loading overlay visible while waiting
- show a more accurate loading message when the built-in CODE server is starting

## User impact

When the built-in CODE server is cold-starting, users should now see:
- a more accurate message: **"Starting the built-in CODE server …"**
- automatic waiting/retry behavior
- fewer cases where reopening the document manually is required

## Changes

### `src/services/collabora.js`
- replace the global retry-counter approach in `checkProxyStatus()`
- switch to a time-based polling loop
- keep polling while proxy status is `starting`, `stopped` (i.e. not yet started), or `restarting`
- tolerate transient request/network failures throughout the polling window
- fail only after a defined overall timeout
- preserve explicit failure when the proxy reports `error`

### `src/view/Office.vue`
- show a dedicated loading message while waiting for the built-in CODE server to become ready
- clear that loading message once proxy readiness succeeds
- keep the existing failure path if startup ultimately times out or configuration is invalid
- fix inconsistent indentation in the `Insert_Button` block

## Notes

- This PR only updates the frontend behavior in `richdocuments`
- backend/proxy changes are handled separately in `richdocumentscode`
  - I'm working on some backend changes (in `richdocumentscode`) in CollaboraOnline/richdocumentscode#343 that should further improve the UX by eliminating blocking on cold starts and also make the status API a bit more useful, but those changes are not a requirement/dependency for this PR.
- the polling behavior is only relevant when the configured WOPI URL points to `proxy.php`

## Testing

Suggested manual verification:
1. Use a setup with the built-in CODE server enabled
2. Ensure the CODE process is not already running
3. Open a document
4. Confirm the UI shows the startup message while the server warms up
5. Confirm the document opens automatically once the proxy reports `OK`
6. Confirm true startup failures still surface an error state

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
