### PR TITLE
test: skip pdf viewer test

### DIFF
--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -109,7 +109,8 @@ describe('Open PDF with richdocuments', () => {
 
 	// Verify that clicking on the file uses the files PDF viewer
 	// and NOT richdocuments
-	it('Open PDF with files PDF viewer', () => {
+	// TODO: Revert once https://github.com/nextcloud/files_pdfviewer/issues/1451 is resolved
+	it.skip('Open PDF with files PDF viewer', () => {
 		cy.get('[data-cy-files-list-row-name="document.pdf"]').click()
 		cy.waitForViewer()
 


### PR DESCRIPTION
* Target version: main

### Summary
There is an upstream issue with the files_pdfviewer app causing the loading spinner to never disappear. This commit can be reverted once https://github.com/nextcloud/files_pdfviewer/issues/1451 is fixed

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
