### PR TITLE
test(save-as): correct file name assertion

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -210,7 +210,7 @@ describe('Direct editing (legacy)', function() {
 					.should('be.visible')
 				cy.get('.saveas-dialog input[type=text]')
 					.should('be.visible')
-					.should('have.value', 'document.rtf')
+					.should('have.value', '/document.rtf')
 
 				cy.get('.saveas-dialog button.button-vue--vue-primary').click()
 


### PR DESCRIPTION
* Target version: main

### Summary
Resolves Cypress test failures in `direct.spec.js`. They started appearing with https://github.com/nextcloud/richdocuments/pull/5689 and are due to a change in the displayed file path when using "Save as" from a direct editing session.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
