### PR TITLE
revert: skip pdf viewer test

### DIFF
--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -109,8 +109,7 @@ describe('Open PDF with richdocuments', () => {
 
 	// Verify that clicking on the file uses the files PDF viewer
 	// and NOT richdocuments
-	// TODO: Revert once https://github.com/nextcloud/files_pdfviewer/issues/1451 is resolved
-	it.skip('Open PDF with files PDF viewer', () => {
+	it('Open PDF with files PDF viewer', () => {
 		cy.get('[data-cy-files-list-row-name="document.pdf"]').click()
 		cy.waitForViewer()
 

--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -117,7 +117,8 @@ describe('Open PDF with richdocuments', () => {
 		cy.get('[data-cy="coolframe"]').should('not.exist')
 
 		// Verify the files PDF viewer is being used
-		cy.get('.viewer__file--active')
+		cy.get('.viewer__file-wrapper')
+			.get('iframe')
 			.its('0.contentDocument')
 			.its('body').should('not.be.empty')
 			.as('pdfViewer')


### PR DESCRIPTION
Reverts nextcloud/richdocuments#5729 as the upstream problem it sought to avoid has been resolved in https://github.com/nextcloud/files_pdfviewer/pull/1454.