### PR TITLE
chore(release): v11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 -->
 # Changelog
 
+## 11.0.0
+
+### Added
+- Integrate with Direct Editing API by @juliusknorr in [#5734](https://github.com/nextcloud/richdocuments/pull/5734)
+- Make preview conversion timeout and max file size configurable by @juliusknorr in [#5733](https://github.com/nextcloud/richdocuments/pull/5733)
+
+### Fixed
+- Make preview timeout an info log instead of error by @CarlSchwan in [#5613](https://github.com/nextcloud/richdocuments/pull/5613)
+- Retry built-in CODE cold starts and show startup status by @joshtrichards in [#5722](https://github.com/nextcloud/richdocuments/pull/5722)
+- Remove expired WOPI tokens with a single query by @juliusknorr in [#5715](https://github.com/nextcloud/richdocuments/pull/5715)
+- Adjust naming to Nextcloud Office (Collabora) by @juliusknorr in [#5710](https://github.com/nextcloud/richdocuments/pull/5710)
+- Save As works with encryption by @juliusknorr in [#5702](https://github.com/nextcloud/richdocuments/pull/5702)
+- Smaller JS bundles by @max-nextcloud in [#5673](https://github.com/nextcloud/richdocuments/pull/5673)
+
+### Other
+- Temporarily revert pdf viewer assertion by @elzody in [#5578](https://github.com/nextcloud/richdocuments/pull/5578)
+- Enhance direct editing test with postMessage handling by @elzody in [#5555](https://github.com/nextcloud/richdocuments/pull/5555)
+- Skip PDF viewer test by @elzody in [#5730](https://github.com/nextcloud/richdocuments/pull/5730)
+- Dependency updates
+
 ## 11.0.0-beta.1
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>11.0.0-beta.1</version>
+	<version>11.0.0</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "11.0.0-beta.1",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "11.0.0-beta.1",
+  "version": "11.0.0",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
* Target version: stable34

### Summary
Gets rid of the `beta` tag and updates the changelog in preparation for the Nextcloud 34 release.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
