### PR TITLE
chore(release): v10.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 -->
 # Changelog
 
+## 10.2.0
+
+### Added
+- Make preview conversion timeout and max file size configurable by @juliusknorr in [#5735](https://github.com/nextcloud/richdocuments/pull/5735)
+
+### Fixed
+- Retry built-in CODE cold starts and show startup status by @joshtrichards in [#5721](https://github.com/nextcloud/richdocuments/pull/5721)
+- Remove expired WOPI tokens with a single query by @juliusknorr in [#5714](https://github.com/nextcloud/richdocuments/pull/5714)
+- Save As works with encryption by @juliusknorr in [#5703](https://github.com/nextcloud/richdocuments/pull/5703)
+- Smaller JS bundles by @max-nextcloud in [#5674](https://github.com/nextcloud/richdocuments/pull/5674)
+- Remove hardcoded language from document template by @juliusknorr in [#5660](https://github.com/nextcloud/richdocuments/pull/5660)
+- Make preview timeout an info log instead of error by @CarlSchwan in [#5641](https://github.com/nextcloud/richdocuments/pull/5641)
+- Check file existence before using Save As by @juliusknorr in [#5443](https://github.com/nextcloud/richdocuments/pull/5443)
+
+### Other
+- Dependency updates
+
 ## 10.1.3
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>10.1.3</version>
+	<version>10.2.0</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "10.1.3",
+  "version": "10.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "10.1.3",
+      "version": "10.2.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "10.1.3",
+  "version": "10.2.0",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
* Target version: stable33

### Summary
Bump version to 10.2.0 and update the changelog in preparation for a new Nextcloud 33 release.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
