### PR TITLE
chore(release): v9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 -->
 # Changelog
 
+## 9.1.0
+
+### Added
+- Make preview conversion timeout and max file size configurable by @juliusknorr in [#5736](https://github.com/nextcloud/richdocuments/pull/5736)
+
+### Fixed
+- Remove expired WOPI tokens with a single query by @juliusknorr in [#5713](https://github.com/nextcloud/richdocuments/pull/5713)
+- Save As works with encryption by @juliusknorr in [#5704](https://github.com/nextcloud/richdocuments/pull/5704)
+- Remove hardcoded language from document template by @juliusknorr in [#5659](https://github.com/nextcloud/richdocuments/pull/5659)
+- Make preview timeout an info log instead of error by @CarlSchwan in [#5642](https://github.com/nextcloud/richdocuments/pull/5642)
+
+### Other
+- Dependency updates
+- NPM audits
+
 ## 9.0.6
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>9.0.6</version>
+	<version>9.1.0</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "9.0.6",
+  "version": "9.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "9.0.6",
+      "version": "9.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "9.0.6",
+  "version": "9.1.0",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
* Target version: stable32

### Summary
Bump the version to 9.1.0 and update the changelog in preparation for a new Nextcloud 32 release.

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
