### PR TITLE
chore(release): v8.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 -->
 # Changelog
 
+## 8.8.0
+
+### Added
+- Make preview conversion timeout and max file size configurable by @juliusknorr in [#5717](https://github.com/nextcloud/richdocuments/pull/5717)
+
+### Fixed
+- Remove expired WOPI tokens with a single query by @juliusknorr in [#5712](https://github.com/nextcloud/richdocuments/pull/5712)
+
+### Other
+- Dependency updates
+- NPM audits
+
 ## 8.7.9
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>8.7.9</version>
+	<version>8.8.0</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "8.7.9",
+  "version": "8.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "8.7.9",
+      "version": "8.8.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "8.7.9",
+  "version": "8.8.0",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
* Target version: stable31

### Summary
Bump the version to 8.8.0 and update the changelog in preparation for a new Nextcloud 31 version.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
