### PR TITLE
chore(release): v8.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 -->
 # Changelog
 
+## 8.5.15
+
+### Fixed
+- Improve file name validation by @emberfiend in [#5718](https://github.com/nextcloud/richdocuments/pull/5718)
+
 ## 8.5.14
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>8.5.14</version>
+	<version>8.5.15</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "8.5.14",
+  "version": "8.5.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "8.5.14",
+      "version": "8.5.15",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "8.5.14",
+  "version": "8.5.15",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
* Target version: stable30

### Summary
Bump the version to 8.5.15 and update the changelog in preparation for a new Nextcloud 30 release.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
