### PR TITLE
fix(database): add index for wopi expiry column

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -16,6 +16,7 @@ use OCA\Richdocuments\Conversion\ConversionProvider;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Listener\AddContentSecurityPolicyListener;
 use OCA\Richdocuments\Listener\AddFeaturePolicyListener;
+use OCA\Richdocuments\Listener\AddMissingIndicesListener;
 use OCA\Richdocuments\Listener\AddSabrePluginListener;
 use OCA\Richdocuments\Listener\BeforeFetchPreviewListener;
 use OCA\Richdocuments\Listener\BeforeGetTemplatesListener;
@@ -57,6 +58,7 @@ use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\BeforeSabrePubliclyLoadedEvent;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent;
+use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\DirectEditing\RegisterDirectEditorEvent;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Template\BeforeGetTemplatesEvent;
@@ -97,6 +99,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(OverwritePublicSharePropertiesEvent::class, OverwritePublicSharePropertiesListener::class);
 		$context->registerEventListener(SabrePluginAddEvent::class, AddSabrePluginListener::class);
 		$context->registerEventListener(BeforeSabrePubliclyLoadedEvent::class, AddSabrePluginListener::class);
+		$context->registerEventListener(AddMissingIndicesEvent::class, AddMissingIndicesListener::class);
 		$context->registerReferenceProvider(OfficeTargetReferenceProvider::class);
 		$context->registerSensitiveMethods(WopiMapper::class, [
 			'getPathForToken',

--- a/lib/Listener/AddMissingIndicesListener.php
+++ b/lib/Listener/AddMissingIndicesListener.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Listener;
+
+use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<AddMissingIndicesEvent>
+ */
+class AddMissingIndicesListener implements IEventListener {
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!($event instanceof AddMissingIndicesEvent)) {
+			return;
+		}
+
+		/**
+		 * Added to @see Version2060Date20200302131958
+		 */
+		$event->addMissingIndex(
+			'richdocuments_wopi',
+			'rd_wopi_expiry_idx',
+			['expiry']
+		);
+	}
+}

--- a/lib/Migration/Version2060Date20200302131958.php
+++ b/lib/Migration/Version2060Date20200302131958.php
@@ -136,6 +136,7 @@ class Version2060Date20200302131958 extends SimpleMigrationStep {
 			]);
 			$table->setPrimaryKey(['id']);
 			$table->addUniqueIndex(['token'], 'rd_wopi_token_idx');
+			$table->addIndex(['expiry'], 'rd_wopi_expiry_idx');
 		}
 
 		if (!$schema->hasTable('richdocuments_direct')) {


### PR DESCRIPTION
* Resolves: #5711 
* Target version: main

### Summary
Because the cleanup background job now deletes all expired WOPI tokens in a single query instead of batching them, it makes sense to introduce an index on the `expiry` column of the `oc_richdocuments_wopi` table. This PR introduces a change to the existing database migration that creates the table (adding an index at creation time) as well as a new `AddMissingIndices` event listener that creates the index when running `occ db:add-missing-indices`. 

I tested everything manually and it works flawlessy. I was not sure how to implement automated testing for this.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
