### PR TITLE
feat: Add application/epub+zip as supported mime type

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -64,6 +64,7 @@ class Capabilities implements ICapability {
 	public const MIMETYPES_OPTIONAL = [
 		'image/svg+xml',
 		'application/pdf',
+		'application/epub+zip',
 		'text/plain',
 		'text/spreadsheet',
 	];


### PR DESCRIPTION
* Resolves: #
* Target version: main

### Summary

Adds `application/epub+zip` to the optional mime types (`mimetypesNoDefaultOpen`).

EPUB is a read-only/import-only format in Collabora and cannot be saved back, so it is exposed as an optional mime type rather than a default-open one — consistent with how `application/pdf` is handled.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required