### PR TITLE
feat(capabilities): dynamic mimetype discovery from wopi xml

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -98,7 +98,7 @@ class Capabilities implements ICapability {
 		private IAppManager $appManager,
 		private ?string $userId,
 		private IURLGenerator $urlGenerator,
-        private DiscoveryService $discoveryService,
+		private DiscoveryService $discoveryService,
 	) {
 	}
 

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -153,7 +153,7 @@ class Capabilities implements ICapability {
 			$defaultMimetypes[] = 'application/pdf';
 		}
 
-		return array_unique($defaultMimetypes);
+		return array_values(array_unique($defaultMimetypes));
 	}
 
 	/**

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Richdocuments;
 
 use OCA\Richdocuments\Service\CapabilitiesService;
+use OCA\Richdocuments\Service\DiscoveryService;
 use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 use OCP\IURLGenerator;
@@ -97,6 +98,7 @@ class Capabilities implements ICapability {
 		private IAppManager $appManager,
 		private ?string $userId,
 		private IURLGenerator $urlGenerator,
+        private DiscoveryService $discoveryService,
 	) {
 	}
 
@@ -141,7 +143,7 @@ class Capabilities implements ICapability {
 	 * @return list<string>
 	 */
 	public function getDefaultMimetypes(): array {
-		$defaultMimetypes = self::MIMETYPES;
+		$defaultMimetypes = $this->discoveryService->getSupportedMimeTypes() ?: self::MIMETYPES;
 
 		if (!$this->capabilitiesService->hasOtherOOXMLApps()) {
 			array_push($defaultMimetypes, ...self::MIMETYPES_MSOFFICE);
@@ -151,7 +153,7 @@ class Capabilities implements ICapability {
 			$defaultMimetypes[] = 'application/pdf';
 		}
 
-		return $defaultMimetypes;
+		return array_unique($defaultMimetypes);
 	}
 
 	/**

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -127,4 +127,35 @@ class DiscoveryService extends CachedRequestService {
 			throw new \Exception('Could not parse discovery XML');
 		}
 	}
+
+    /**
+     * Dynamically get all supported mime types out of the discovery XML
+     * @todo Currently no categories given from endpoint
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function getSupportedMimeTypes(): array
+    {
+        $mimeTypes = [];
+
+        try {
+            $parsed = $this->getParsed();
+        } catch (\Exception $e) {
+            // @todo fallback to a default set instead of empty array
+            return $mimeTypes;
+        }
+
+        foreach ($parsed->xpath('//net-zone/app') as $app) {
+            $mimeTypeName = (string)$app['name']; // (e.g. "application/pdf")
+
+            // Filter (Settings, Capabilities, etc.)
+            if (!str_contains($mimeTypeName, '/')) {
+                continue;
+            }
+            $mimeTypes[] = $mimeTypeName;
+        }
+
+        return array_unique($mimeTypes);
+    }
 }

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -128,34 +128,33 @@ class DiscoveryService extends CachedRequestService {
 		}
 	}
 
-    /**
-     * Dynamically get all supported mime types out of the discovery XML
-     * @todo Currently no categories given from endpoint
-     *
-     * @return array
-     * @throws \Exception
-     */
-    public function getSupportedMimeTypes(): array
-    {
-        $mimeTypes = [];
+	/**
+	 * Dynamically get all supported mime types out of the discovery XML
+	 * @todo Currently no categories given from endpoint
+	 *
+	 * @return array
+	 * @throws \Exception
+	 */
+	public function getSupportedMimeTypes(): array {
+		$mimeTypes = [];
 
-        try {
-            $parsed = $this->getParsed();
-        } catch (\Exception $e) {
-            // @todo fallback to a default set instead of empty array
-            return $mimeTypes;
-        }
+		try {
+			$parsed = $this->getParsed();
+		} catch (\Exception $e) {
+			// @todo fallback to a default set instead of empty array
+			return $mimeTypes;
+		}
 
-        foreach ($parsed->xpath('//net-zone/app') as $app) {
-            $mimeTypeName = (string)$app['name']; // (e.g. "application/pdf")
+		foreach ($parsed->xpath('//net-zone/app') as $app) {
+			$mimeTypeName = (string)$app['name']; // (e.g. "application/pdf")
 
-            // Filter (Settings, Capabilities, etc.)
-            if (!str_contains($mimeTypeName, '/')) {
-                continue;
-            }
-            $mimeTypes[] = $mimeTypeName;
-        }
+			// Filter (Settings, Capabilities, etc.)
+			if (!str_contains($mimeTypeName, '/')) {
+				continue;
+			}
+			$mimeTypes[] = $mimeTypeName;
+		}
 
-        return array_values(array_unique($mimeTypes));
-    }
+		return array_values(array_unique($mimeTypes));
+	}
 }

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -156,6 +156,6 @@ class DiscoveryService extends CachedRequestService {
             $mimeTypes[] = $mimeTypeName;
         }
 
-        return array_unique($mimeTypes);
+        return array_values(array_unique($mimeTypes));
     }
 }


### PR DESCRIPTION
Fixes #5742. This PR introduces dynamic mimetype discovery by parsing the WOPI discovery.xml using XPath, fallback in Capabilities is the static mimetypes array to ensure core stability. 

Note: There are still some files in the code where Capabilities::MIMETYPES is used. This has to be correctly changed via dependency injection to use the new dynamic obtaining of the MIMETYPES
Furthermore a/some UnitTest(s) would also be required in DiscoveryServiceTest class.

Further on the discovery endpoint does not yet provide categories for the mimetypes.