### PR TITLE
fix(RemoteService): remove redundant stream cleanup in convertFileTo()

### DIFF
--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -68,11 +68,7 @@ class RemoteService {
 			throw new Exception('Failed to open stream');
 		}
 
-		try {
-			return $this->convertTo($file->getName(), $stream, $format, [], $timeout);
-		} finally {
-			fclose($stream);
-		}
+		return $this->convertTo($file->getName(), $stream, $format, [], $timeout);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes #5743

`convertFileTo()` opens a raw stream and passes it to `convertTo()`, which hands it to the Guzzle-based HTTP client as the multipart request body. Guzzle wraps it in a PSR-7 stream and closes the underlying resource once the request has been sent. By the time the `finally` block runs, the resource is no longer valid, so `fclose()` logs a warning on every conversion — one per generated preview/thumbnail.

Since Guzzle takes ownership of the stream and `convertTo()` already handles request errors, this PR drops the redundant try/finally block entirely and returns the conversion result directly, as discussed in the review below.

## Testing

The removal of the explicit cleanup has been discussed in the review; the original symptom and its diagnosis were validated independently by multiple users in #5743 on different stacks (Nextcloud 32/33, richdocuments 9.1/10.2, MariaDB/PostgreSQL, Ubuntu/Debian, Collabora 25.x/26.x): conversions and previews keep working as expected and the warning is no longer logged.