### PR TITLE
fix: guard fclose() in RemoteService::convertFileTo() against double-close

### DIFF
--- a/lib/Service/RemoteService.php
+++ b/lib/Service/RemoteService.php
@@ -71,7 +71,9 @@ class RemoteService {
 		try {
 			return $this->convertTo($file->getName(), $stream, $format, [], $timeout);
 		} finally {
-			fclose($stream);
+			if (is_resource($stream)) {
+				fclose($stream);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

`convertFileTo()` opens a local file stream and passes it to `convertTo()`, which hands it to the HTTP client as the multipart request body. Guzzle wraps the resource in a PSR-7 stream and **closes the underlying resource when the request completes** — so by the time the `finally` block runs, `fclose($stream)` operates on an already-closed resource and PHP logs:

```
Exception: fclose(): supplied resource is not a valid stream resource
  in apps/richdocuments/lib/Service/RemoteService.php line 73
```

This fires on **every successful conversion** (document preview generation), flooding the Nextcloud log on instances where convert-to is working correctly. The conversion itself succeeds — the warning is pure noise, but it's logged at error level and drowns out real problems.

## Fix

Guard the `fclose()` with `is_resource()` so cleanup only runs when the stream is still open (e.g. when `convertTo()` throws before the request is sent).

## Verification

Reproduced and verified on Nextcloud 34.0.0 + richdocuments 11.0.0 + Collabora 25.04 behind nginx:
- confirmed empirically that the stream is already closed after `convertTo()` returns (`is_resource()` → false)
- with the guard applied, conversion still returns the converted document and no warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)