### PR TITLE
chore: update php min version

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -33,7 +33,7 @@ jobs:
         code-image: [ 'release', 'nightly' ]
         node-version: [16.x]
         containers: [1, 2, 3]
-        php-versions: [ '8.2' ]
+        php-versions: [ '8.3' ]
         databases: [ 'sqlite' ]
         server-versions: [ 'master' ]
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         code-image: [ 'release', 'nightly' ]
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['sqlite']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
@@ -123,7 +123,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['mysql']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
@@ -198,7 +198,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['pgsql']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
@@ -275,7 +275,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.2']
+        php-versions: ['8.3']
         databases: ['oci']
         server-versions: ['master']
         scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']

--- a/.github/workflows/update-nextcloud-ocp.yml
+++ b/.github/workflows/update-nextcloud-ocp.yml
@@ -41,11 +41,11 @@ jobs:
           submodules: true
         continue-on-error: true
 
-      - name: Set up php8.2
+      - name: Set up php8.3
         if: steps.checkout.outcome == 'success'
         uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2.36.0
         with:
-          php-version: 8.2
+          php-version: 8.3
           # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation
           extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
           coverage: none

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,6 +32,7 @@ You can also edit your documents off-line with the Collabora Office app from the
 	<screenshot>https://github.com/nextcloud/richdocuments/raw/main/screenshots/Nextcloud-spreadsheet.png</screenshot>
 	<screenshot>https://github.com/nextcloud/richdocuments/raw/main/screenshots/Nextcloud-presentation.png</screenshot>
 	<dependencies>
+		<php min-version="8.3"/>
 		<nextcloud min-version="35" max-version="35"/>
 	</dependencies>
 	<background-jobs>

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"prefer-stable": true,
 	"config": {
 		"platform": {
-			"php": "8.2"
+			"php": "8.3"
 		},
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,7 +8,7 @@
 		errorLevel="4"
 		findUnusedBaselineEntry="true"
 		findUnusedCode="false"
-		phpVersion="8.2"
+		phpVersion="8.3"
 		resolveFromConfigFile="true"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns="https://getpsalm.org/schema/config"

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -8,7 +8,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.1"
+			"php": "8.3"
 		}
 	}
 }


### PR DESCRIPTION
* Target version: main

### Summary
PHP 8.2 support has been dropped for Nextcloud 35 (https://github.com/nextcloud/server/commit/a7da9cd5969c414c66074a3dc4b938e3d6f193ec) so our CI is failing all over the place.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
