### PR TITLE
fix(ci): disable OCM signed requests for federated share tests

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -154,7 +154,7 @@ jobs:
           php occ config:app:set richdocuments wopi_url --value="http://localhost:9980"
           php occ config:app:set richdocuments public_wopi_url --value="http://localhost:9980"
           php occ config:system:set allow_local_remote_servers --value true --type bool
-          php occ config:app:set core ocm_signed_request_disabled --value true --type bool
+          php occ config:app:set core ocm_signed_request_disabled --value="true"
           php occ richdocuments:activate-config
 
           curl http://admin:admin@localhost:8081/ocs/v1.php/cloud/capabilities\?format\=json -H 'OCS-APIRequest: true'

--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -154,6 +154,7 @@ jobs:
           php occ config:app:set richdocuments wopi_url --value="http://localhost:9980"
           php occ config:app:set richdocuments public_wopi_url --value="http://localhost:9980"
           php occ config:system:set allow_local_remote_servers --value true --type bool
+          php occ config:app:set core ocm_signed_request_disabled --value true --type bool
           php occ richdocuments:activate-config
 
           curl http://admin:admin@localhost:8081/ocs/v1.php/cloud/capabilities\?format\=json -H 'OCS-APIRequest: true'

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -145,6 +145,8 @@ Cypress.Commands.add('shareFileToRemoteUser', (user, path, targetUser, shareData
 			url: `${url}/ocs/v2.php/apps/files_sharing/api/v1/remote_shares/pending?format=json`,
 		})
 	}).then(({ body }) => {
+		cy.wrap(body.ocs.data).should('have.length.greaterThan', 0,
+			'No pending federated shares found for recipient — federation setup likely failed')
 		for (const index in body.ocs.data) {
 			cy.ocsRequest(targetUser, {
 				method: 'POST',

--- a/tests/run-integration.sh
+++ b/tests/run-integration.sh
@@ -52,6 +52,7 @@ $OCC config:app:set richdocuments wopi_url --value="http://localhost:9980"
 $OCC config:app:set richdocuments public_wopi_url --value="http://localhost:9980"
 $OCC richdocuments:activate-config
 $OCC config:system:set allow_local_remote_servers --value true --type bool
+$OCC config:app:set core ocm_signed_request_disabled --value="true"
 $OCC config:system:set gs.trustedHosts 0 --value="localhost:$PORT_SERVERA"
 $OCC config:system:set gs.trustedHosts 1 --value="localhost:$PORT_SERVERB"
 


### PR DESCRIPTION
The federated editing Cypress tests were failing because self-federated OCM share notifications were being rejected due to RFC 9421 signature verification failures. The CI server runs over plain HTTP, but OCMSignatoryManager::fetchJwks() hardcodes https:// for JWKS URLs, causing the fetch to fail. This results in confirmSignedOrigin() throwing "instance is supposed to sign its request" and returning HTTP 400, so the pending share is never created for the recipient and document.odt never appears in the files list.

Set ocm_signed_request_disabled=true to bypass the signing requirement in the HTTP test environment, where inter-server TLS is unavailable. Also add an early assertion in shareFileToRemoteUser() so any future federation setup failures produce a clear Cypress error rather than silently cascading into a timeout on cy.openFile().

Assisted-by: ClaudeCode:claude-sonnet-4-6


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
