### PR TITLE
fix: guard share attribute parse

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -176,7 +176,8 @@ export default {
 		getFilePickerBuilder(t('richdocuments', 'Insert file from {name}', { name: OC.theme.name }))
 			.setMimeTypeFilter(mimeTypeFilter)
 			.setFilter((node) => {
-				const downloadShareAttribute = JSON.parse(node.attributes['share-attributes']).find((shareAttribute) => shareAttribute.key === 'download')
+				const raw = node.attributes['share-attributes']
+				const downloadShareAttribute = (raw ? JSON.parse(raw) : []).find((shareAttribute) => shareAttribute.key === 'download')
 				const downloadPermissions = downloadShareAttribute !== undefined ? (downloadShareAttribute.enabled || downloadShareAttribute.value) : true
 				return (node.permissions & OC.PERMISSION_READ) && downloadPermissions
 			})


### PR DESCRIPTION
Assisted-by: Claude Code:Opus 4.8


* Target version: main

### Summary
The file picker's filter calls JSON.parse(node.attributes['share-attributes']) unconditionally, but the picker's default PROPFIND never requests share-attributes, so it's always undefined. JSON.parse(undefined) throws "unexpected character at line 1 column 1", breaking image insertion for every node. This guards the parse, defaulting to allowing download when the attribute is absent.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
