### PR TITLE
chore(ci): skip federated cypress tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,7 +58,7 @@ jobs:
         php-versions: ['8.3']
         databases: ['sqlite']
         server-versions: ['master']
-        scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
+        scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.code-image }}-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -126,7 +126,7 @@ jobs:
         php-versions: ['8.3']
         databases: ['mysql']
         server-versions: ['master']
-        scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
+        scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -201,7 +201,7 @@ jobs:
         php-versions: ['8.3']
         databases: ['pgsql']
         server-versions: ['master']
-        scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
+        scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 
@@ -278,7 +278,7 @@ jobs:
         php-versions: ['8.3']
         databases: ['oci']
         server-versions: ['master']
-        scenarios: ['wopi', 'direct', 'federation', 'api', 'secure-view', 'admin-settings']
+        scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
 

--- a/cypress/e2e/share-federated.spec.js
+++ b/cypress/e2e/share-federated.spec.js
@@ -7,7 +7,7 @@ import { randHash } from '../utils/index.js'
 const shareOwner = new User(randHash(), randHash())
 const shareRecipient = new User(randHash(), randHash())
 
-describe('Federated sharing of office documents', function() {
+describe.skip('Federated sharing of office documents', function() {
 
 	before(function() {
 		cy.nextcloudEnableApp('testing')

--- a/tests/features/direct.feature
+++ b/tests/features/direct.feature
@@ -85,6 +85,7 @@ Feature: Direct editing
     Then Collabora downloads the file and it is equal to "./../emptyTemplates/template.ods"
 
   @federation
+  @known-failure-ci
   Scenario: Open a federated shared file through direct editing
     Given on instance "serverA"
     And as user "user1"
@@ -107,6 +108,7 @@ Feature: Direct editing
     Then Collabora downloads the file and it is equal to "./../emptyTemplates/template.ods"
 
   @federation
+  @known-failure-ci
   Scenario: Open a file in a federated shared folder through direct editing
     Given on instance "serverA"
     And as user "user1"


### PR DESCRIPTION
* Target version: main

### Summary
Federation tests break due to what is seems to be a server regression introduced in nextcloud/server@789ff6a8a3f (TokenController not respecting ocm_signed_request_disabled). Until it can be looked into further upstream, we can skip these tests so that CI is in a good state to fix other issues and merge PRs. The failures would not affect real setups with HTTPS.

A revert commit will be immediately triggered upon merging this PR so as not to forget it.

🤖 I was looking into this issue with Claude, and I had it skip these tests in the end, so this commit was produced by an AI assistant.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
