### PR TITLE
fix(previews): properly read from lazy cache

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -251,7 +251,7 @@ class AppConfig {
 	}
 
 	public function isPreviewGenerationEnabled(): bool {
-		return $this->appConfig->getAppValueBool('preview_generation', true);
+		return $this->appConfig->getAppValueBool('preview_generation', true, lazy: true);
 	}
 
 	/**


### PR DESCRIPTION
* Target version: main

### Summary
According to the documentation in [app_settings.md](https://github.com/nextcloud/richdocuments/blob/main/docs/app_settings.md#previews), the correct way to disable document preview generation is via the following command:

```
occ config:app:set richdocuments preview_generation --type boolean --lazy --value false
```

However, I noticed that this does not actually disable preview generation in all cases, as the app config does not actually check for a value in the lazy cache:

https://github.com/nextcloud/richdocuments/blob/68cdca19da53a4f53a159bec32ea7fccf8d87a17/lib/AppConfig.php#L253-L255

According to the documentation for [`OCP\AppFramework\Services\IAppConfig::getAppValueBool()`](https://nextcloud-server.netlify.app/classes/ocp-appframework-services-iappconfig#method_getAppValueBool), if a config value is lazy then the `$lazy` argument must be set to `true`. If it is not set to true then it would only be loaded from the lazy cache if something else reached for the lazy cache earlier in the request, which loads all lazy values into the cache. Otherwise, `$lazy` defaults to `false` so if nothing else in the request gets a value from the lazy cache, then the preview generation is not actually disabled.

This change ensures that the preview generation config value is fetched from the lazy cache explicitly, so that it always has the expected behavior and is not dependent on something else hitting it earlier in the request.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
