### PR TITLE
fix(federation): ensure initiator server is trusted

### DIFF
--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -10,8 +10,10 @@ namespace OCA\Richdocuments\Controller;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Exceptions\ExpiredTokenException;
 use OCA\Richdocuments\Exceptions\UnknownTokenException;
+use OCA\Richdocuments\Service\FederationService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\Http\Client\IClientService;
@@ -31,6 +33,7 @@ class FederationController extends OCSController {
 		private IUserManager $userManager,
 		private IURLGenerator $urlGenerator,
 		private IClientService $clientService,
+		private FederationService $federationService,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -65,6 +68,10 @@ class FederationController extends OCSController {
 		try {
 			$initiatorWopi = $this->wopiMapper->getWopiForToken($token);
 			if (empty($initiatorWopi->getEditorUid()) && !empty($initiatorWopi->getRemoteServer()) && !empty($initiatorWopi->getRemoteServerToken())) {
+				if (!$this->federationService->isTrustedRemote($initiatorWopi->getRemoteServer())) {
+					throw new OCSForbiddenException();
+				}
+
 				$client = $this->clientService->newClient();
 				$response = $client->post(
 					rtrim($initiatorWopi->getRemoteServer(), '/') . '/ocs/v2.php/apps/richdocuments/api/v1/federation/user?format=json',

--- a/lib/Controller/OCSController.php
+++ b/lib/Controller/OCSController.php
@@ -222,6 +222,12 @@ class OCSController extends \OCP\AppFramework\OCSController {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		if (!$this->federationService->isTrustedRemote($initiatorServer)) {
+			$response = new DataResponse([], Http::STATUS_FORBIDDEN);
+			$response->throttle();
+			return $response;
+		}
+
 		$direct = $this->directMapper->newDirect(null, $node->getId(), null, $shareToken, $initiatorServer, $initiatorToken);
 
 		return new DataResponse([

--- a/tests/features/bootstrap/DirectContext.php
+++ b/tests/features/bootstrap/DirectContext.php
@@ -104,6 +104,34 @@ class DirectContext implements Context {
 		$this->handleDirectEditingLink();
 	}
 
+	/**
+	 * @When /^User "([^"]*)" cannot open the last share link through direct editing initiator from server "([^"]*)"$/
+	 */
+	public function userCannotOpenTheLastShareLinkThroughDirectEditingInitiatorFromServer($user, $initiatorServer) {
+		$shareToken = $this->sharingContext->getLastShareData()['token'];
+		$this->serverContext->usingWebAsUser($user);
+		$this->requestInitiatorDirectEditingLink($shareToken, $initiatorServer);
+		$this->serverContext->assertHttpStatusCode(403);
+	}
+
+	/**
+	 * @When /^User "([^"]*)" opens the last share link through direct editing initiator from server "([^"]*)"$/
+	 */
+	public function userOpensTheLastShareLinkThroughDirectEditingInitiatorFromServer($user, $server) {
+		$shareToken = $this->sharingContext->getLastShareData()['token'];
+		$this->serverContext->usingWebAsUser($user);
+		$this->requestInitiatorDirectEditingLink($shareToken, $this->serverContext->getServer($server));
+		$this->handleDirectEditingLink();
+	}
+
+	private function requestInitiatorDirectEditingLink(string $shareToken, string $initiatorServer): void {
+		$this->serverContext->sendOCSRequest('POST', 'apps/richdocuments/api/v1/direct/share/initiator', [
+			'shareToken' => $shareToken,
+			'initiatorServer' => $initiatorServer,
+			'initiatorToken' => 'test-token',
+		], ['auth' => null]);
+	}
+
 	private function handleDirectEditingLink() {
 		$this->serverContext->assertHttpStatusCode(200);
 		$data = $this->serverContext->getOCSResponseData();

--- a/tests/features/direct.feature
+++ b/tests/features/direct.feature
@@ -280,6 +280,27 @@ Feature: Direct editing
     And as user "user2"
     When User "user2" cannot open the file "/document-share-link.odt" in the last share link through direct editing from server "serverA" with password "wrongpassword"
 
+  Scenario: Direct share initiator endpoint rejects untrusted server
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/document-initiator-untrusted.odt"
+    And as "user1" create a share with
+      | path      | /document-initiator-untrusted.odt |
+      | shareType | 3                                 |
+    When User "user1" cannot open the last share link through direct editing initiator from server "http://untrusted.example.com/"
+
+  @federation @known-failure-ci
+  Scenario: Direct share initiator endpoint accepts trusted server
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/document-initiator-trusted.odt"
+    And as "user1" create a share with
+      | path      | /document-initiator-trusted.odt |
+      | shareType | 3                               |
+    When User "user1" opens the last share link through direct editing initiator from server "serverB"
+    And Collabora fetches checkFileInfo
+    Then checkFileInfo "BaseFileName" is "document-initiator-trusted.odt"
+
   @federation @known-failure-ci
   Scenario: Open a link that originates on a federated share through direct editing
     Given user "user3" exists

--- a/tests/lib/Controller/FederationControllerTest.php
+++ b/tests/lib/Controller/FederationControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Tests\Richdocuments\Controller;
+
+use OCA\Richdocuments\Controller\FederationController;
+use OCA\Richdocuments\Db\Wopi;
+use OCA\Richdocuments\Db\WopiMapper;
+use OCA\Richdocuments\Service\FederationService;
+use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class FederationControllerTest extends TestCase {
+	private FederationController $controller;
+	private WopiMapper $wopiMapper;
+	private FederationService $federationService;
+	private IClientService $clientService;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->wopiMapper = $this->createMock(WopiMapper::class);
+		$this->federationService = $this->createMock(FederationService::class);
+		$this->clientService = $this->createMock(IClientService::class);
+
+		$this->controller = new FederationController(
+			'richdocuments',
+			$this->createMock(IRequest::class),
+			$this->createMock(IConfig::class),
+			$this->createMock(LoggerInterface::class),
+			$this->wopiMapper,
+			$this->createMock(IUserManager::class),
+			$this->createMock(IURLGenerator::class),
+			$this->clientService,
+			$this->federationService,
+		);
+	}
+
+	private function makeGuestWopi(string $remoteServer, string $remoteServerToken): Wopi {
+		$wopi = new Wopi();
+		$wopi->setRemoteServer($remoteServer);
+		$wopi->setRemoteServerToken($remoteServerToken);
+		return $wopi;
+	}
+
+	/**
+	 * @test
+	 */
+	public function remoteWopiTokenThrowsForbiddenForUntrustedServer(): void {
+		$wopi = $this->makeGuestWopi('http://evil.example.com/', 'dummy');
+		$this->wopiMapper->method('getWopiForToken')->willReturn($wopi);
+		$this->federationService->method('isTrustedRemote')->with('http://evil.example.com/')->willReturn(false);
+		$this->clientService->expects($this->never())->method('newClient');
+
+		$this->expectException(OCSForbiddenException::class);
+		$this->controller->remoteWopiToken('some-token');
+	}
+
+	/**
+	 * @test
+	 */
+	public function remoteWopiTokenMakesHttpPostForTrustedServer(): void {
+		$wopi = $this->makeGuestWopi('http://trusted.example.com/', 'real-token');
+		$this->wopiMapper->method('getWopiForToken')->willReturn($wopi);
+		$this->federationService->method('isTrustedRemote')->with('http://trusted.example.com/')->willReturn(true);
+
+		$httpResponse = $this->createMock(IResponse::class);
+		$httpResponse->method('getBody')->willReturn(json_encode([
+			'ocs' => ['data' => ['displayName' => 'Remote User']],
+		]));
+
+		$httpClient = $this->createMock(IClient::class);
+		$httpClient->expects($this->once())
+			->method('post')
+			->with($this->stringContains('http://trusted.example.com/'))
+			->willReturn($httpResponse);
+
+		$this->clientService->method('newClient')->willReturn($httpClient);
+
+		$response = $this->controller->remoteWopiToken('some-token');
+		$this->assertEquals(200, $response->getStatus());
+	}
+}

--- a/tests/lib/Controller/OCSControllerTest.php
+++ b/tests/lib/Controller/OCSControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Tests\Richdocuments\Controller;
+
+use OCA\Richdocuments\Controller\OCSController;
+use OCA\Richdocuments\Db\Direct;
+use OCA\Richdocuments\Db\DirectMapper;
+use OCA\Richdocuments\DirectEditing\OfficeDirectEditor;
+use OCA\Richdocuments\Service\FederationService;
+use OCA\Richdocuments\TemplateManager;
+use OCA\Richdocuments\TokenManager;
+use OCP\AppFramework\Http;
+use OCP\Constants;
+use OCP\DirectEditing\IManager as IDirectEditingManager;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\Http\Client\IClientService;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use OCP\Share\IManager as IShareManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class OCSControllerTest extends TestCase {
+	private OCSController $controller;
+	private FederationService $federationService;
+	private IShareManager $shareManager;
+	private DirectMapper $directMapper;
+	private IURLGenerator $urlGenerator;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->federationService = $this->createMock(FederationService::class);
+		$this->shareManager = $this->createMock(IShareManager::class);
+		$this->directMapper = $this->createMock(DirectMapper::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+
+		$this->controller = new OCSController(
+			'richdocuments',
+			$this->createMock(IRequest::class),
+			$this->createMock(IRootFolder::class),
+			$this->createMock(IClientService::class),
+			null,
+			$this->directMapper,
+			$this->urlGenerator,
+			$this->createMock(TemplateManager::class),
+			$this->createMock(TokenManager::class),
+			$this->shareManager,
+			$this->federationService,
+			$this->createMock(IDirectEditingManager::class),
+			$this->createMock(OfficeDirectEditor::class),
+			$this->createMock(LoggerInterface::class),
+		);
+	}
+
+	private function makeShare(): IShare {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(42);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getPassword')->willReturn(null);
+		$share->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
+		$share->method('getNode')->willReturn($file);
+		return $share;
+	}
+
+	/**
+	 * @test
+	 */
+	public function createPublicFromInitiatorBlocksUntrustedServer(): void {
+		$this->shareManager->method('getShareByToken')->willReturn($this->makeShare());
+		$this->federationService->method('isTrustedRemote')->with('http://evil.example.com/')->willReturn(false);
+		$this->directMapper->expects($this->never())->method('newDirect');
+
+		$response = $this->controller->createPublicFromInitiator(
+			'http://evil.example.com/',
+			'dummy',
+			'share-token',
+		);
+
+		$this->assertEquals(Http::STATUS_FORBIDDEN, $response->getStatus());
+	}
+
+	/**
+	 * @test
+	 */
+	public function createPublicFromInitiatorAllowsTrustedServer(): void {
+		$this->shareManager->method('getShareByToken')->willReturn($this->makeShare());
+		$this->federationService->method('isTrustedRemote')->with('http://trusted.example.com/')->willReturn(true);
+
+		$direct = new Direct();
+		$direct->setToken('direct-abc123');
+		$this->directMapper->method('newDirect')->willReturn($direct);
+
+		$this->urlGenerator->method('linkToRouteAbsolute')
+			->willReturn('http://cloud.example.com/apps/richdocuments/direct/direct-abc123');
+
+		$response = $this->controller->createPublicFromInitiator(
+			'http://trusted.example.com/',
+			'initiator-token',
+			'share-token',
+		);
+
+		$this->assertEquals(Http::STATUS_OK, $response->getStatus());
+		$this->assertArrayHasKey('url', $response->getData());
+	}
+}


### PR DESCRIPTION
* Target version: main

### Summary
Make sure the initiator server is trusted.

This PR includes PHPUnit and Behat tests to cover this specific attack vector as well.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
