### PR TITLE
fix(federation): verify initiator token type

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -415,7 +415,7 @@ class DocumentController extends Controller {
 
 			return new DataResponse(array_merge(
 				$params,
-				$wopi->jsonSerialize(),
+				['token' => $wopi->getToken()],
 			));
 		} catch (Exception $e) {
 			$this->logger->error('Failed to generate token for file', [ 'exception' => $e ]);

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -7,6 +7,7 @@
 
 namespace OCA\Richdocuments\Controller;
 
+use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Exceptions\ExpiredTokenException;
 use OCA\Richdocuments\Exceptions\UnknownTokenException;
@@ -67,6 +68,9 @@ class FederationController extends OCSController {
 	public function remoteWopiToken($token): DataResponse {
 		try {
 			$initiatorWopi = $this->wopiMapper->getWopiForToken($token);
+			if ($initiatorWopi->getTokenType() !== Wopi::TOKEN_TYPE_INITIATOR) {
+				throw new OCSNotFoundException();
+			}
 			if (empty($initiatorWopi->getEditorUid()) && !empty($initiatorWopi->getRemoteServer()) && !empty($initiatorWopi->getRemoteServerToken())) {
 				if (!$this->federationService->isTrustedRemote($initiatorWopi->getRemoteServer())) {
 					throw new OCSForbiddenException();
@@ -86,7 +90,13 @@ class FederationController extends OCSController {
 				}
 			}
 			$this->logger->debug('COOL-Federation-Initiator: Token ' . $token . ' returned');
-			return new DataResponse($initiatorWopi);
+			return new DataResponse([
+				'tokenType' => $initiatorWopi->getTokenType(),
+				'editorUid' => $initiatorWopi->getEditorUid(),
+				'guestDisplayname' => $initiatorWopi->getGuestDisplayname(),
+				'canwrite' => $initiatorWopi->getCanwrite(),
+				'hideDownload' => $initiatorWopi->getHideDownload(),
+			]);
 		} catch (UnknownTokenException) {
 			$this->logger->debug('COOL-Federation-Initiator: Token ' . $token . 'not found');
 			throw new OCSNotFoundException();

--- a/tests/features/bootstrap/FederationContext.php
+++ b/tests/features/bootstrap/FederationContext.php
@@ -17,12 +17,29 @@ class FederationContext implements Context {
 	private $serverContext;
 	/** @var SharingContext */
 	private $sharingContext;
+	/** @var WopiContext */
+	private $wopiContext;
+	/** @var RichDocumentsContext */
+	private $richDocumentsContext;
 
 	/** @BeforeScenario */
 	public function gatherContexts(BeforeScenarioScope $scope) {
 		$environment = $scope->getEnvironment();
 		$this->serverContext = $environment->getContext(ServerContext::class);
 		$this->sharingContext = $environment->getContext(SharingContext::class);
+		$this->wopiContext = $environment->getContext(WopiContext::class);
+		$this->richDocumentsContext = $environment->getContext(RichDocumentsContext::class);
+	}
+
+	/**
+	 * @When I POST the WOPI access token to the federation endpoint
+	 */
+	public function iPostWopiAccessTokenToFederationEndpoint(): void {
+		$this->serverContext->sendOCSRequest(
+			'POST',
+			'apps/richdocuments/api/v1/federation',
+			['token' => $this->wopiContext->getWopiToken()]
+		);
 	}
 
 	/**
@@ -54,5 +71,19 @@ class FederationContext implements Context {
 			$this->serverContext->getAuth()[0],
 			$table
 		);
+	}
+
+	/**
+	 * @When I POST the initiator token to the federation endpoint
+	 */
+	public function iPostInitiatorTokenToFederationEndpoint(): void {
+		foreach ($this->richDocumentsContext->getRedirectHistory() as $url) {
+			if (str_contains($url, '/richdocuments/remote')) {
+				parse_str(parse_url($url, PHP_URL_QUERY), $params);
+				$this->serverContext->sendOCSRequest('POST', 'apps/richdocuments/api/v1/federation', ['token' => $params['remoteServerToken']]);
+				return;
+			}
+		}
+		throw new \RuntimeException('No federation redirect found in redirect history');
 	}
 }

--- a/tests/features/bootstrap/RichDocumentsContext.php
+++ b/tests/features/bootstrap/RichDocumentsContext.php
@@ -29,6 +29,7 @@ class RichDocumentsContext implements Context {
 	public $wopiToken;
 	/** @var array List of opened file ids in order to compare opening accross instances */
 	private $fileIds = [];
+	private array $redirectHistory = [];
 	/** @var array List of templates fetched for a given file type */
 	private $templates = [];
 	private array $directoryListing = [];
@@ -64,8 +65,8 @@ class RichDocumentsContext implements Context {
 				]
 			)
 		);
-		$redirects = $result->getHeader('X-Guzzle-Redirect-History');
-		$lastServer = array_pop($redirects);
+		$this->redirectHistory = $result->getHeader('X-Guzzle-Redirect-History');
+		$lastServer = end($this->redirectHistory) ?: null;
 		if ($lastServer) {
 			$this->currentServer = parse_url($lastServer, PHP_URL_SCHEME) . '://' . parse_url($lastServer, PHP_URL_HOST) . (
 				parse_url($lastServer, PHP_URL_PORT) ? ':' . parse_url($lastServer, PHP_URL_PORT) : ''
@@ -75,6 +76,10 @@ class RichDocumentsContext implements Context {
 
 		Assert::assertNotEmpty($this->fileId);
 		Assert::assertNotEmpty($this->wopiToken);
+	}
+
+	public function getRedirectHistory(): array {
+		return $this->redirectHistory;
 	}
 
 	/**

--- a/tests/features/federation.feature
+++ b/tests/features/federation.feature
@@ -5,6 +5,19 @@ Background:
 	And user "user2" exists
   And user "user3" exists
 
+  Scenario: Federation endpoint accepts initiator tokens
+    Given on instance "serverA"
+    And as user "user1"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/fed-api-positive.odt"
+    And share the file "/fed-api-positive.odt" as a federated share to "user2" on "serverB"
+
+    Given on instance "serverB"
+    And as user "user2"
+    And user "user2" accepts last share
+    When User "user2" opens "/fed-api-positive.odt"
+    And I POST the initiator token to the federation endpoint
+    Then the HTTP status code should be "200"
+
   Scenario: Share a file by federation and open it
     Given on instance "serverA"
     And as user "user1"

--- a/tests/features/wopi.feature
+++ b/tests/features/wopi.feature
@@ -389,6 +389,13 @@ Feature: WOPI
     When Collabora fetches checkFileInfo for version "1"
     Then the WOPI HTTP status code should be "403"
 
+  Scenario: Federation endpoint rejects non-initiator tokens
+    Given as user "user1"
+    And User "user1" uploads file "./../emptyTemplates/template.odt" to "/federation-reject-test.odt"
+    When User "user1" opens "/federation-reject-test.odt"
+    And I POST the WOPI access token to the federation endpoint
+    Then the HTTP status code should be "404"
+
   Scenario: Guest repeated checkFileInfo requests are rate-limited
     Given as user "user1"
     And User "user1" uploads file "./../emptyTemplates/template.odt" to "/file.odt"

--- a/tests/lib/Controller/FederationControllerTest.php
+++ b/tests/lib/Controller/FederationControllerTest.php
@@ -1,7 +1,6 @@
 <?php
 
 declare(strict_types=1);
-
 /**
  * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -14,12 +13,14 @@ use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\Db\WopiMapper;
 use OCA\Richdocuments\Service\FederationService;
 use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -27,13 +28,15 @@ use Psr\Log\LoggerInterface;
 class FederationControllerTest extends TestCase {
 	private FederationController $controller;
 	private WopiMapper $wopiMapper;
+	private IUserManager $userManager;
 	private FederationService $federationService;
 	private IClientService $clientService;
 
-	public function setUp(): void {
+	protected function setUp(): void {
 		parent::setUp();
 
 		$this->wopiMapper = $this->createMock(WopiMapper::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->federationService = $this->createMock(FederationService::class);
 		$this->clientService = $this->createMock(IClientService::class);
 
@@ -43,7 +46,7 @@ class FederationControllerTest extends TestCase {
 			$this->createMock(IConfig::class),
 			$this->createMock(LoggerInterface::class),
 			$this->wopiMapper,
-			$this->createMock(IUserManager::class),
+			$this->userManager,
 			$this->createMock(IURLGenerator::class),
 			$this->clientService,
 			$this->federationService,
@@ -52,9 +55,23 @@ class FederationControllerTest extends TestCase {
 
 	private function makeGuestWopi(string $remoteServer, string $remoteServerToken): Wopi {
 		$wopi = new Wopi();
+		$wopi->setTokenType(Wopi::TOKEN_TYPE_INITIATOR);
 		$wopi->setRemoteServer($remoteServer);
 		$wopi->setRemoteServerToken($remoteServerToken);
 		return $wopi;
+	}
+
+	/**
+	 * @test
+	 */
+	public function testRemoteWopiTokenRejectsNonInitiatorType(): void {
+		$wopi = Wopi::fromParams(['tokenType' => Wopi::TOKEN_TYPE_USER]);
+		$this->wopiMapper->expects($this->once())
+			->method('getWopiForToken')
+			->willReturn($wopi);
+
+		$this->expectException(OCSNotFoundException::class);
+		$this->controller->remoteWopiToken('some-token');
 	}
 
 	/**
@@ -93,5 +110,37 @@ class FederationControllerTest extends TestCase {
 
 		$response = $this->controller->remoteWopiToken('some-token');
 		$this->assertEquals(200, $response->getStatus());
+	}
+
+	/**
+	 * @test
+	 */
+	public function testRemoteWopiTokenReturnsMinimalFields(): void {
+		$wopi = Wopi::fromParams([
+			'tokenType' => Wopi::TOKEN_TYPE_INITIATOR,
+			'editorUid' => 'user1',
+			'canwrite' => true,
+			'hideDownload' => false,
+		]);
+		$this->wopiMapper->expects($this->once())
+			->method('getWopiForToken')
+			->willReturn($wopi);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getDisplayName')->willReturn('User One');
+		$this->userManager->expects($this->once())
+			->method('get')
+			->with('user1')
+			->willReturn($user);
+
+		$response = $this->controller->remoteWopiToken('some-token');
+		$data = $response->getData();
+
+		$this->assertCount(5, $data);
+		$this->assertSame(Wopi::TOKEN_TYPE_INITIATOR, $data['tokenType']);
+		$this->assertSame('user1', $data['editorUid']);
+		$this->assertSame('User One', $data['guestDisplayname']);
+		$this->assertTrue($data['canwrite']);
+		$this->assertFalse($data['hideDownload']);
 	}
 }


### PR DESCRIPTION
* Target version: main

### Summary
Verify that the WOPI token with the request hitting this endpoint is of type `TOKEN_TYPE_INITIATOR` and that it returns less information.

This PR includes PHPUnit and integration tests.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
