### PR TITLE
fix(wopi): use fresh storage mtime for conflict detection and responses

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -641,14 +641,18 @@ class WopiController extends Controller {
 		try {
 			$file = $this->getFileForWopiToken($wopi);
 			$wopiHeaderTime = $this->request->getHeader('X-COOL-WOPI-Timestamp');
+			$storageMtime = $file->getStorage()->filemtime($file->getInternalPath());
 
-			if (!empty($wopiHeaderTime) && $wopiHeaderTime !== Helper::toISO8601($file->getMTime() ?? 0)) {
+			if (!empty($wopiHeaderTime) && $wopiHeaderTime !== Helper::toISO8601($storageMtime ?: 0)) {
 				$this->logger->debug('Document timestamp mismatch ! WOPI client says mtime {headerTime} but storage says {storageTime}', [
 					'headerTime' => $wopiHeaderTime,
-					'storageTime' => Helper::toISO8601($file->getMTime() ?? 0)
+					'storageTime' => Helper::toISO8601($storageMtime ?: 0)
 				]);
 				// Tell WOPI client about this conflict.
-				return new JSONResponse(['COOLStatusCode' => self::COOL_STATUS_DOC_CHANGED], Http::STATUS_CONFLICT);
+				return new JSONResponse([
+					'COOLStatusCode' => self::COOL_STATUS_DOC_CHANGED,
+					'LastModifiedTime' => Helper::toISO8601($storageMtime ?: 0),
+				], Http::STATUS_CONFLICT);
 			}
 
 			$content = fopen('php://input', 'rb');
@@ -670,7 +674,8 @@ class WopiController extends Controller {
 				$wopi->setTemplateId(null);
 				$this->wopiMapper->update($wopi);
 			}
-			return new JSONResponse(['LastModifiedTime' => Helper::toISO8601($file->getMTime())]);
+			$storageMtime = $file->getStorage()->filemtime($file->getInternalPath());
+			return new JSONResponse(['LastModifiedTime' => Helper::toISO8601($storageMtime ?: $file->getMTime())]);
 		} catch (NotFoundException $e) {
 			$this->logger->warning($e->getMessage(), ['exception' => $e]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);


### PR DESCRIPTION
**Resolves:**
- https://github.com/nextcloud/richdocuments/issues/5832
- https://github.com/nextcloud/richdocuments/issues/5794

**Target version:** `main`

### Summary
Apparently, in some cases when multiple people are editing a document, especially in longer editing sessions, the `mtime` of the file in the `oc_filecache` table can become out of sync (behind) what the `mtime` is on the file storage, leading to a conflict. Re-scanning files on an instance via `occ files:scan` resolves the conflict as the file cache's `mtime` is updated to match the storage's.

I have not been able to reproduce the issue, but hopefully reading the `mtime` from the storage itself helps instead of relying on a potentially outdated one. Additionally, it includes the `LastModifiedTime` in the conflict dialog.

Assisted-by: ClaudeCode:claude-sonnet-4-6

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
