### PR TITLE
feat: Add text/markdown as supported mime type

### DIFF
--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -66,6 +66,7 @@ class Capabilities implements ICapability {
 		'application/pdf',
 		'application/epub+zip',
 		'text/plain',
+		'text/markdown',
 		'text/spreadsheet',
 	];
 

--- a/src/file-actions.js
+++ b/src/file-actions.js
@@ -51,3 +51,46 @@ const openPdf = {
 }
 
 registerFileAction(openPdf)
+
+const openMarkdown = {
+	id: 'office-open-markdown',
+
+	iconSvgInline: () => {
+		// Make sure the icon is the correct color
+		return appIcon.replaceAll(/#(fff|0{6})/g, 'currentColor')
+	},
+
+	displayName: () => {
+		return t('richdocuments',
+			'Edit with {productName}',
+			{ productName: getCapabilities().productName })
+	},
+
+	enabled: ({ nodes }) => {
+		if (nodes.length !== 1) {
+			return false
+		}
+
+		if ((nodes[0].permissions & Permission.READ) === 0) {
+			return false
+		}
+
+		const isMarkdown = nodes[0].mime === 'text/markdown'
+		// Only enable the file action when Collabora is not the default handler
+		const optionalMimetypes = getCapabilities().mimetypesNoDefaultOpen
+		return isMarkdown && optionalMimetypes.includes('text/markdown')
+	},
+
+	exec: ({ nodes }) => {
+		const file = nodes[0]
+
+		// If no viewer API, we can't open the document
+		if (!OCA.Viewer) {
+			return
+		}
+
+		OCA.Viewer.openWith('richdocuments', { path: file.path })
+	},
+}
+
+registerFileAction(openMarkdown)


### PR DESCRIPTION
This is related to
<https://github.com/CollaboraOnline/online/issues/16018>.

### Summary

Once both https://gerrit.collaboraoffice.com/c/online/+/7180 is submitted and this PR is merged, users can edit markdown files in COOL, which was inconsistent, since convert-to worked, but not interactive editing.