### PR TITLE
Fix: enforce authorization in template field endpoints

### DIFF
--- a/lib/Controller/TemplateFieldController.php
+++ b/lib/Controller/TemplateFieldController.php
@@ -12,15 +12,36 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\Constants;
+use OCP\Files\File;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 class TemplateFieldController extends OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		private TemplateFieldService $templateFieldService,
+		private IRootFolder $rootFolder,
+		private IUserSession $userSession,
 	) {
 		parent::__construct($appName, $request);
+	}
+
+	/** Resolve strictly within the acting user's scope (blocks IDOR). */
+	private function getUserFile(int $fileId): File {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			throw new NotFoundException();
+		}
+		$node = $this->rootFolder->getUserFolder($user->getUID())->getFirstNodeById($fileId);
+		if (!$node instanceof File) {
+			throw new NotFoundException();
+		}
+		return $node;
 	}
 
 	/**
@@ -30,9 +51,10 @@ class TemplateFieldController extends OCSController {
 	#[NoAdminRequired]
 	public function extractFields(int $fileId): DataResponse {
 		try {
-			$fields = $this->templateFieldService->extractFields($fileId);
-
+			$fields = $this->templateFieldService->extractFields($this->getUserFile($fileId));
 			return new DataResponse($fields, Http::STATUS_OK);
+		} catch (NotFoundException) {
+			return new DataResponse(['File not found'], Http::STATUS_NOT_FOUND);
 		} catch (\Exception) {
 			return new DataResponse(['Unable to extract fields from given file'], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -46,14 +68,24 @@ class TemplateFieldController extends OCSController {
 	#[NoAdminRequired]
 	public function fillFields(int $fileId, array $fields = [], ?string $destination = null, ?string $convert = null): DataResponse {
 		try {
-			$content = $this->templateFieldService->fillFields($fileId, $fields, $destination, $convert);
+			$file = $this->getUserFile($fileId);
 
+			// Filling a PDF overwrites the source in place, so require write access.
+			if ($file->getMimeType() === 'application/pdf'
+				&& !($file->getPermissions() & Constants::PERMISSION_UPDATE)) {
+				throw new NotPermittedException();
+			}
+
+			$content = $this->templateFieldService->fillFields($file, $fields, $destination, $convert);
 			if ($destination === null) {
 				echo $content;
 				die();
 			}
-
 			return new DataResponse([], Http::STATUS_OK);
+		} catch (NotFoundException) {
+			return new DataResponse(['File not found'], Http::STATUS_NOT_FOUND);
+		} catch (NotPermittedException) {
+			return new DataResponse(['No permission to modify this file'], Http::STATUS_FORBIDDEN);
 		} catch (\Exception) {
 			return new DataResponse(['Unable to fill fields into the given file'], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}


### PR DESCRIPTION
Assisted-by: Claude Code:Opus 4.8

* Target version: main

### Summary
extractFields and fillFields resolved a global fileId via rootFolder->getFirstNodeById(), which searches across all users' storage. Any authenticated user could pass an arbitrary id to read another user's file contents or fill/overwrite it.
Changes:

- Resolve the id within the acting user's folder (getUserFolder()->getFirstNodeById()) so only accessible nodes (including valid shares) are returned, with a baseline READ check.
- Require PERMISSION_UPDATE before filling a PDF, since that overwrites the source in place.

Because resolution is now user-scoped, getPermissions() reflects the caller's share-level rights, making the permission check meaningful.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
