### PR TITLE
fix(ci): fix collabora aliasgroup

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -44,7 +44,7 @@ jobs:
         image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'juliushaertl/nc-code-nightly:latest' }} # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false --o:home_mode.enable=true'
-          aliasgroup1: 'http://172.17.0.1'
+          aliasgroup1: 'http://172.17.0.1|http://localhost'
         ports:
           - "9980:9980"
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,7 +67,7 @@ jobs:
         image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'ghcr.io/juliusknorr/code-nightly:latest' }} # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false'
-          aliasgroup1: 'http://nextcloud'
+          aliasgroup1: 'http://localhost'
         ports:
           - "9980:9980"
 
@@ -142,7 +142,7 @@ jobs:
         image: ghcr.io/juliusknorr/nextcloud-dev-code:latest # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false'
-          aliasgroup1: 'http://nextcloud'
+          aliasgroup1: 'http://localhost'
         ports:
           - "9980:9980"
 
@@ -219,7 +219,7 @@ jobs:
         image: ghcr.io/juliusknorr/nextcloud-dev-code:latest # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false'
-          aliasgroup1: 'http://nextcloud'
+          aliasgroup1: 'http://localhost'
         ports:
           - "9980:9980"
 
@@ -304,7 +304,7 @@ jobs:
         image: ghcr.io/juliusknorr/nextcloud-dev-code:latest # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false'
-          aliasgroup1: 'http://nextcloud'
+          aliasgroup1: 'http://localhost'
         ports:
           - "9980:9980"
 


### PR DESCRIPTION
* Target version: main

### Summary
It seems something with the latest Collabora image broke CI. It is now not responding with discovery XML from `/hosting/discovery`. This seems to be related to an upstream change that shipped with Collabora 26.04 that changes the alias groups setting, so the workflows need to change to use the correct alias group.

https://github.com/CollaboraOnline/online/commit/69a7b0efa82e5a098939a96896fdac7a8cb01efb

Assisted-by: ClaudeCode:claude-sonnet-4-6

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
