### PR TITLE
fix(ci): use only nightly collabora image

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        code-image: [ 'release', 'nightly' ]
+        code-image: [ 'nightly' ]
         node-version: [16.x]
         containers: [1, 2, 3]
         php-versions: [ '8.3' ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        code-image: [ 'release', 'nightly' ]
+        code-image: [ 'nightly' ]
         php-versions: ['8.3']
         databases: ['sqlite']
         server-versions: ['master']
@@ -64,7 +64,7 @@ jobs:
 
     services:
       collabora:
-        image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'ghcr.io/juliusknorr/code-nightly:latest' }} # zizmor: ignore[unpinned-images]
+        image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'juliushaertl/nc-code-nightly:latest' }} # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'


### PR DESCRIPTION
### Summary
The release version of the Collabora container contains a bug that prevents extra_params from being considered. This is problematic because the CI environment passes config values this way to disable SSL. This causes tests to fail as it is unable to request to /hosting/discovery over HTTP. The bug is already fixed upstream but has not been released yet, so we can at least keep nightly going so that there is still some testing.

Additionally, stop using juliusknorr/code-nightly:latest as it is outdated. Switch to julishaertl/nc-code-nightly:latest.

**I will add the release image back once the fixed version has been released. This is only so tests pass, making merging of important PRs possible again.**

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
