### PR TITLE
[stable32] fix(ci): use only nightly collabora image

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        code-image: [ 'release' ]
+        code-image: [ 'nightly' ]
         node-version: [16.x]
         containers: [1, 2, 3]
         php-versions: [ '8.1' ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        code-image: [ 'release' ]
+        code-image: [ 'nightly' ]
         php-versions: ['8.1']
         databases: ['sqlite']
         server-versions: ['stable32']
@@ -61,7 +61,7 @@ jobs:
 
     services:
       collabora:
-        image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'ghcr.io/juliusknorr/code-nightly:latest' }}
+        image: ${{ matrix.code-image == 'release' && 'collabora/code:latest' || 'juliushaertl/nc-code-nightly:latest' }} # zizmor: ignore[unpinned-images]
         env:
           extra_params: '--o:ssl.enable=false'
           aliasgroup1: 'http://nextcloud'


### PR DESCRIPTION
Backport of https://github.com/nextcloud/richdocuments/pull/5892

This will be force merged because the PR was already approved and merged and this is simply a backport.