### PR TITLE
fix(ci): stabilize cypress tests

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -47,6 +47,7 @@ jobs:
           aliasgroup1: 'http://172.17.0.1'
         ports:
           - "9980:9980"
+        options: --cap-add SYS_ADMIN --cap-add SYS_CHROOT
 
     steps:
       - name: Checkout server

--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -220,13 +220,18 @@ describe('Direct editing (legacy)', function() {
 				.then((token) => {
 					cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'classic')
 					cy.logout()
-					cy.visit(token)
+					cy.visit(token, {
+						onBeforeLoad(win) {
+							cy.spy(win, 'postMessage').as('postMessage')
+						},
+					})
 					cy.waitForCollabora(false)
+					cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 					cy.get('[data-cy="coolframe"]').then($iframe => {
 						const collaboraOrigin = $iframe[0].contentWindow.location.origin
 						cy.spy($iframe[0].contentWindow, 'postMessage').as('postMessage')
-						cy.dispatchMessageFromOrigin(collaboraOrigin, { MessageId: 'App_LoadingStatus', Values: { Status: 'Document_Loaded' } })
-						cy.waitForPostMessage('Host_PostmessageReady', undefined, { targetOrigin: collaboraOrigin })
+						cy.dispatchMessageFromOrigin(collaboraOrigin, { MessageId: 'Action_Paste', Values: {} })
+						cy.waitForPostMessage('Action_Paste', undefined, { targetOrigin: collaboraOrigin })
 					})
 				})
 		})
@@ -250,7 +255,7 @@ describe('Direct editing (legacy)', function() {
 	it('Save as', function() {
 		createDirectEditingLink(randUser, this.fileId)
 			.then((token) => {
-				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'tabbed')
+				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'notebookbar')
 				cy.logout()
 				cy.visit(token, {
 					onBeforeLoad(win) {
@@ -265,9 +270,14 @@ describe('Direct editing (legacy)', function() {
 						.should('be.visible')
 
 					cy.get('button[aria-label="File"]').click()
-					cy.get('button[aria-label="Save As"]').click()
+					cy.get('button[aria-label="Save As"]')
+						.should('be.visible', { timeout: 10_000 })
+						.click()
 
-					cy.get('#saveas-entries #saveas-entry-1').click()
+					cy.get('#saveas-entries > div', { timeout: 30_000 })
+						.contains('Rich Text (.rtf)')
+						.should('be.visible')
+						.click()
 				})
 
 				cy.get('.saveas-dialog')

--- a/src/document.js
+++ b/src/document.js
@@ -635,9 +635,9 @@ const documentsMain = {
 
 		$('footer,nav').show()
 		documentsMain.UI.hideEditor()
-		documentsMain.openLocally()
-
-		PostMessages.sendPostMessage('parent', 'close')
+		if (!isDirectEditing()) {
+			PostMessages.sendPostMessage('parent', 'close')
+		}
 	},
 
 	onCloseViewer() {


### PR DESCRIPTION
### Summary
This pull request attempts to stabilize failing Cypress tests and addresses the following concerns:

- There was a Vue.js mixin being called but `document.js` is not a Vue component so it did not exist
- Add a direct editing guard to `PostMessages.sendPostMessage('parent', 'close')` to prevent an infinite loop in `document.js`
- Grant `SYS_ADMIN` and `SYS_CHROOT` capabilities to the Collabora container so that forkit processes can call `coolmount`, preventing PHP workers from being stalled
- The "Save as" test in `direct.spec.js` was made more robust and uses a more resilient selector
- The post message target origin test in `direct.spec.js` was made less flakey by confirming Collabora has finished initializing before setting the post message spy

*🤖 This PR was made with the help of Claude but the PR description is my own.*

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
