### PR TITLE
fix(file-actions): use stable32 file actions api

### DIFF
--- a/src/file-actions.js
+++ b/src/file-actions.js
@@ -66,24 +66,22 @@ const openMarkdown = {
 			{ productName: getCapabilities().productName })
 	},
 
-	enabled: ({ nodes }) => {
-		if (nodes.length !== 1) {
+	enabled: (files) => {
+		if (files.length !== 1) {
 			return false
 		}
 
-		if ((nodes[0].permissions & Permission.READ) === 0) {
+		if ((files[0].permissions & Permission.READ) === 0) {
 			return false
 		}
 
-		const isMarkdown = nodes[0].mime === 'text/markdown'
+		const isMarkdown = files[0].mime === 'text/markdown'
 		// Only enable the file action when Collabora is not the default handler
 		const optionalMimetypes = getCapabilities().mimetypesNoDefaultOpen
 		return isMarkdown && optionalMimetypes.includes('text/markdown')
 	},
 
-	exec: ({ nodes }) => {
-		const file = nodes[0]
-
+	exec: (file) => {
 		// If no viewer API, we can't open the document
 		if (!OCA.Viewer) {
 			return


### PR DESCRIPTION
### Summary
The [stable32 backport of the original fix](https://github.com/nextcloud/richdocuments/pull/5918) uses the modern file actions API for Nextcloud 33+ and was never adjusted for Nextcloud 32.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
