### PR TITLE
fix: Use type hinting in commands

### DIFF
--- a/lib/Command/InstallDefaultFonts.php
+++ b/lib/Command/InstallDefaultFonts.php
@@ -25,7 +25,7 @@ class InstallDefaultFonts extends Command {
 			->setDescription('Install default fonts');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->fontService->installDefaultFonts();
 			return 0;

--- a/lib/Command/UpdateEmptyTemplates.php
+++ b/lib/Command/UpdateEmptyTemplates.php
@@ -25,7 +25,7 @@ class UpdateEmptyTemplates extends Command {
 			->setDescription('Update empty template files');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->templateManager->updateEmptyTemplates();
 			$output->writeln('<info>Empty template files were updated</info>');


### PR DESCRIPTION
Make it compatible with newer version of symfony/console


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
