### PR TITLE
fix(templates): avoid extra file write

### DIFF
--- a/lib/Listener/FileCreatedFromTemplateListener.php
+++ b/lib/Listener/FileCreatedFromTemplateListener.php
@@ -55,7 +55,7 @@ class FileCreatedFromTemplateListener implements IEventListener {
 			return;
 		}
 
-		if ($this->capabilitiesService->hasFormFilling()) {
+		if ($this->capabilitiesService->hasFormFilling() && !empty($event->getTemplateFields())) {
 			try {
 				$filledTemplate = $this->templateFieldService->fillFields($templateFile, $event->getTemplateFields(), null, $event->getTarget()->getExtension());
 				$event->getTarget()->putContent($filledTemplate);


### PR DESCRIPTION
Avoids an extra file write when no template fields are provided. Not only does this avoid an extra write to the file, but it consequently also prevents the files_antivirus app from doing a second, sequential scan on the file; this should reduce the latency between creating a file and seeing it.

Assisted-by: ClaudeCode:claude-sonnet-4-6

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
