### PR TITLE
fix: hanging test in direct.spec.js

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -288,7 +288,7 @@ describe('Direct editing (legacy)', function() {
 
 				cy.get('.saveas-dialog button.button-vue--vue-primary').click()
 
-				cy.waitForPostMessage('Action_Save_Resp', { success: true })
+				cy.waitForPostMessage('Action_Save_Resp', { success: true, fileName: 'document.rtf' })
 				cy.closeDirectDocument()
 			})
 	})

--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -288,9 +288,7 @@ describe('Direct editing (legacy)', function() {
 
 				cy.get('.saveas-dialog button.button-vue--vue-primary').click()
 
-				cy.get('@loleafletframe').within(() => {
-					cy.verifyOpen('document.rtf')
-				})
+				cy.waitForPostMessage('Action_Save_Resp', { success: true })
 				cy.closeDirectDocument()
 			})
 	})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,8 +11,8 @@ addCommands()
 const url = Cypress.config('baseUrl').replace(/\/index.php\/?$/g, '')
 
 Cypress.Commands.add('logout', (route = '/') => {
-	cy.session('_guest', function() {
-	})
+	Cypress.session.clearAllSavedSessions()
+	cy.clearCookies()
 })
 
 Cypress.Commands.add('createFolder', (user, target) => {

--- a/lib/Migration/Version10000Date20251217143558.php
+++ b/lib/Migration/Version10000Date20251217143558.php
@@ -41,7 +41,7 @@ class Version10000Date20251217143558 extends SimpleMigrationStep {
 			return null;
 		}
 
-		$table->changeColumn('version', [
+		$table->modifyColumn('version', [
 			'type' => Type::getType('string'),
 			'notnull' => false,
 			'length' => 1024,


### PR DESCRIPTION
Fixes hanging tests in `direct.spec.js` because the sessions were not being cleared properly, and fixes a psalm error regarding a change to OCP.

Assisted-by: ClaudeCode:claude-sonnet-4-6

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
