### PR TITLE
test(cypress): trigger direct editing Save As via postMessage

### DIFF
--- a/cypress/e2e/direct.spec.js
+++ b/cypress/e2e/direct.spec.js
@@ -255,7 +255,7 @@ describe('Direct editing (legacy)', function() {
 	it('Save as', function() {
 		createDirectEditingLink(randUser, this.fileId)
 			.then((token) => {
-				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'notebookbar')
+				cy.nextcloudTestingAppConfigSet('richdocuments', 'uiDefaults-UIMode', 'classic')
 				cy.logout()
 				cy.visit(token, {
 					onBeforeLoad(win) {
@@ -265,19 +265,13 @@ describe('Direct editing (legacy)', function() {
 				cy.waitForCollabora(false)
 				cy.waitForPostMessage('App_LoadingStatus', { Status: 'Document_Loaded' })
 
-				cy.get('@loleafletframe').within(() => {
-					cy.get('.notebookbar-tabs-container')
-						.should('be.visible')
+				cy.get('[data-cy="coolframe"]').then(($iframe) => {
+					const collaboraOrigin = $iframe[0].contentWindow.location.origin
 
-					cy.get('button[aria-label="File"]').click()
-					cy.get('button[aria-label="Save As"]')
-						.should('be.visible', { timeout: 10_000 })
-						.click()
-
-					cy.get('#saveas-entries > div', { timeout: 30_000 })
-						.contains('Rich Text (.rtf)')
-						.should('be.visible')
-						.click()
+					cy.dispatchMessageFromOrigin(collaboraOrigin, {
+						MessageId: 'UI_SaveAs',
+						Values: { format: 'rtf' },
+					})
 				})
 
 				cy.get('.saveas-dialog')


### PR DESCRIPTION
### Summary
The Save As test in `direct.spec.js` was failing consistently, despite a very similar test aims to test the same thing passing in `integration.spec.js`. The only fix I could find was to not try using the drop-down in Collabora but rather to trigger the Save As dialog via the Post Message API. I spent hours debugging this failure with Claude and was not getting anywhere, so this is the best course of action. The actual UX flow of clicking the Save As button in Collabora and selecting a format from the drop-down is covered by the successful `integration.spec.js` test, so I think it's fine to do it this way in the direct editing test.

The original reason for the failure was, I believe, related to slow and inconsistent CI runs causing timing issues and weird page behavior. Running the test locally, it passed every single time without fail. But, local Cypress runs much better than on CI.

**🤖 The code was generated by Claude but the PR and commit descriptions are my own. I fully understand what the code does and why.**

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
