### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1348,12 +1348,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "3afd687611686c5ce2880fb6f87336a74a2ebf87"
+                "reference": "b2883ab5ad6a7ab012cac0c42c1580083e2aae68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/3afd687611686c5ce2880fb6f87336a74a2ebf87",
-                "reference": "3afd687611686c5ce2880fb6f87336a74a2ebf87",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/b2883ab5ad6a7ab012cac0c42c1580083e2aae68",
+                "reference": "b2883ab5ad6a7ab012cac0c42c1580083e2aae68",
                 "shasum": ""
             },
             "require": {
@@ -1389,7 +1389,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-08-21T00:37:52+00:00"
+            "time": "2026-08-29T04:41:42+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency