### PR TITLE
fix(Versions): update version only after save with current mtime

### DIFF
--- a/src/view/FilesAppIntegration.js
+++ b/src/view/FilesAppIntegration.js
@@ -116,7 +116,7 @@ export default {
 			const newFileModel = oldFile.clone()
 			newFileModel.set('id', node.fileid)
 			newFileModel.set('name', newName)
-			newFileModel.set('mtime', Date.now())
+			newFileModel.set('mtime', node.mtime?.getTime())
 			this.getFileList()
 				.add(newFileModel.toJSON())
 		}
@@ -484,6 +484,13 @@ export default {
 				fileId: this.fileId,
 				filePath: (this.filePath ?? '') + '/' + this.fileName,
 			},
+		}
+	},
+
+	async refreshFileInfo() {
+		const node = await this.getFileNode(true)
+		if (node) {
+			emit('files:node:updated', node)
 		}
 	},
 

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -406,7 +406,7 @@ export default {
 		close() {
 			FilesAppIntegration.close()
 			if (this.modified) {
-				FilesAppIntegration.updateFileInfo(undefined, Date.now())
+				FilesAppIntegration.refreshFileInfo()
 			}
 			disableScrollLock()
 			this.restoreFavicon()
@@ -526,7 +526,7 @@ export default {
 						this.switchToSavedAsFile(newFileName)
 					} else {
 						// When saving the current file, update its modification time
-						FilesAppIntegration.updateFileInfo(undefined, Date.now())
+						FilesAppIntegration.refreshFileInfo()
 					}
 				}
 				break
@@ -580,19 +580,11 @@ export default {
 			case 'Action_GetLinkPreview':
 				this.resolveLink(args.url)
 				break
-			case 'Action_Save':
-				if (this.modified) {
-					FilesAppIntegration.updateFileInfo(undefined, Date.now())
-				}
-				break
-			case 'UI_Save':
-				FilesAppIntegration.updateFileInfo(undefined, Date.now())
-				break
 			case 'Clicked_Button':
 				this.buttonClicked(args)
 				break
 			case 'Doc_ModifiedStatus':
-				if (args.Modified !== this.modified && !this.openingLocally) {
+				if (this.modified && !args.Modified && !this.openingLocally) {
 					FilesAppIntegration.updateFileInfo(undefined, Date.now())
 				}
 				this.modified = args.Modified


### PR DESCRIPTION
### Summary

- files_version matches the item's mtime with the node's to consider whether an item is the current one. This often does not match with Date.now() as it does not match real file's mtime
- fetches the current mtime from the server upon save. This can be avoided, when Collabora also sends the mtime along the Doc_ModifiedStatus message
- Action_Save and UI_Save actions would trigger updates before the actual save action, meta data cannot be correct at this time
- There are still edge cases:
  1. The current version is not always detected correctly, leading to "broken" preview image and download link. The image stays until a refresh, the link will work once it turns into a regular version. It is already a lot better.
  2. Sometimes the version generation can take longer (saw it happening once after 2min), in those case the preview and download link do not work. Out of scope here.

Assisted-by: Claude:claude-sonnet-5

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required

### 🏁 Checklist

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI