### PR TITLE
[stable34] chore: skip nightly collabora tests

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -30,7 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        code-image: [ 'nightly' ]
+        # Skip nightly Collabora image until the upstream nightly container issue is resolved
+        # https://github.com/CollaboraOnline/online/issues/16175
+        code-image: [ 'release' ]
         node-version: [16.x]
         containers: [1, 2, 3]
         php-versions: [ '8.2' ]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,7 +54,9 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        code-image: [ 'nightly' ]
+        # Skip nightly Collabora image until the upstream nightly container issue is resolved
+        # https://github.com/CollaboraOnline/online/issues/16175
+        code-image: [ 'release' ]
         php-versions: ['8.2']
         databases: ['sqlite']
         server-versions: ['stable34']


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/richdocuments/pull/6025

There is an upstream issue with the nightly build of Collabora. Although it builds successfully, there is a runtime error preventing coolwsd from accepting any connections. See https://github.com/CollaboraOnline/online/issues/16175

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
