### PR TITLE
refactor(l10n): move language tag logic to backend

### DIFF
--- a/lib/Conversion/ConversionProvider.php
+++ b/lib/Conversion/ConversionProvider.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Richdocuments\Conversion;
 
+use OCA\Richdocuments\Service\LanguageService;
 use OCA\Richdocuments\Service\RemoteService;
 use OCA\Richdocuments\Service\SecureViewService;
 use OCP\Files\Conversion\ConversionMimeProvider;
@@ -56,6 +57,7 @@ class ConversionProvider implements IConversionProvider {
 		private LoggerInterface $logger,
 		IFactory $l10nFactory,
 		private SecureViewService $secureViewService,
+		private LanguageService $languageService,
 	) {
 		$this->l10n = $l10nFactory->get('richdocuments');
 	}
@@ -168,15 +170,8 @@ class ConversionProvider implements IConversionProvider {
 		return $this->remoteService->convertFileTo(
 			$file,
 			$targetFileExtension,
-			conversionOptions: ['lang' => $this->getConversionLanguage()]
+			conversionOptions: ['lang' => $this->languageService->getBCP47LanguageTag()]
 		);
-	}
-
-	private function getConversionLanguage(): string {
-		$locale = $this->l10n->getLocaleCode();
-		$language = $locale !== '' ? $locale : $this->l10n->getLanguageCode();
-
-		return str_replace('_', '-', $language);
 	}
 
 	private function getMimeProvidersFor(array $inputMimeTypes, string $outputMimeType): array {

--- a/lib/Service/InitialStateService.php
+++ b/lib/Service/InitialStateService.php
@@ -28,6 +28,7 @@ class InitialStateService {
 		private TemplateManager $templateManager,
 		private CapabilitiesService $capabilitiesService,
 		private IConfig $config,
+		private LanguageService $languageService,
 		private ?string $userId,
 	) {
 	}
@@ -42,6 +43,7 @@ class InitialStateService {
 		$this->initialState->provideInitialState('hasNextcloudBranding', $this->capabilitiesService->hasNextcloudBranding());
 		$this->initialState->provideInitialState('instanceId', $this->config->getSystemValue('instanceid'));
 		$this->initialState->provideInitialState('wopi_callback_url', $this->appConfig->getNextcloudUrl());
+		$this->initialState->provideInitialState('bcp47Language', $this->languageService->getBCP47LanguageTag());
 		$this->provideOptions();
 
 		$this->hasProvidedCapabilities = true;

--- a/lib/Service/LanguageService.php
+++ b/lib/Service/LanguageService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Richdocuments\Service;
+
+use OCA\Richdocuments\AppInfo\Application;
+use OCP\L10N\IFactory;
+
+class LanguageService {
+	private const LOCALE_OVERRIDES = [
+		'de' => [
+			'de_CH' => 'de-CH',
+			'gsw' => 'de-CH',
+			'gsw_CH' => 'de-CH',
+		],
+		'fr' => [
+			'fr_CH' => 'fr-CH',
+		],
+		'it' => [
+			'it_CH' => 'it-CH',
+		],
+	];
+
+	public function __construct(
+		private IFactory $l10nFactory,
+	) {
+	}
+
+	/**
+	 * Converts the current user's Nextcloud language/locale settings into the
+	 * BCP 47 language tag Collabora Online expects.
+	 */
+	public function getBCP47LanguageTag(): string {
+		$l10n = $this->l10nFactory->get(Application::APPNAME);
+
+		// getLanguageCode()/getLocaleCode() mirror @nextcloud/l10n's getLanguage()/getLocale()
+		$language = str_replace('_', '-', $l10n->getLanguageCode());
+		$locale = $l10n->getLocaleCode();
+
+		$language = match ($language) {
+			'de-DE' => 'de', // German formal should just be treated as 'de'
+			'es-419' => 'es-MX', // not a valid locale string in COOL
+			default => $language,
+		};
+
+		if ($language === 'en-GB' && $locale === 'en_AU') {
+			$language = 'en-AU';
+		}
+
+		return self::LOCALE_OVERRIDES[$language][$locale] ?? $language;
+	}
+}

--- a/src/components/CoolFrame.vue
+++ b/src/components/CoolFrame.vue
@@ -28,7 +28,7 @@
 <script>
 
 import { generateCSSVarTokens, getCollaboraTheme, getUITheme } from '../helpers/coolParameters.js'
-import { languageToBCP47 } from '../helpers/index.js'
+import { loadState } from '@nextcloud/initial-state'
 import PostMessageService from '../services/postMessage.tsx'
 
 export default {
@@ -74,7 +74,7 @@ export default {
 		window.addEventListener('message', this.handlePostMessage)
 
 		if (this.iframeUrl.length > 0) {
-			this.formAction = this.iframeUrl + '?lang=' + languageToBCP47()
+			this.formAction = this.iframeUrl + '?lang=' + loadState('richdocuments', 'bcp47Language', '')
 			this.isIframeLoaded = true
 		} else {
 			return

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -3,52 +3,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { getLanguage, getLocale } from '@nextcloud/l10n'
-
-const languageToBCP47 = () => {
-	let language = getLanguage().replace(/_/g, '-')
-	const locale = getLocale()
-
-	// German formal should just be treated as 'de'
-	if (language === 'de-DE') {
-		language = 'de'
-	}
-
-	// es-419 should be mapped as this is not considered a valid locale string in COOL
-	if (language === 'es-419') {
-		language = 'es-MX'
-	}
-
-	// Australia
-	if (language === 'en-GB' && locale === 'en_AU') {
-		language = 'en-AU'
-	}
-
-	// special case where setting the bc47 region depending on the locale setting makes sense
-	const whitelist = {
-		de: {
-			de_CH: 'de-CH',
-			gsw: 'de-CH',
-			gsw_CH: 'de-CH',
-		},
-		fr: {
-			fr_CH: 'fr-CH',
-		},
-		it: {
-			it_CH: 'it-CH',
-		},
-	}
-	const matchingWhitelist = whitelist[language]
-	if (typeof matchingWhitelist !== 'undefined' && typeof matchingWhitelist[locale] !== 'undefined') {
-		return matchingWhitelist[locale]
-	}
-
-	// Collabora Online expects BCP47 language tag syntax.
-	// When the Nextcloud language consists of two parts, we send both,
-	// as the region is then provided by the language setting.
-	return language
-}
-
 const getNextcloudVersion = () => {
 	return parseInt(OC.config.version.split('.')[0])
 }
@@ -68,7 +22,6 @@ const getRandomId = (length = 5) => {
 }
 
 export {
-	languageToBCP47,
 	getNextcloudVersion,
 	splitPath,
 	getRandomId,

--- a/src/helpers/url.js
+++ b/src/helpers/url.js
@@ -5,7 +5,6 @@
 
 import { getRootUrl, generateUrl } from '@nextcloud/router'
 import { getSharingToken } from '@nextcloud/sharing/public'
-import { languageToBCP47 } from './index.js'
 import Config from './../services/config.tsx'
 
 const getSearchParam = (name) => {
@@ -39,7 +38,7 @@ const getWopiUrl = ({ fileId, readOnly, closeButton, revisionHistory, target = u
 	//   https://<loolwsd-server>:9980/hosting/discovery
 	return Config.get('urlsrc')
 		+ 'WOPISrc=' + encodeURIComponent(getWopiSrc(fileId))
-		+ '&lang=' + languageToBCP47()
+		+ '&lang=' + Config.get('bcp47Language')
 		+ (closeButton ? '&closebutton=1' : '')
 		+ (revisionHistory ? '&revisionhistory=1' : '')
 		+ (readOnly ? '&permission=readonly' : '')

--- a/src/services/config.tsx
+++ b/src/services/config.tsx
@@ -11,6 +11,7 @@ class ConfigService {
 	constructor() {
 		this.values = {
 			wopi_callback_url: loadState('richdocuments', 'wopi_callback_url', ''),
+			bcp47Language: loadState('richdocuments', 'bcp47Language', ''),
 			...loadState('richdocuments', 'document', {}),
 		}
 	}

--- a/tests/lib/Conversion/ConversionProviderTest.php
+++ b/tests/lib/Conversion/ConversionProviderTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Tests\Richdocuments\Conversion;
 
 use OCA\Richdocuments\Conversion\ConversionProvider;
+use OCA\Richdocuments\Service\LanguageService;
 use OCA\Richdocuments\Service\RemoteOptionsService;
 use OCA\Richdocuments\Service\RemoteService;
 use OCA\Richdocuments\Service\SecureViewService;
@@ -26,6 +27,7 @@ class ConversionProviderTest extends TestCase {
 	private IFactory&MockObject $l10nFactory;
 	private IL10N&MockObject $l10n;
 	private SecureViewService&MockObject $secureViewService;
+	private LanguageService&MockObject $languageService;
 	private ConversionProvider $provider;
 
 	protected function setUp(): void {
@@ -36,6 +38,7 @@ class ConversionProviderTest extends TestCase {
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->secureViewService = $this->createMock(SecureViewService::class);
+		$this->languageService = $this->createMock(LanguageService::class);
 
 		$this->l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
 		$this->l10nFactory->method('get')
@@ -47,20 +50,21 @@ class ConversionProviderTest extends TestCase {
 			$this->logger,
 			$this->l10nFactory,
 			$this->secureViewService,
+			$this->languageService,
 		);
 	}
 
 	public function testConvertFilePassesCurrentLocaleToCollabora(): void {
 		$file = $this->createMock(File::class);
 
-		$this->l10n->expects($this->once())
-			->method('getLocaleCode')
-			->willReturn('de_DE');
+		$this->languageService->expects($this->once())
+			->method('getBCP47LanguageTag')
+			->willReturn('de');
 		$this->secureViewService->method('isEnabled')
 			->willReturn(false);
 		$this->remoteService->expects($this->once())
 			->method('convertFileTo')
-			->with($file, 'pdf', RemoteOptionsService::REMOTE_TIMEOUT_DEFAULT, ['lang' => 'de-DE'])
+			->with($file, 'pdf', RemoteOptionsService::REMOTE_TIMEOUT_DEFAULT, ['lang' => 'de'])
 			->willReturn('pdf-content');
 
 		$result = $this->provider->convertFile($file, 'application/pdf');

--- a/tests/lib/Service/LanguageServiceTest.php
+++ b/tests/lib/Service/LanguageServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Tests\Richdocuments\Service;
+
+use OCA\Richdocuments\AppInfo\Application;
+use OCA\Richdocuments\Service\LanguageService;
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LanguageServiceTest extends TestCase {
+	private IFactory&MockObject $l10nFactory;
+	private IL10N&MockObject $l10n;
+	private LanguageService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10nFactory->method('get')
+			->with(Application::APPNAME)
+			->willReturn($this->l10n);
+
+		$this->service = new LanguageService($this->l10nFactory);
+	}
+
+	public static function languageProvider(): array {
+		return [
+			'plain pass-through' => ['en', 'en_US', 'en'],
+			'German formal is treated as plain German' => ['de_DE', 'de_DE', 'de'],
+			'es-419 is mapped to es-MX for COOL' => ['es_419', 'es_419', 'es-MX'],
+			'Australian English' => ['en_GB', 'en_AU', 'en-AU'],
+			'British English without Australian locale stays en-GB' => ['en_GB', 'en_GB', 'en-GB'],
+			'Swiss German locale' => ['de', 'de_CH', 'de-CH'],
+			'Swiss German (gsw locale)' => ['de', 'gsw', 'de-CH'],
+			'Swiss German (gsw_CH locale)' => ['de', 'gsw_CH', 'de-CH'],
+			'Swiss French locale' => ['fr', 'fr_CH', 'fr-CH'],
+			'Swiss Italian locale' => ['it', 'it_CH', 'it-CH'],
+			'German without Swiss locale stays de' => ['de', 'de_DE', 'de'],
+		];
+	}
+
+	/**
+	 * @dataProvider languageProvider
+	 */
+	public function testGetBCP47LanguageTag(string $languageCode, string $localeCode, string $expected): void {
+		$this->l10n->method('getLanguageCode')->willReturn($languageCode);
+		$this->l10n->method('getLocaleCode')->willReturn($localeCode);
+
+		$this->assertSame($expected, $this->service->getBCP47LanguageTag());
+	}
+}


### PR DESCRIPTION
As outlined in https://github.com/nextcloud/richdocuments/issues/6034, the Nextcloud language and locale settings to BCP 47 language tag conversion needs to be refactored so it's only located in one place; right now it's in two places, which is unmaintainable.

Moving this logic to the backend makes sense because it exists in two places when it should really exist in one. This keeps it maintainable. The backend is the natural place because requests to Collabora happen there, and the logic can be injected into the frontend via initial state.

Assisted-by: ClaudeCode:claude-sonnet-5

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
