### PR TITLE
fix(wopi): report a locked file as 423, not 500

### DIFF
--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -663,7 +663,10 @@ class WopiController extends Controller {
 				$this->wrappedFilesystemOperation($wopi, fn () => $file->putContent($content));
 			} catch (LockedException $e) {
 				$this->logger->error($e->getMessage(), ['exception' => $e]);
-				return new JSONResponse(['message' => 'File locked'], Http::STATUS_INTERNAL_SERVER_ERROR);
+				// The file is locked by another operation and we wrote nothing.
+				// Report it as such, so the client can retry rather than treat
+				// this as a server fault or as a change behind its back.
+				return new JSONResponse(['message' => 'File locked'], Http::STATUS_LOCKED);
 			}
 
 			if ($wopi->hasTemplateId()) {
@@ -805,7 +808,8 @@ class WopiController extends Controller {
 			try {
 				$this->wrappedFilesystemOperation($wopi, fn () => $file->putContent($content));
 			} catch (LockedException) {
-				return new JSONResponse(['message' => 'File locked'], Http::STATUS_INTERNAL_SERVER_ERROR);
+				// As in putFile(): nothing was written, so this is not a server fault.
+				return new JSONResponse(['message' => 'File locked'], Http::STATUS_LOCKED);
 			}
 
 			// epub is exception (can be uploaded but not opened so don't try to get access token)


### PR DESCRIPTION
When putContent() throws LockedException the file is locked by another operation and we have written nothing. Answering 500 says the server is broken, which it isn't, and it buries a routine, self-resolving condition in the error logs.

It also misleads the editor. Collabora Online cannot tell a genuine fault from a refusal, so after the failed upload it asks for CheckFileInfo to work out whether the document in storage is still the one it knows. A 423 lets it see the upload for what it was and retry once the lock clears.

423 is what this controller already answers with when the lock manager reports a file locked in lock() and refreshLock(); use it on the write path too.

Do not use 409: in WOPI that means the document changed in storage, and Collabora Online reads it that way. It would put a conflict dialog in front of the user, asking them to discard their work or overwrite a file that nobody has touched.

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
