### PR TITLE
chore: pin workflows to stable35

### DIFF
--- a/.github/workflows/cypress-e2e.yml
+++ b/.github/workflows/cypress-e2e.yml
@@ -37,7 +37,7 @@ jobs:
         containers: [1, 2, 3]
         php-versions: [ '8.3' ]
         databases: [ 'sqlite' ]
-        server-versions: [ 'master' ]
+        server-versions: [ 'stable35' ]
 
     name: runner ${{ matrix.code-image}}-${{ matrix.containers }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -59,7 +59,7 @@ jobs:
         code-image: [ 'release' ]
         php-versions: ['8.3']
         databases: ['sqlite']
-        server-versions: ['master']
+        server-versions: ['stable35']
         scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.code-image }}-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
@@ -127,7 +127,7 @@ jobs:
       matrix:
         php-versions: ['8.3']
         databases: ['mysql']
-        server-versions: ['master']
+        server-versions: ['stable35']
         scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
@@ -202,7 +202,7 @@ jobs:
       matrix:
         php-versions: ['8.3']
         databases: ['pgsql']
-        server-versions: ['master']
+        server-versions: ['stable35']
         scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}
@@ -279,7 +279,7 @@ jobs:
       matrix:
         php-versions: ['8.3']
         databases: ['oci']
-        server-versions: ['master']
+        server-versions: ['stable35']
         scenarios: ['wopi', 'direct', 'api', 'secure-view', 'admin-settings']
 
     name: integration-${{ matrix.scenarios }}-${{ matrix.php-versions }}-${{ matrix.databases }}-${{ matrix.server-versions }}


### PR DESCRIPTION
This was missed when stable35 was branched off from master.

Assisted-by: ClaudeCode:claude-sonnet-5

### Checklist

- [x] Code is properly formatted
- [x] Sign-off message is added to all commits
- [x] Documentation (manuals or wiki) has been updated or is not required
