### PR TITLE
chore(release): 11.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 -->
 # Changelog
 
+## 11.1.1
+
+### Fixed
+
+- Report a locked file as 423, not 500 by @timar in [#6063](https://github.com/nextcloud/richdocuments/pull/6063)
+- Pass language to Collabora file conversions by @xhon-pelushi in [#6037](https://github.com/nextcloud/richdocuments/pull/6037)
+- Include ooxml types in form filling by @elzody in [#6028](https://github.com/nextcloud/richdocuments/pull/6028)
+- Avoid extra file write by @elzody in [#5994](https://github.com/nextcloud/richdocuments/pull/5994)
+- Stabilize cypress tests by @elzody in [#5941](https://github.com/nextcloud/richdocuments/pull/5941)
+
+### Other
+
+- Move language tag logic to backend by @elzody in [#6052](https://github.com/nextcloud/richdocuments/pull/6052)
+- Skip nightly collabora tests by @elzody in [#6031](https://github.com/nextcloud/richdocuments/pull/6031)
+- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#6000](https://github.com/nextcloud/richdocuments/pull/6000)
+- Trigger direct editing Save As via postMessage by @elzody in [#5995](https://github.com/nextcloud/richdocuments/pull/5995)
+- Dependency updates
+
 ## 11.1.0
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>11.1.0</version>
+	<version>11.1.1</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "11.1.0",
+      "version": "11.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "11.1.0",
+  "version": "11.1.1",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
### Fixed

- Report a locked file as 423, not 500 by @timar in [#6063](https://github.com/nextcloud/richdocuments/pull/6063)
- Pass language to Collabora file conversions by @xhon-pelushi in [#6037](https://github.com/nextcloud/richdocuments/pull/6037)
- Include ooxml types in form filling by @elzody in [#6028](https://github.com/nextcloud/richdocuments/pull/6028)
- Avoid extra file write by @elzody in [#5994](https://github.com/nextcloud/richdocuments/pull/5994)
- Stabilize cypress tests by @elzody in [#5941](https://github.com/nextcloud/richdocuments/pull/5941)

### Other

- Move language tag logic to backend by @elzody in [#6052](https://github.com/nextcloud/richdocuments/pull/6052)
- Skip nightly collabora tests by @elzody in [#6031](https://github.com/nextcloud/richdocuments/pull/6031)
- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#6000](https://github.com/nextcloud/richdocuments/pull/6000)
- Trigger direct editing Save As via postMessage by @elzody in [#5995](https://github.com/nextcloud/richdocuments/pull/5995)
- Dependency updates