### PR TITLE
chore(release): 10.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 -->
 # Changelog
 
+## 10.3.1
+
+### Fixed
+
+- Report a locked file as 423, not 500 by @timar in [#6062](https://github.com/nextcloud/richdocuments/pull/6062)
+- Pass language to Collabora file conversions by @xhon-pelushi in [#6036](https://github.com/nextcloud/richdocuments/pull/6036)
+- Include ooxml types in form filling by @elzody in [#6027](https://github.com/nextcloud/richdocuments/pull/6027)
+- Avoid extra file write by @elzody in [#5993](https://github.com/nextcloud/richdocuments/pull/5993)
+- Stabilize cypress tests by @elzody in [#5940](https://github.com/nextcloud/richdocuments/pull/5940)
+
+### Other
+
+- Move language tag logic to backend by @elzody in [#6051](https://github.com/nextcloud/richdocuments/pull/6051)
+- Skip nightly collabora tests by @elzody in [#6032](https://github.com/nextcloud/richdocuments/pull/6032)
+- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#5999](https://github.com/nextcloud/richdocuments/pull/5999)
+- Dependency updates
+
 ## 10.3.0
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>10.3.0</version>
+	<version>10.3.1</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "10.3.0",
+      "version": "10.3.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
### Fixed

- Report a locked file as 423, not 500 by @timar in [#6062](https://github.com/nextcloud/richdocuments/pull/6062)
- Pass language to Collabora file conversions by @xhon-pelushi in [#6036](https://github.com/nextcloud/richdocuments/pull/6036)
- Include ooxml types in form filling by @elzody in [#6027](https://github.com/nextcloud/richdocuments/pull/6027)
- Avoid extra file write by @elzody in [#5993](https://github.com/nextcloud/richdocuments/pull/5993)
- Stabilize cypress tests by @elzody in [#5940](https://github.com/nextcloud/richdocuments/pull/5940)

### Other

- Move language tag logic to backend by @elzody in [#6051](https://github.com/nextcloud/richdocuments/pull/6051)
- Skip nightly collabora tests by @elzody in [#6032](https://github.com/nextcloud/richdocuments/pull/6032)
- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#5999](https://github.com/nextcloud/richdocuments/pull/5999)
- Dependency updates