### PR TITLE
chore(release): 9.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 -->
 # Changelog
 
+## 9.2.2
+
+### Fixed
+
+- Report a locked file as 423, not 500 by @timar in [#6061](https://github.com/nextcloud/richdocuments/pull/6061)
+- Pass language to Collabora file conversions by @xhon-pelushi in [#6035](https://github.com/nextcloud/richdocuments/pull/6035)
+- Include ooxml types in form filling by @elzody in [#6026](https://github.com/nextcloud/richdocuments/pull/6026)
+- Npm audit by @elzody in [#6009](https://github.com/nextcloud/richdocuments/pull/6009)
+- Avoid extra file write by @elzody in [#5992](https://github.com/nextcloud/richdocuments/pull/5992)
+
+### Other
+
+- Move language tag logic to backend by @elzody in [#6050](https://github.com/nextcloud/richdocuments/pull/6050)
+- Fix npm audit by @nextcloud-command in [#6049](https://github.com/nextcloud/richdocuments/pull/6049)
+- Skip nightly collabora tests by @elzody in [#6033](https://github.com/nextcloud/richdocuments/pull/6033)
+- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#5998](https://github.com/nextcloud/richdocuments/pull/5998)
+- Dependency updates
+
 ## 9.2.1
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>9.2.1</version>
+	<version>9.2.2</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "9.2.1",
+      "version": "9.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "9.2.1",
+  "version": "9.2.2",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
### Fixed

- Report a locked file as 423, not 500 by @timar in [#6061](https://github.com/nextcloud/richdocuments/pull/6061)
- Pass language to Collabora file conversions by @xhon-pelushi in [#6035](https://github.com/nextcloud/richdocuments/pull/6035)
- Include ooxml types in form filling by @elzody in [#6026](https://github.com/nextcloud/richdocuments/pull/6026)
- Npm audit by @elzody in [#6009](https://github.com/nextcloud/richdocuments/pull/6009)
- Avoid extra file write by @elzody in [#5992](https://github.com/nextcloud/richdocuments/pull/5992)

### Other

- Move language tag logic to backend by @elzody in [#6050](https://github.com/nextcloud/richdocuments/pull/6050)
- Fix npm audit by @nextcloud-command in [#6049](https://github.com/nextcloud/richdocuments/pull/6049)
- Skip nightly collabora tests by @elzody in [#6033](https://github.com/nextcloud/richdocuments/pull/6033)
- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#5998](https://github.com/nextcloud/richdocuments/pull/5998)
- Dependency updates