### PR TITLE
chore(release): 12.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 -->
 # Changelog
 
+## 12.0.0-beta.2
+
+### Fixed
+
+- Report a locked file as 423, not 500 by @timar in [#6064](https://github.com/nextcloud/richdocuments/pull/6064)
+- Pass language to Collabora file conversions by @xhon-pelushi in [#6038](https://github.com/nextcloud/richdocuments/pull/6038)
+- Include ooxml types in form filling by @elzody in [#6029](https://github.com/nextcloud/richdocuments/pull/6029)
+- Avoid extra file write by @elzody in [#5971](https://github.com/nextcloud/richdocuments/pull/5971)
+
+### Other
+
+- Move language tag logic to backend by @elzody in [#6053](https://github.com/nextcloud/richdocuments/pull/6053)
+- Pin workflows to stable35 by @elzody in [#6056](https://github.com/nextcloud/richdocuments/pull/6056)
+- Skip nightly collabora tests by @elzody in [#6030](https://github.com/nextcloud/richdocuments/pull/6030)
+- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#6001](https://github.com/nextcloud/richdocuments/pull/6001)
+- Use only nightly collabora image by @elzody in [#5894](https://github.com/nextcloud/richdocuments/pull/5894)
+- Trigger direct editing Save As via postMessage by @elzody in [#5982](https://github.com/nextcloud/richdocuments/pull/5982)
+- Dependency updates
+
 ## 12.0.0-beta.1
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 
 You can also edit your documents off-line with the Collabora Office app from the **[Android](https://play.google.com/store/apps/details?id=com.collabora.libreoffice)** and **[iOS](https://apps.apple.com/us/app/collabora-office/id1440482071)** store.]]></description>
-	<version>12.0.0-beta.1</version>
+	<version>12.0.0-beta.2</version>
 	<licence>agpl</licence>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<types>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "richdocuments",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "richdocuments",
-      "version": "12.0.0-beta.1",
+      "version": "12.0.0-beta.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "richdocuments",
   "description": "Collabora online integration",
-  "version": "12.0.0-beta.1",
+  "version": "12.0.0-beta.2",
   "authors": [
     {
       "name": "Julius Härtl",


### PR DESCRIPTION
### Fixed

- Report a locked file as 423, not 500 by @timar in [#6064](https://github.com/nextcloud/richdocuments/pull/6064)
- Pass language to Collabora file conversions by @xhon-pelushi in [#6038](https://github.com/nextcloud/richdocuments/pull/6038)
- Include ooxml types in form filling by @elzody in [#6029](https://github.com/nextcloud/richdocuments/pull/6029)
- Avoid extra file write by @elzody in [#5971](https://github.com/nextcloud/richdocuments/pull/5971)

### Other

- Move language tag logic to backend by @elzody in [#6053](https://github.com/nextcloud/richdocuments/pull/6053)
- Pin workflows to stable35 by @elzody in [#6056](https://github.com/nextcloud/richdocuments/pull/6056)
- Skip nightly collabora tests by @elzody in [#6030](https://github.com/nextcloud/richdocuments/pull/6030)
- Hide extra fonts instructions when built-in CODE selected by @xhon-pelushi in [#6001](https://github.com/nextcloud/richdocuments/pull/6001)
- Use only nightly collabora image by @elzody in [#5894](https://github.com/nextcloud/richdocuments/pull/5894)
- Trigger direct editing Save As via postMessage by @elzody in [#5982](https://github.com/nextcloud/richdocuments/pull/5982)
- Dependency updates