### PR TITLE
fix(viewer): use the header height token for the document offset

### DIFF
--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -733,7 +733,7 @@ export default {
 	width: 100%;
 	height: 100vh;
 	height: 100dvh;
-	top: -50px;
+	top: calc(var(--header-height) * -1);
 	position: absolute;
 	z-index: 10001;
 }


### PR DESCRIPTION
- Nextcloud 35 reduces --header-height from 50px to 44px.
- The fixed -50px offset now cuts off the top of the Collabora Online toolbar.
- Use calc(var(--header-height) * -1) so the offset follows the theme.

Before:
<img width="1917" height="1053" alt="image" src="https://github.com/user-attachments/assets/e57b409c-2348-413b-9f6a-820a29226d22" />

After:

<img width="1917" height="1053" alt="image" src="https://github.com/user-attachments/assets/b141849f-4b29-4bc3-a627-92dc8a8c084f" />
