### PR TITLE
chore: Adjust naming to Collabora Online

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   - SPDX-FileCopyrightText: 2013-2016 ownCloud, Inc.
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-# Nextcloud Office (powered by Collabora Online)
+# Collabora Online
 
 [![REUSE status](https://api.reuse.software/badge/github.com/nextcloud/richdocuments)](https://api.reuse.software/info/github.com/nextcloud/richdocuments)
 
@@ -11,17 +11,17 @@
 
 ![](https://raw.githubusercontent.com/nextcloud/richdocuments/main/screenshots/Nextcloud-writer.png)
 
-Nextcloud Office (Collabora) supports editing your documents in real time with multiple other editors, showing high fidelity, WYSIWYG rendering and preserving the layout and formatting of your documents.
+Collabora Online supports editing your documents in real time with multiple other editors, showing high fidelity, WYSIWYG rendering and preserving the layout and formatting of your documents.
 
 Users can insert and reply to comments and invite others without a Nextcloud account for anonymous editing of files with a public link shared folder.
 
-Nextcloud Office (Collabora) supports dozens of document formats including DOC, DOCX, PPT, PPTX, XLS, XLSX + ODF, Import/View Visio, Publisher and many more…
+Collabora Online supports dozens of document formats including DOC, DOCX, PPT, PPTX, XLS, XLSX + ODF, Import/View Visio, Publisher and many more…
 
-Nextcloud Office (Collabora) is based on the Collabora Online Development Edition (CODE) and is available free and under heavy development, adding features and improvements all the time! Enterprise users have access to the more stable, scalable Collabora Online Enterprise based version through a Nextcloud support subscription.
+Collabora Online is based on the Collabora Online Development Edition (CODE) and is available free and under heavy development, adding features and improvements all the time! Enterprise users have access to the more stable, scalable Collabora Online Enterprise based version through a Nextcloud support subscription.
 
 ## Installation
 
-Nextcloud Office (Collabora) is built on Collabora Online which requires a dedicated service running next to the Nextcloud webserver stack. There are several ways to run the coolwsd service. For full details, see the related section in the admin manual https://docs.nextcloud.com/server/latest/admin_manual/office/index.html
+Collabora Online is built on Collabora Online which requires a dedicated service running next to the Nextcloud webserver stack. There are several ways to run the coolwsd service. For full details, see the related section in the admin manual https://docs.nextcloud.com/server/latest/admin_manual/office/index.html
 
 This repository covers only the Nextcloud integration app which requires a Collabora Online server to connect to.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 -->
 <info>
 	<id>richdocuments</id>
-	<name>Nextcloud Office (Collabora)</name>
+	<name>Collabora Online</name>
 	<summary>Edit office documents directly in your browser.</summary>
 	<description><![CDATA[This application can connect to a Collabora Online (or other) server (WOPI-like Client). Nextcloud is the WOPI Host. Please read the documentation to learn more about that.
 

--- a/cypress/e2e/open.spec.js
+++ b/cypress/e2e/open.spec.js
@@ -126,14 +126,14 @@ describe('Open PDF with richdocuments', () => {
 		cy.get('@pdfViewer').find('.pdfViewer').should('exist')
 	})
 
-	// Verify that using the file action 'Edit with Nextcloud Office (Collabora)'
+	// Verify that using the file action 'Edit with Collabora Online'
 	// opens the file using richdocuments
 	it('Open PDF with richdocuments', () => {
 		cy.get('[data-cy-files-list-row-name="document.pdf"]').as('pdf')
 		cy.get('@pdf').find('.action-items').as('actions')
 
 		cy.get('@actions').find('.action-item__menutoggle').click()
-		cy.get('.action-button__longtext').contains('Edit with Nextcloud Office (Collabora)').click()
+		cy.get('.action-button__longtext').contains('Edit with Collabora Online').click()
 
 		// Wait for Collabora to open
 		cy.waitForViewer()

--- a/docs/app_settings.md
+++ b/docs/app_settings.md
@@ -2,16 +2,16 @@
   - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-## Nextcloud Office (Collabora) App Settings
+## Collabora Online App Settings
 
 ### Collabora Online Server
 URL (and port) of the Collabora Online server that provides the editing functionality as a WOPI client. Collabora Online should use the same protocol (http:// or https://) as the server installation. Naturally, https:// is recommended.
 
 ### Restrict usage to specific groups
-By default the app is enabled for all. When this setting is active, only members of specified groups can use Nextcloud Office (Collabora).
+By default the app is enabled for all. When this setting is active, only members of specified groups can use Collabora Online.
 
 ### Restrict edit to specific groups
-By default all users can edit documents with Nextcloud Office (Collabora). When this setting is active, only the members of specified groups can edit, others can only view documents.
+By default all users can edit documents with Collabora Online. When this setting is active, only the members of specified groups can edit, others can only view documents.
 
 ### Use OOXML by default for new files
 By default new files created by users are in OpenDocument Format (ODF). When this setting is active, new files will be created in Office Open XML (OOXML) format.
@@ -27,7 +27,7 @@ Canonical webroot, in case there are multiple, for Collabora Online to use. Prov
 
 ### Theme
 
-By default Nextcloud Office (Collabora) comes with Nextcloud theme (monochrome icons following Nextcloud style), to change to a more traditional office look:
+By default Collabora Online comes with Nextcloud theme (monochrome icons following Nextcloud style), to change to a more traditional office look:
 
 	occ config:app:set richdocuments theme --value="collabora"
 

--- a/docs/frontend-integration.md
+++ b/docs/frontend-integration.md
@@ -6,7 +6,7 @@
 
 ### Configuration
 
-The Nextcloud Office (Collabora) configuration for creating new files with their mimetype and extension per file type is exposed to `OCA.RichDocuments.config.create`.
+The Collabora Online configuration for creating new files with their mimetype and extension per file type is exposed to `OCA.RichDocuments.config.create`.
 
 ```json
 {
@@ -30,7 +30,7 @@ The Nextcloud Office (Collabora) configuration for creating new files with their
 ### Open viewer
 
 
-The following two methods are exposed in order to manually trigger the Nextcloud Office (Collabora) viewer opening a file:
+The following two methods are exposed in order to manually trigger the Collabora Online viewer opening a file:
 
 #### Open an existing file
 
@@ -247,7 +247,7 @@ Example failed event data:
 
 ### WOPI PostMessages
 
-Collabora Online emits various post messages which are catched and handled by the Nextcloud Office (Collabora)
+Collabora Online emits various post messages which are catched and handled by the Collabora Online
 Integration app. Postmessages which are sent from the WOPI host (Collabora) to the editor (
 Nextcloud) are also exposed through the Nextcloud event bus under the `richdocuments:wopi-post`
 event name. For details on the post messages see

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -27,12 +27,12 @@ It is possible your firewall is blocking connections. Try to start docker after 
 
 ### We are sorry, this is an unexpected connection error. Please try again. error.
 
-The Nextcloud Office (Collabora) app doesn't work at the moment, if you enable it only for certain groups. Remove the group filter in the App section.
+The Collabora Online app doesn't work at the moment, if you enable it only for certain groups. Remove the group filter in the App section.
 
-### Nextcloud Office (Collabora) doesn't handle my 100 users.
+### Collabora Online doesn't handle my 100 users.
 
 This docker image is designed for home usage with a limited numbers of users and open documents. If you need a more scalable solution, consider a support subscription for a reliable, business-ready online office experience.
 
-#### Nextcloud Office (Collabora) doesn't work with Encryption.
+#### Collabora Online doesn't work with Encryption.
 
 Yes, this is currently unsupported. Find more questions and answers in the discussion thread on the forums and post a new topic in the Collabora category if you have unanswered questions!

--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -11,6 +11,7 @@ namespace OCA\Richdocuments\Notification;
 
 use OC\User\NoUserException;
 use OCA\Richdocuments\AppInfo\Application;
+use OCA\Richdocuments\Service\CapabilitiesService;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
 use OCP\IURLGenerator;
@@ -27,6 +28,7 @@ class Notifier implements INotifier {
 	public const SUBJECT_MENTIONED_TARGET_USER = 'targetUser';
 
 	public function __construct(
+		private CapabilitiesService $capabilitiesService,
 		private IFactory $factory,
 		private IUserManager $userManager,
 		private IURLGenerator $urlGenerator,
@@ -41,7 +43,7 @@ class Notifier implements INotifier {
 
 	#[\Override]
 	public function getName(): string {
-		return 'Office';
+		return $this->capabilitiesService->getProductName();
 	}
 
 	#[\Override]

--- a/lib/Service/CapabilitiesService.php
+++ b/lib/Service/CapabilitiesService.php
@@ -107,7 +107,7 @@ class CapabilitiesService extends CachedRequestService {
 			return $this->getCapabilities()['productName'];
 		}
 
-		return $this->l10n->t('Nextcloud Office (Collabora)');
+		return $this->l10n->t('Collabora Online');
 	}
 
 	public function hasOtherOOXMLApps(): bool {

--- a/lib/Settings/Section.php
+++ b/lib/Settings/Section.php
@@ -8,7 +8,6 @@
 namespace OCA\Richdocuments\Settings;
 
 use OCA\Richdocuments\Service\CapabilitiesService;
-use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
@@ -16,7 +15,6 @@ class Section implements IIconSection {
 	public function __construct(
 		private IURLGenerator $url,
 		private CapabilitiesService $capabilitites,
-		private IL10N $l10n,
 	) {
 	}
 
@@ -27,9 +25,6 @@ class Section implements IIconSection {
 
 	#[\Override]
 	public function getName() {
-		if ($this->capabilitites->hasNextcloudBranding()) {
-			return $this->l10n->t('Office');
-		}
 		return $this->capabilitites->getProductName();
 	}
 

--- a/lib/TaskProcessing/TextToDocumentProvider.php
+++ b/lib/TaskProcessing/TextToDocumentProvider.php
@@ -33,7 +33,7 @@ class TextToDocumentProvider implements ISynchronousWatermarkingProvider {
 
 	#[\Override]
 	public function getName(): string {
-		return $this->l->t('Nextcloud Office (Collabora) text document generator');
+		return $this->l->t('Collabora Online text document generator');
 	}
 
 	#[\Override]

--- a/lib/TaskProcessing/TextToSpreadsheetProvider.php
+++ b/lib/TaskProcessing/TextToSpreadsheetProvider.php
@@ -33,7 +33,7 @@ class TextToSpreadsheetProvider implements ISynchronousProvider {
 
 	#[\Override]
 	public function getName(): string {
-		return $this->l->t('Nextcloud Office (Collabora) spreadsheet generator');
+		return $this->l->t('Collabora Online spreadsheet generator');
 	}
 
 	#[\Override]

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -8,7 +8,7 @@
 		<div class="section">
 			<h2>{{ productName }}</h2>
 			<p v-if="hasNextcloudBranding" class="description">
-				{{ t('richdocuments', 'Nextcloud Office (powered by Collabora Online) is a powerful online office suite with collaborative editing, which supports all major documents, spreadsheet and presentation file formats and works together with all modern browsers.') }}
+				{{ t('richdocuments', 'Collabora Online is a powerful online office suite with collaborative editing, which supports all major documents, spreadsheet and presentation file formats and works together with all modern browsers.') }}
 			</p>
 			<p v-else class="description">
 				{{ t('richdocuments', 'Collabora Online is a powerful LibreOffice-based online office suite with collaborative editing, which supports all major documents, spreadsheet and presentation file formats and works together with all modern browsers.') }}
@@ -77,7 +77,7 @@
 						:disabled="updating">
 					<label for="customserver">{{ t('richdocuments', 'Use your own server') }}</label><br>
 					<p class="option-inline">
-						<em>{{ t('richdocuments', 'Nextcloud Office (Collabora) requires a separate server running Collabora Online to provide editing capabilities.') }}</em>
+						<em>{{ t('richdocuments', 'Collabora Online requires a separate server running Collabora Online to provide editing capabilities.') }}</em>
 						<em>{{ t('richdocuments', 'Collabora Online requires a separate server acting as a WOPI-like Client to provide editing capabilities.') }}</em>
 					</p>
 					<div v-if="serverMode === 'custom'" class="option-inline">
@@ -312,9 +312,9 @@
 			<h2>{{ t('richdocuments', 'Secure View') }}</h2>
 			<p>{{ t('richdocuments', 'Secure view enables you to secure office documents by blocking downloads, previews and showing a watermark') }}</p>
 			<ul>
-				<li>{{ t('richdocuments', 'The settings only apply to compatible office files that are opened in Nextcloud Office (Collabora)') }}</li>
+				<li>{{ t('richdocuments', 'The settings only apply to compatible office files that are opened in Collabora Online') }}</li>
 				<li>{{ t('richdocuments', 'Downloading the file through WebDAV will be blocked') }}</li>
-				<li>{{ t('richdocuments', 'The following options within Nextcloud Office (Collabora) will be disabled: Copy, Download, Export, Print') }}</li>
+				<li>{{ t('richdocuments', 'The following options within Collabora Online will be disabled: Copy, Download, Export, Print') }}</li>
 				<li>{{ t('richdocuments', 'Files may still be downloadable via WOPI requests if WOPI settings are not correctly configured') }}</li>
 				<li>{{ t('richdocuments', 'Previews will be blocked') }}</li>
 			</ul>
@@ -483,7 +483,7 @@ export default {
 	},
 	data() {
 		return {
-			productName: loadState('richdocuments', 'productName', 'Nextcloud Office (Collabora)'),
+			productName: loadState('richdocuments', 'productName', 'Collabora Online'),
 			hasNextcloudBranding: loadState('richdocuments', 'hasNextcloudBranding', true),
 
 			serverMode: '',

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -4,8 +4,8 @@
 -->
 
 <template>
-	<NcSettingsSection :name="t('richdocuments', 'Nextcloud Office (Collabora)')"
-		:description="t('richdocuments', 'Personal Settings for Nextcloud Office (Collabora)')"
+	<NcSettingsSection :name="t('richdocuments', 'Collabora Online')"
+		:description="t('richdocuments', 'Personal Settings for Collabora Online')"
 		:limit-width="true">
 		<!-- Template folder selection -->
 		<div class="template-folder-settings">
@@ -30,7 +30,7 @@
 		</div>
 		<p>
 			<em>
-				{{ t('richdocuments', 'Templates inside of this directory will be added to the template selector of Nextcloud Office (Collabora).') }}
+				{{ t('richdocuments', 'Templates inside of this directory will be added to the template selector of Collabora Online.') }}
 			</em>
 		</p>
 

--- a/src/view/Office.vue
+++ b/src/view/Office.vue
@@ -231,7 +231,7 @@ export default {
 			return this.loading >= LOADING_STATE.FRAME_READY || this.debug
 		},
 		iframeTitle() {
-			return loadState('richdocuments', 'productName', 'Nextcloud Office (Collabora)')
+			return loadState('richdocuments', 'productName', 'Collabora Online')
 		},
 		showLoadingIndicator() {
 			return this.loading < LOADING_STATE.FRAME_READY
@@ -239,7 +239,7 @@ export default {
 		errorMessage() {
 			switch (parseInt(this.error)) {
 			case LOADING_ERROR.COLLABORA_UNCONFIGURED:
-				return t('richdocuments', '{productName} is not configured', { productName: loadState('richdocuments', 'productName', 'Nextcloud Office (Collabora)') })
+				return t('richdocuments', '{productName} is not configured', { productName: loadState('richdocuments', 'productName', 'Collabora Online') })
 			case LOADING_ERROR.PROXY_FAILED:
 				return t('richdocuments', 'Starting the built-in CODE server failed')
 			default:
@@ -389,7 +389,7 @@ export default {
 			this.loadingTimeout = setTimeout(() => {
 				console.error('Document loading failed due to timeout: Please check for failing network requests')
 				this.loading = LOADING_STATE.FAILED
-				this.error = t('richdocuments', 'Failed to load {productName} - please try again later', { productName: loadState('richdocuments', 'productName', 'Nextcloud Office (Collabora)') })
+				this.error = t('richdocuments', 'Failed to load {productName} - please try again later', { productName: loadState('richdocuments', 'productName', 'Collabora Online') })
 			}, (getCapabilities().config.timeout * 1000 || 15000))
 		},
 		sendPostMessage(msgId, values = {}) {


### PR DESCRIPTION
Per the 2026-09-11 office suite naming decisions, the Collabora integration is named **Collabora Online** (was "Nextcloud Office (Collabora)").

- Renames the app name (info.xml) and all user-facing strings (admin/personal settings, Office view fallbacks, task processing providers, cypress assertions)
- Settings section heading no longer branches on the Collabora product version check (hasNextcloudBranding): default installs now show the product name, and white-label installs (custom theme + vendor productName in capabilities) show the vendor's own name instead of a hardcoded "Office"
- Notification source name uses the product name instead of a hardcoded untranslated "Office" (rendered in the notification settings list and notification previews)
- Docs updated; CHANGELOG untouched

The appstore listing is generated from info.xml, so it picks the new name up at release. Translation files regenerate via the usual pipeline.

Backports: #PR-stable35, #PR-stable34 (opened against stable35/stable34, mirroring the branch footprint of the previous naming adjustment; the v10 line intentionally keeps "Nextcloud Office", matching v10.3.1).