### PR TITLE
fix(templates): handle upload errors properly

### DIFF
--- a/lib/Controller/TemplatesController.php
+++ b/lib/Controller/TemplatesController.php
@@ -101,16 +101,21 @@ class TemplatesController extends Controller {
 		$files = $this->request->getUploadedFile('files');
 
 		if (!is_null($files)) {
-			$mimeType = !empty($files['type'] ?? '') ? $files['type'] : $this->mimeTypeDetector->detect($files['tmp_name']);
 			$error = $files['error'] ?? 0;
 
 			if ($error !== 0) {
 				$this->logger->error('Failed to get the uploaded file. PHP file upload error code: ' . $error);
+				$message = match ($error) {
+					UPLOAD_ERR_INI_SIZE, UPLOAD_ERR_FORM_SIZE => $this->l10n->t('File is too big'),
+					default => $this->l10n->t('Failed to upload the file'),
+				};
 				return new JSONResponse(
-					['data' => ['message' => $this->l10n->t('Failed to upload the file')]],
+					['data' => ['message' => $message]],
 					Http::STATUS_BAD_REQUEST
 				);
 			}
+
+			$mimeType = !empty($files['type'] ?? '') ? $files['type'] : $this->mimeTypeDetector->detect($files['tmp_name']);
 
 			if (is_uploaded_file($files['tmp_name']) && !Filesystem::isFileBlacklisted($files['tmp_name'])) {
 				if ($files['size'] > $this->maxSize) {

--- a/src/components/AdminSettings/GlobalTemplates.vue
+++ b/src/components/AdminSettings/GlobalTemplates.vue
@@ -111,6 +111,10 @@ export default {
 			if (!templateAlreadyExists) {
 				const template = await this.uploadTemplate(selectedFile)
 
+				if (template === null) {
+					return
+				}
+
 				this.existingTemplates.push(template)
 				showSuccess(t('richdocuments', 'Uploaded template "{name}"', { name: template.name }))
 			} else {
@@ -123,18 +127,20 @@ export default {
 
 			formData.append('files', file)
 
-			let res = null
 			try {
-				res = await axios.post(url, formData, {
+				const res = await axios.post(url, formData, {
 					headers: {
 						'Content-Type': 'multipart/form-data',
 					},
 				})
-			} catch (error) {
-				showError(error.response.data.data.message)
-			}
 
-			return res.data.data
+				return res.data.data
+			} catch (error) {
+				showError(error.response?.data?.data?.message
+					?? t('richdocuments', 'Failed to upload the file'))
+
+				return null
+			}
 		},
 		async deleteTemplate(templateId) {
 			const url = generateUrl('/apps/richdocuments/template/' + templateId)


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/richdocuments/issues/6075
* Target version: main

### Summary

When trying to upload a global template that failed (e.g. file was too large), it would try to detect the MIME type of the file even if it didn't exist, causing a 500 Internal Server Error response. Instead, we should check for errors first, and then try to detect the MIME type only after we know there are no errors.

Assisted-by: ClaudeCode:claude-opus-5

### Checklist

- [ ] Code is properly formatted
- [ ] Sign-off message is added to all commits
- [ ] Documentation (manuals or wiki) has been updated or is not required
